### PR TITLE
URL Safe-Iron

### DIFF
--- a/E2ETests/tests/specs/federate_authorization_code_flow.spec.ts
+++ b/E2ETests/tests/specs/federate_authorization_code_flow.spec.ts
@@ -37,7 +37,7 @@ test.describe.serial('認可コードフローフェデレーションのテス�
         scope: scopes,
         redirect_uri: redirectUri,
         grant_type: 'authorization_code',
-        state: (url.searchParams.get('state') ?? '').replace(/ /g, '+')
+        state: (url.searchParams.get('state') ?? '')
       }
     });
     console.log((await response.body()).toString());

--- a/IdpUtilities/Iron.cs
+++ b/IdpUtilities/Iron.cs
@@ -26,11 +26,52 @@ namespace IdpUtilities
             public int Ttl { get; set; } = 0;
             public int TimestampSkewSec { get; set; } = 60;
             public int LocalTimeOffsetMsec { get; set; } = 0;
-            public string Salt { get; set; }
-            public string Iv { get; set; }
+            public string? Salt { get; set; }
+            public string? Iv { get; set; }
         }
 
         private static readonly string MacPrefix = "Fe26.2";
+
+        /// <summary>
+        /// Convert a Base64 string to a URL-safe Base64 string
+        /// </summary>
+        private static string ToBase64UrlSafe(string base64)
+        {
+            return base64.Replace('+', '-').Replace('/', '_').Replace("=", string.Empty);
+        }
+
+        /// <summary>
+        /// Convert bytes to a URL-safe Base64 string
+        /// </summary>
+        private static string ToBase64UrlSafe(byte[] data)
+        {
+            return ToBase64UrlSafe(Convert.ToBase64String(data));
+        }
+
+        /// <summary>
+        /// Convert a URL-safe Base64 string back to a standard Base64 string for decoding
+        /// </summary>
+        private static string FromBase64UrlSafe(string base64Url)
+        {
+            string base64 = base64Url.Replace('-', '+').Replace('_', '/');
+
+            // Add padding if needed
+            switch (base64.Length % 4)
+            {
+                case 2: base64 += "=="; break;
+                case 3: base64 += "="; break;
+            }
+
+            return base64;
+        }
+
+        /// <summary>
+        /// Convert a URL-safe Base64 string to bytes
+        /// </summary>
+        private static byte[] FromBase64UrlSafeToBytes(string base64Url)
+        {
+            return Convert.FromBase64String(FromBase64UrlSafe(base64Url));
+        }
 
         public static async Task<string> Seal<T>(T model, string password, Options options)
         {
@@ -41,8 +82,8 @@ namespace IdpUtilities
             var key = await GenerateKey(password, options);
             var encrypted = EncryptStringToBytes_Aes(objectString, key.Key, key.Iv);
 
-            var encryptedB64 = Convert.ToBase64String(encrypted);
-            var iv = Convert.ToBase64String(key.Iv);
+            var encryptedB64 = ToBase64UrlSafe(encrypted);
+            var iv = ToBase64UrlSafe(key.Iv);
             var expiration = options.Ttl > 0 ? (now + options.Ttl).ToString() : "";
             var macBaseString = $"{MacPrefix}*{key.Salt}*{iv}*{encryptedB64}*{expiration}";
 
@@ -89,12 +130,12 @@ namespace IdpUtilities
                 throw new Exception("Bad hmac value");
             }
 
-            var encrypted = Convert.FromBase64String(encryptedB64);
+            var encrypted = FromBase64UrlSafeToBytes(encryptedB64);
             var decryptOptions = new Options { Algorithm = options.Algorithm, Salt = encryptionSalt, Iv = encryptionIv };
             var key = await GenerateKey(password, decryptOptions);
             var decrypted = DecryptStringFromBytes_Aes(encrypted, key.Key, key.Iv);
 
-            return JsonSerializer.Deserialize<T>(decrypted);
+            return JsonSerializer.Deserialize<T>(decrypted) ?? throw new Exception("Failed to deserialize data");
         }
 
         private static async Task<(byte[] Key, byte[] Iv, string Salt)> GenerateKey(string password, Options options)
@@ -111,7 +152,7 @@ namespace IdpUtilities
 
             var salt = options.Salt ?? GenerateRandomSalt(options.SaltBits);
             var key = await Pbkdf2(password, salt, options.Iterations, options.Algorithm);
-            var iv = string.IsNullOrEmpty(options.Iv) ? GenerateRandomIv(options.Algorithm) : Convert.FromBase64String(options.Iv);
+            var iv = string.IsNullOrEmpty(options.Iv) ? GenerateRandomIv(options.Algorithm) : FromBase64UrlSafeToBytes(options.Iv);
 
             return (key, iv, salt);
         }
@@ -161,11 +202,11 @@ namespace IdpUtilities
             }
         }
 
-        private static async Task<byte[]> Pbkdf2(string password, string salt, int iterations, string algorithm)
+        private static Task<byte[]> Pbkdf2(string password, string salt, int iterations, string algorithm)
         {
             using (var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, Encoding.UTF8.GetBytes(salt), iterations, HashAlgorithmName.SHA256))
             {
-                return rfc2898DeriveBytes.GetBytes(32);
+                return Task.FromResult(rfc2898DeriveBytes.GetBytes(32));
             }
         }
 
