### PR TITLE
fix: correct authorization code handling and token generation

### DIFF
--- a/MockOpenIdProvider/Controllers/AuthorizationController.cs
+++ b/MockOpenIdProvider/Controllers/AuthorizationController.cs
@@ -25,7 +25,6 @@ namespace MockOpenIdProvider.Controllers
 
             if (Client?.RedirectUri == redirect_uri)
             {
-                var code = Guid.NewGuid();
                 var AuthorizationCode = new AuthorizationCode {
                     Code = Guid.NewGuid().ToString(),
                     CreatedAt = DateTime.UtcNow,
@@ -36,7 +35,7 @@ namespace MockOpenIdProvider.Controllers
                 };
                 await _context.AddAsync(AuthorizationCode);
                 await _context.SaveChangesAsync();
-                return Redirect($"{redirect_uri}?code={code}&state={state}&nonce={nonce}");
+                return Redirect($"{redirect_uri}?code={AuthorizationCode.Code}&state={state}&nonce={nonce}");
             }
 
             return Redirect(

--- a/MockOpenIdProvider/Controllers/TokenController.cs
+++ b/MockOpenIdProvider/Controllers/TokenController.cs
@@ -1,17 +1,76 @@
 using IdpUtilities;
 using Microsoft.AspNetCore.Mvc;
+using MockOpenIdProvider.Models;
+using Microsoft.EntityFrameworkCore;
 
 namespace MockOpenIdProvider.Controllers
 {
     [Route("token")]
     public class TokenController : Controller
     {
+        private readonly IdpDbContext _context;
+
+        public TokenController(IdpDbContext context)
+        {
+            _context = context;
+        }
+
         [HttpPost]
         /// <summary>Token リクエストを受信し、アクセストークンを返します。</summary>
-        public IActionResult Index([FromForm] string grant_type, [FromForm] string code, [FromForm] string redirect_uri, [FromForm] string client_id, [FromForm] string client_secret)
+        /// <remarks>
+        /// - Client Authentication
+        /// - grant_type のチェック
+        /// - authorization_code のチェック
+        /// - redirect_uri のチェック
+        /// </remarks>
+        public async Task<IActionResult> Index([FromForm] string grant_type, [FromForm] string code, [FromForm] string redirect_uri, [FromForm] string client_id, [FromForm] string client_secret)
         {
+            if (grant_type != "authorization_code")
+            {
+                return Json(new { error = "unsupported_grant_type" });
+            }
+            if (string.IsNullOrEmpty(code) || string.IsNullOrEmpty(redirect_uri) || string.IsNullOrEmpty(client_id) || string.IsNullOrEmpty(client_secret))
+            {
+                return Json(new { error = "invalid_request" });
+            }
+            if (!await _context.Clients.AnyAsync(c => c.ClientId == client_id && c.ClientSecret == client_secret))
+            {
+                return Json(new { error = "invalid_client" });
+            }
+            var AuthorizationCode = await _context.AuthorizationCodes.Where(
+                ac => ac.Code == code && ac.Client.ClientId == client_id && ac.Client.ClientSecret == client_secret
+            ).FirstOrDefaultAsync();
+            if (AuthorizationCode == null)
+            {
+                return Json(new { error = "invalid_grant" });
+            }
+            if (AuthorizationCode.Used)
+            {
+                return Json(new { error = "invalid_grant" });
+            }
+            if (AuthorizationCode.ExpiresIn < (int) (DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1))).TotalSeconds)
+            {
+                return Json(new { error = "invalid_grant" });
+            }
+            AuthorizationCode.Used = true;
+            _context.Update(AuthorizationCode);
             var token = RandomUtil.GenerateRandomBytes(32);
-            return Json(new { access_token = token, token_type = "Bearer" });
+            var AccessToken = new AccessToken {
+                Token = token,
+                CreatedAt = DateTime.UtcNow,
+                ExpiresIn = (int) (DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1))).TotalSeconds + 3600,
+                Client = AuthorizationCode.Client,
+                ClientId = AuthorizationCode.ClientId
+            };
+            await _context.AddAsync(AccessToken);
+            await _context.SaveChangesAsync();
+            return Json(
+                new {
+                    access_token = token,
+                    token_type = "Bearer",
+                    expires_in = 3600,
+                }
+            );
         }
     }
 }


### PR DESCRIPTION
This pull request includes several important changes to the `MockOpenIdProvider` project, specifically focusing on the `AuthorizationController` and `TokenController` to improve the handling of authorization codes and token generation.

### Authorization Code Handling:

* [`MockOpenIdProvider/Controllers/AuthorizationController.cs`](diffhunk://#diff-34a73b54f972ede579b8c0ca9c195c809d3c87c7cc53bb3873902cb0584ebc6eL28): Replaced the use of a locally generated `code` variable with the `Code` property of the `AuthorizationCode` object for the redirect URI. This ensures that the correct authorization code is used in the redirect URI. [[1]](diffhunk://#diff-34a73b54f972ede579b8c0ca9c195c809d3c87c7cc53bb3873902cb0584ebc6eL28) [[2]](diffhunk://#diff-34a73b54f972ede579b8c0ca9c195c809d3c87c7cc53bb3873902cb0584ebc6eL39-R38)

### Token Generation and Validation:

* [`MockOpenIdProvider/Controllers/TokenController.cs`](diffhunk://#diff-f5272cce653c849aeb53c44652a68b2d911c4c80e37d44abfc27c4daa3212b71R3-R73): Added dependency injection for `IdpDbContext` and updated the `Index` method to handle various validation checks for `grant_type`, `code`, `redirect_uri`, `client_id`, and `client_secret`. This includes verifying client credentials, checking the validity and usage of the authorization code, and generating an access token with an expiration time.