@@ -175,7 +216,7 @@ namespace IdpUtilities
             using (var hmac = new HMACSHA256(key.Key))
             {
                 var hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(data));
-                var digest = Convert.ToBase64String(hash).Replace('+', '-').Replace('/', '_').Replace("=", string.Empty);
+                var digest = ToBase64UrlSafe(hash);
                 return (digest, key.Salt);
             }
         }
@@ -187,7 +228,7 @@ namespace IdpUtilities
             {
                 rng.GetBytes(salt);
             }
-            return Convert.ToBase64String(salt);
+            return ToBase64UrlSafe(salt);
         }
 
         private static byte[] GenerateRandomIv(string algorithm)

--- a/IdpUtilities/Iron.cs
+++ b/IdpUtilities/Iron.cs
@@ -135,7 +135,7 @@ namespace IdpUtilities
             var key = await GenerateKey(password, decryptOptions);
             var decrypted = DecryptStringFromBytes_Aes(encrypted, key.Key, key.Iv);
 
-            return JsonSerializer.Deserialize<T>(decrypted) ?? throw new Exception("Failed to deserialize data");
+            return JsonSerializer.Deserialize<T>(decrypted) ?? throw new JsonException($"Failed to deserialize data into type {typeof(T)}. Data: {decrypted}");
         }
 
         private static async Task<(byte[] Key, byte[] Iv, string Salt)> GenerateKey(string password, Options options)


### PR DESCRIPTION
This pull request introduces enhancements to the `IdpUtilities` library to ensure URL-safe Base64 encoding for cryptographic operations and updates associated tests to validate these changes. It also includes minor refactoring for improved code clarity and reliability. Below are the most important changes grouped by theme:

Fixes #12 

### URL-Safe Base64 Encoding Enhancements:
* Added utility methods `ToBase64UrlSafe`, `FromBase64UrlSafe`, and `FromBase64UrlSafeToBytes` to handle conversions between standard Base64 and URL-safe Base64 formats. (`IdpUtilities/Iron.cs`, [IdpUtilities/Iron.csL29-R75](diffhunk://#diff-ed8bc78a28a1991a21a4e754ca8094d9940139ec849d75207f886523c9cf3170L29-R75))
* Updated the `Seal` method to use URL-safe Base64 for encrypted data and initialization vector (IV). (`IdpUtilities/Iron.cs`, [IdpUtilities/Iron.csL44-R86](diffhunk://#diff-ed8bc78a28a1991a21a4e754ca8094d9940139ec849d75207f886523c9cf3170L44-R86))
* Updated the `Unseal` method to decode URL-safe Base64 data during decryption. (`IdpUtilities/Iron.cs`, [IdpUtilities/Iron.csL92-R138](diffhunk://#diff-ed8bc78a28a1991a21a4e754ca8094d9940139ec849d75207f886523c9cf3170L92-R138))
* Modified `GenerateRandomSalt` to return URL-safe Base64 strings. (`IdpUtilities/Iron.cs`, [IdpUtilities/Iron.csL190-R231](diffhunk://#diff-ed8bc78a28a1991a21a4e754ca8094d9940139ec849d75207f886523c9cf3170L190-R231))

### Test Coverage Improvements:
* Added two new test cases: 
  - `SealAndUnseal_WorksWithSpecialCharacters` to verify sealing and unsealing of data containing special characters.
  - `Seal_GeneratesUrlSafeString` to ensure that sealed strings are URL-safe. (`IdpUtilities.Test/IronTests.cs`, [IdpUtilities.Test/IronTests.csR67-R106](diffhunk://#diff-a4691823d9c9731e378b91143958212c53ba4504b49c1363afe44474cce44389R67-R106))

### Code Refactoring and Reliability:
* Changed properties `Salt` and `Iv` in the `Options` class to nullable strings (`string?`) for better null safety. (`IdpUtilities/Iron.cs`, [IdpUtilities/Iron.csL29-R75](diffhunk://#diff-ed8bc78a28a1991a21a4e754ca8094d9940139ec849d75207f886523c9cf3170L29-R75))
* Simplified the `Pbkdf2` method by removing unnecessary `async` and directly returning a `Task`. (`IdpUtilities/Iron.cs`, [IdpUtilities/Iron.csL164-R209](diffhunk://#diff-ed8bc78a28a1991a21a4e754ca8094d9940139ec849d75207f886523c9cf3170L164-R209))
* Improved error handling in `Unseal` by throwing an exception if deserialization fails. (`IdpUtilities/Iron.cs`, [IdpUtilities/Iron.csL92-R138](diffhunk://#diff-ed8bc78a28a1991a21a4e754ca8094d9940139ec849d75207f886523c9cf3170L92-R138))

### Bug Fix:
* Removed an unnecessary replacement of spaces with '+' in the `state` parameter for the authorization code flow. (`E2ETests/tests/specs/federate_authorization_code_flow.spec.ts`, [E2ETests/tests/specs/federate_authorization_code_flow.spec.tsL40-R40](diffhunk://#diff-0dcd1e19de352a8fcc3c7233228085593271f45d0751ef2f052dbb037b8e81c5L40-R40))