### PR TITLE
feat: ユーザー管理アーキテクチャの実装

### DIFF
--- a/E2ETests/tests/specs/user_management_flow.spec.ts
+++ b/E2ETests/tests/specs/user_management_flow.spec.ts
@@ -1,0 +1,273 @@
+import { test, expect, APIRequestContext } from '@playwright/test';
+import { URLSearchParams } from 'url';
+
+// Test configuration
+const ECAUTH_BASE = 'http://localhost:8081';
+const MOCK_IDP_BASE = 'http://localhost:9091';
+const ECAUTH_CLIENT_ID = 'test-ecauth-client';
+const MOCK_CLIENT_ID = 'test-mock-federate-client';
+
+test.describe.serial('User Management Flow', () => {
+  let request: APIRequestContext;
+  let authorizationCode: string;
+  let ecAuthCode: string;
+  let idToken: string;
+  let accessToken: string;
+
+  test.beforeAll(async ({ playwright }) => {
+    request = await playwright.request.newContext({
+      ignoreHTTPSErrors: true,
+      httpCredentials: {
+        username: 'alice',
+        password: 'password'
+      }
+    });
+  });
+
+  test.afterAll(async () => {
+    await request.dispose();
+  });
+
+  test('Step 1: Start authorization flow with EcAuth', async () => {
+    const params = new URLSearchParams({
+      response_type: 'code',
+      client_id: ECAUTH_CLIENT_ID,
+      redirect_uri: 'https://example.com/callback',
+      scope: 'openid profile email',
+      state: 'test-state-123',
+      nonce: 'test-nonce-456'
+    });
+
+    const response = await request.get(`${ECAUTH_BASE}/authorization?${params.toString()}`);
+    
+    // EcAuth should redirect to MockIdP for authentication
+    expect(response.status()).toBe(200);
+    const redirectUrl = response.url();
+    expect(redirectUrl).toContain(MOCK_IDP_BASE);
+    expect(redirectUrl).toContain('/authorization');
+    
+    // Extract the state parameter from MockIdP redirect
+    const mockIdpUrl = new URL(redirectUrl);
+    const mockIdpState = mockIdpUrl.searchParams.get('state');
+    expect(mockIdpState).toBeTruthy();
+    
+    // Follow the redirect to MockIdP
+    const mockIdpResponse = await request.get(redirectUrl);
+    expect(mockIdpResponse.status()).toBe(302);
+    
+    // MockIdP should redirect back with authorization code
+    const callbackUrl = new URL(mockIdpResponse.headers()['location']);
+    expect(callbackUrl.hostname).toBe('localhost');
+    expect(callbackUrl.port).toBe('8081');
+    expect(callbackUrl.pathname).toBe('/authorization-callback');
+    
+    authorizationCode = callbackUrl.searchParams.get('code')!;
+    expect(authorizationCode).toBeTruthy();
+  });
+
+  test('Step 2: EcAuth receives callback and creates/retrieves user', async () => {
+    // EcAuth processes the callback from MockIdP
+    const callbackUrl = `${ECAUTH_BASE}/authorization-callback?code=${authorizationCode}&state=test-state-123`;
+    const response = await request.get(callbackUrl);
+    
+    // Should redirect back to client with new authorization code
+    expect(response.status()).toBe(302);
+    const clientRedirectUrl = new URL(response.headers()['location']);
+    expect(clientRedirectUrl.hostname).toBe('example.com');
+    expect(clientRedirectUrl.pathname).toBe('/callback');
+    
+    ecAuthCode = clientRedirectUrl.searchParams.get('code')!;
+    expect(ecAuthCode).toBeTruthy();
+    expect(ecAuthCode).not.toBe(authorizationCode); // Should be different code
+  });
+
+  test('Step 3: Exchange EcAuth authorization code for tokens', async () => {
+    const params = new URLSearchParams({
+      grant_type: 'authorization_code',
+      code: ecAuthCode,
+      redirect_uri: 'https://example.com/callback',
+      client_id: ECAUTH_CLIENT_ID
+    });
+
+    const response = await request.post(`${ECAUTH_BASE}/token`, {
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Authorization': 'Basic ' + Buffer.from(`${ECAUTH_CLIENT_ID}:secret`).toString('base64')
+      },
+      data: params.toString()
+    });
+
+    expect(response.status()).toBe(200);
+    const tokenResponse = await response.json();
+    
+    expect(tokenResponse).toHaveProperty('access_token');
+    expect(tokenResponse).toHaveProperty('id_token');
+    expect(tokenResponse).toHaveProperty('token_type', 'Bearer');
+    expect(tokenResponse).toHaveProperty('expires_in');
+    expect(tokenResponse).toHaveProperty('scope');
+    
+    idToken = tokenResponse.id_token;
+    accessToken = tokenResponse.access_token;
+  });
+
+  test('Step 4: Verify ID token contains user information', async () => {
+    // Parse JWT without verification (for testing)
+    const idTokenParts = idToken.split('.');
+    expect(idTokenParts).toHaveLength(3);
+    
+    const payload = JSON.parse(Buffer.from(idTokenParts[1], 'base64').toString());
+    
+    // Verify required OIDC claims
+    expect(payload).toHaveProperty('iss', `${ECAUTH_BASE}/test-tenant`);
+    expect(payload).toHaveProperty('sub'); // EcAuth user subject
+    expect(payload).toHaveProperty('aud', ECAUTH_CLIENT_ID);
+    expect(payload).toHaveProperty('exp');
+    expect(payload).toHaveProperty('iat');
+    expect(payload).toHaveProperty('nonce', 'test-nonce-456');
+    
+    // Verify user claims if profile scope was requested
+    expect(payload).toHaveProperty('name');
+    
+    // Email claim should be present if email scope was requested
+    // Note: EcAuth stores hashed email, so actual email might not be in token
+  });
+
+  test('Step 5: Verify same user is returned on subsequent logins', async () => {
+    // Start another authorization flow
+    const params = new URLSearchParams({
+      response_type: 'code',
+      client_id: ECAUTH_CLIENT_ID,
+      redirect_uri: 'https://example.com/callback',
+      scope: 'openid profile',
+      state: 'test-state-789',
+      nonce: 'test-nonce-012'
+    });
+
+    // Go through the flow again
+    const authResponse = await request.get(`${ECAUTH_BASE}/authorization?${params.toString()}`);
+    const mockIdpRedirect = authResponse.url();
+    
+    const mockIdpResponse = await request.get(mockIdpRedirect);
+    const callbackUrl = new URL(mockIdpResponse.headers()['location']);
+    const newAuthCode = callbackUrl.searchParams.get('code')!;
+    
+    const ecAuthCallbackResponse = await request.get(
+      `${ECAUTH_BASE}/authorization-callback?code=${newAuthCode}&state=test-state-789`
+    );
+    const clientRedirect = new URL(ecAuthCallbackResponse.headers()['location']);
+    const newEcAuthCode = clientRedirect.searchParams.get('code')!;
+    
+    // Exchange for tokens
+    const tokenParams = new URLSearchParams({
+      grant_type: 'authorization_code',
+      code: newEcAuthCode,
+      redirect_uri: 'https://example.com/callback',
+      client_id: ECAUTH_CLIENT_ID
+    });
+
+    const tokenResponse = await request.post(`${ECAUTH_BASE}/token`, {
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Authorization': 'Basic ' + Buffer.from(`${ECAUTH_CLIENT_ID}:secret`).toString('base64')
+      },
+      data: tokenParams.toString()
+    });
+
+    const newTokens = await tokenResponse.json();
+    const newIdToken = newTokens.id_token;
+    
+    // Parse both ID tokens
+    const originalPayload = JSON.parse(Buffer.from(idToken.split('.')[1], 'base64').toString());
+    const newPayload = JSON.parse(Buffer.from(newIdToken.split('.')[1], 'base64').toString());
+    
+    // Verify same user subject is returned
+    expect(newPayload.sub).toBe(originalPayload.sub);
+    expect(newPayload.name).toBe(originalPayload.name);
+  });
+
+  test('Step 6: Verify authorization code cannot be reused', async () => {
+    // Try to use the same authorization code again
+    const params = new URLSearchParams({
+      grant_type: 'authorization_code',
+      code: ecAuthCode, // Reuse the code from Step 3
+      redirect_uri: 'https://example.com/callback',
+      client_id: ECAUTH_CLIENT_ID
+    });
+
+    const response = await request.post(`${ECAUTH_BASE}/token`, {
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Authorization': 'Basic ' + Buffer.from(`${ECAUTH_CLIENT_ID}:secret`).toString('base64')
+      },
+      data: params.toString()
+    });
+
+    expect(response.status()).toBe(400);
+    const errorResponse = await response.json();
+    expect(errorResponse).toHaveProperty('error', 'invalid_grant');
+  });
+
+  test('Step 7: Verify different external users get different EcAuth users', async () => {
+    // Create a new request context with different credentials
+    const bobRequest = await request.context().playwright.request.newContext({
+      ignoreHTTPSErrors: true,
+      httpCredentials: {
+        username: 'bob',
+        password: 'password'
+      }
+    });
+
+    try {
+      // Start authorization flow for Bob
+      const params = new URLSearchParams({
+        response_type: 'code',
+        client_id: ECAUTH_CLIENT_ID,
+        redirect_uri: 'https://example.com/callback',
+        scope: 'openid profile email',
+        state: 'bob-state-123',
+        nonce: 'bob-nonce-456'
+      });
+
+      // Go through the flow with Bob's credentials
+      const authResponse = await bobRequest.get(`${ECAUTH_BASE}/authorization?${params.toString()}`);
+      const mockIdpResponse = await bobRequest.get(authResponse.url());
+      const callbackUrl = new URL(mockIdpResponse.headers()['location']);
+      const bobAuthCode = callbackUrl.searchParams.get('code')!;
+      
+      const ecAuthCallbackResponse = await bobRequest.get(
+        `${ECAUTH_BASE}/authorization-callback?code=${bobAuthCode}&state=bob-state-123`
+      );
+      const clientRedirect = new URL(ecAuthCallbackResponse.headers()['location']);
+      const bobEcAuthCode = clientRedirect.searchParams.get('code')!;
+      
+      // Exchange for tokens
+      const tokenParams = new URLSearchParams({
+        grant_type: 'authorization_code',
+        code: bobEcAuthCode,
+        redirect_uri: 'https://example.com/callback',
+        client_id: ECAUTH_CLIENT_ID
+      });
+
+      const tokenResponse = await bobRequest.post(`${ECAUTH_BASE}/token`, {
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Authorization': 'Basic ' + Buffer.from(`${ECAUTH_CLIENT_ID}:secret`).toString('base64')
+        },
+        data: tokenParams.toString()
+      });
+
+      const bobTokens = await tokenResponse.json();
+      const bobIdToken = bobTokens.id_token;
+      
+      // Parse ID tokens
+      const alicePayload = JSON.parse(Buffer.from(idToken.split('.')[1], 'base64').toString());
+      const bobPayload = JSON.parse(Buffer.from(bobIdToken.split('.')[1], 'base64').toString());
+      
+      // Verify different users have different subjects
+      expect(bobPayload.sub).not.toBe(alicePayload.sub);
+      expect(bobPayload.name).not.toBe(alicePayload.name);
+    } finally {
+      await bobRequest.dispose();
+    }
+  });
+});

--- a/EcAuth.sln
+++ b/EcAuth.sln
@@ -22,6 +22,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IdpUtilities.Test", "IdpUti
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MockOpenIdProvider.Test", "MockOpenIdProvider.Test\MockOpenIdProvider.Test.csproj", "{8D8DCA55-7954-4FAD-AA60-0E1D8D493B27}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IdentityProvider.Test", "IdentityProvider.Test\IdentityProvider.Test.csproj", "{3F5D5C24-8E8C-4F8A-B3D5-C1A5E9F6D2B7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -112,6 +114,18 @@ Global
 		{8D8DCA55-7954-4FAD-AA60-0E1D8D493B27}.Release|x64.Build.0 = Release|Any CPU
 		{8D8DCA55-7954-4FAD-AA60-0E1D8D493B27}.Release|x86.ActiveCfg = Release|Any CPU
 		{8D8DCA55-7954-4FAD-AA60-0E1D8D493B27}.Release|x86.Build.0 = Release|Any CPU
+		{3F5D5C24-8E8C-4F8A-B3D5-C1A5E9F6D2B7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3F5D5C24-8E8C-4F8A-B3D5-C1A5E9F6D2B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3F5D5C24-8E8C-4F8A-B3D5-C1A5E9F6D2B7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3F5D5C24-8E8C-4F8A-B3D5-C1A5E9F6D2B7}.Debug|x64.Build.0 = Debug|Any CPU
+		{3F5D5C24-8E8C-4F8A-B3D5-C1A5E9F6D2B7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3F5D5C24-8E8C-4F8A-B3D5-C1A5E9F6D2B7}.Debug|x86.Build.0 = Debug|Any CPU
+		{3F5D5C24-8E8C-4F8A-B3D5-C1A5E9F6D2B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3F5D5C24-8E8C-4F8A-B3D5-C1A5E9F6D2B7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3F5D5C24-8E8C-4F8A-B3D5-C1A5E9F6D2B7}.Release|x64.ActiveCfg = Release|Any CPU
+		{3F5D5C24-8E8C-4F8A-B3D5-C1A5E9F6D2B7}.Release|x64.Build.0 = Release|Any CPU
+		{3F5D5C24-8E8C-4F8A-B3D5-C1A5E9F6D2B7}.Release|x86.ActiveCfg = Release|Any CPU
+		{3F5D5C24-8E8C-4F8A-B3D5-C1A5E9F6D2B7}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/IdentityProvider.Test/Controllers/AuthorizationCallbackControllerTests.cs
+++ b/IdentityProvider.Test/Controllers/AuthorizationCallbackControllerTests.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using IdentityProvider.Controllers;
+using IdentityProvider.Models;
+using IdentityProvider.Services;
+using IdentityProvider.Test.Helpers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace IdentityProvider.Test.Controllers
+{
+    public class AuthorizationCallbackControllerTests : IDisposable
+    {
+        private readonly EcAuthDbContext _context;
+        private readonly Mock<IUserService> _userServiceMock;
+        private readonly Mock<IExternalIdpService> _externalIdpServiceMock;
+        private readonly Mock<IAuthorizationCodeService> _authCodeServiceMock;
+        private readonly Mock<ILogger<AuthorizationCallbackController>> _loggerMock;
+        private readonly AuthorizationCallbackController _controller;
+        private readonly ServiceCollection _services;
+        private readonly ServiceProvider _serviceProvider;
+
+        public AuthorizationCallbackControllerTests()
+        {
+            // Setup in-memory database
+            var options = new DbContextOptionsBuilder<EcAuthDbContext>()
+                .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+                .Options;
+            _context = new EcAuthDbContext(options);
+
+            // Setup mocks
+            _userServiceMock = new Mock<IUserService>();
+            _externalIdpServiceMock = new Mock<IExternalIdpService>();
+            _authCodeServiceMock = new Mock<IAuthorizationCodeService>();
+            _loggerMock = new Mock<ILogger<AuthorizationCallbackController>>();
+
+            // Setup services for HttpContext.RequestServices
+            _services = new ServiceCollection();
+            _services.AddSingleton(_externalIdpServiceMock.Object);
+            _services.AddSingleton(_authCodeServiceMock.Object);
+            _serviceProvider = _services.BuildServiceProvider();
+
+            // Create controller
+            _controller = new AuthorizationCallbackController(
+                _context,
+                _userServiceMock.Object,
+                _loggerMock.Object);
+
+            // Setup HttpContext
+            _controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    RequestServices = _serviceProvider
+                }
+            };
+        }
+
+        public void Dispose()
+        {
+            _context.Dispose();
+            _serviceProvider.Dispose();
+        }
+
+        [Fact]
+        public async Task Index_Get_ReturnsErrorView_WhenErrorParameterPresent()
+        {
+            // Act
+            var result = await _controller.Index("test-code", "test-state", null, "access_denied", "User denied access");
+
+            // Assert
+            var viewResult = Assert.IsType<ViewResult>(result);
+            Assert.Equal("Index", viewResult.ViewName);
+            var model = Assert.IsType<Dictionary<string, string>>(viewResult.Model);
+            Assert.Equal("access_denied", model["error"]);
+            Assert.Equal("User denied access", model["error_description"]);
+        }
+
+        [Fact]
+        public async Task Index_Get_ReturnsErrorView_WhenCodeMissing()
+        {
+            // Act
+            var result = await _controller.Index(null, "test-state", null, null, null);
+
+            // Assert
+            var viewResult = Assert.IsType<ViewResult>(result);
+            Assert.Equal("Index", viewResult.ViewName);
+            var model = Assert.IsType<Dictionary<string, string>>(viewResult.Model);
+            Assert.Equal("invalid_request", model["error"]);
+        }
+
+        [Fact]
+        public async Task Index_Get_ReturnsErrorView_WhenStateMissing()
+        {
+            // Act
+            var result = await _controller.Index("test-code", null, null, null, null);
+
+            // Assert
+            var viewResult = Assert.IsType<ViewResult>(result);
+            Assert.Equal("Index", viewResult.ViewName);
+            var model = Assert.IsType<Dictionary<string, string>>(viewResult.Model);
+            Assert.Equal("invalid_request", model["error"]);
+        }
+
+        [Fact]
+        public async Task Index_Post_CreatesUserAndRedirects_WhenValidRequest()
+        {
+            // Arrange
+            var organizationId = 1;
+            var providerId = "test-provider";
+            var clientId = "test-client";
+            var redirectUri = "https://example.com/callback";
+            var scope = "openid profile email";
+
+            // Create sealed state
+            var stateData = new
+            {
+                provider = providerId,
+                organizationId = organizationId,
+                clientId = clientId,
+                redirectUri = redirectUri,
+                originalState = "original-state"
+            };
+            var sealedState = await IronTestHelper.SealStateAsync(stateData);
+
+            // Setup mocks
+            var externalUserInfo = new ExternalUserInfo
+            {
+                Subject = "external-subject",
+                Email = "test@example.com",
+                Name = "Test User"
+            };
+            _externalIdpServiceMock
+                .Setup(x => x.GetExternalUserInfoAsync(
+                    providerId, "test-code", It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(externalUserInfo);
+
+            var ecAuthUser = new EcAuthUser
+            {
+                Id = 1,
+                Subject = "ecauth-subject",
+                EmailHash = "hash",
+                OrganizationId = organizationId
+            };
+            _userServiceMock
+                .Setup(x => x.GetOrCreateUserAsync(It.IsAny<UserCreationRequest>()))
+                .ReturnsAsync(ecAuthUser);
+
+            _authCodeServiceMock
+                .Setup(x => x.GenerateAuthorizationCodeAsync(
+                    It.IsAny<int>(), ecAuthUser.Id, redirectUri, scope))
+                .ReturnsAsync("new-auth-code");
+
+            // Create form data
+            var formCollection = new FormCollection(new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>
+            {
+                ["code"] = "test-code",
+                ["state"] = sealedState,
+                ["scope"] = scope
+            });
+            _controller.HttpContext.Request.Form = formCollection;
+
+            // Act
+            var result = await _controller.Index("test-code", sealedState, scope);
+
+            // Assert
+            var redirectResult = Assert.IsType<RedirectResult>(result);
+            Assert.StartsWith("https://example.com/callback?code=new-auth-code&state=original-state", redirectResult.Url);
+            
+            // Verify services were called
+            _externalIdpServiceMock.Verify(x => x.GetExternalUserInfoAsync(
+                providerId, "test-code", It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+            _userServiceMock.Verify(x => x.GetOrCreateUserAsync(
+                It.Is<UserCreationRequest>(r => 
+                    r.ExternalProvider == providerId &&
+                    r.ExternalSubject == externalUserInfo.Subject &&
+                    r.Email == externalUserInfo.Email &&
+                    r.OrganizationId == organizationId)), Times.Once);
+            _authCodeServiceMock.Verify(x => x.GenerateAuthorizationCodeAsync(
+                It.IsAny<int>(), ecAuthUser.Id, redirectUri, scope), Times.Once);
+        }
+
+        [Fact]
+        public async Task Index_Post_ReturnsErrorView_WhenStateInvalid()
+        {
+            // Arrange
+            var formCollection = new FormCollection(new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>
+            {
+                ["code"] = "test-code",
+                ["state"] = "invalid-state",
+                ["scope"] = "openid"
+            });
+            _controller.HttpContext.Request.Form = formCollection;
+
+            // Act
+            var result = await _controller.Index("test-code", "invalid-state", "openid");
+
+            // Assert
+            var viewResult = Assert.IsType<ViewResult>(result);
+            Assert.Equal("Index", viewResult.ViewName);
+            var model = Assert.IsType<Dictionary<string, string>>(viewResult.Model);
+            Assert.Equal("invalid_request", model["error"]);
+        }
+
+        [Fact]
+        public async Task Index_Post_ReturnsErrorView_WhenExternalIdpServiceThrows()
+        {
+            // Arrange
+            var stateData = new
+            {
+                provider = "test-provider",
+                organizationId = 1,
+                clientId = "test-client",
+                redirectUri = "https://example.com/callback",
+                originalState = "original-state"
+            };
+            var sealedState = await IronTestHelper.SealStateAsync(stateData);
+
+            _externalIdpServiceMock
+                .Setup(x => x.GetExternalUserInfoAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ThrowsAsync(new Exception("External IdP error"));
+
+            var formCollection = new FormCollection(new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>
+            {
+                ["code"] = "test-code",
+                ["state"] = sealedState,
+                ["scope"] = "openid"
+            });
+            _controller.HttpContext.Request.Form = formCollection;
+
+            // Act
+            var result = await _controller.Index("test-code", sealedState, "openid");
+
+            // Assert
+            var viewResult = Assert.IsType<ViewResult>(result);
+            Assert.Equal("Index", viewResult.ViewName);
+            var model = Assert.IsType<Dictionary<string, string>>(viewResult.Model);
+            Assert.Equal("server_error", model["error"]);
+        }
+    }
+}

--- a/IdentityProvider.Test/Controllers/TokenControllerTests.cs
+++ b/IdentityProvider.Test/Controllers/TokenControllerTests.cs
@@ -26,6 +26,7 @@ namespace IdentityProvider.Test.Controllers
         private readonly Mock<ILogger<TokenController>> _loggerMock;
         private readonly TokenController _controller;
         private readonly RsaKeyPair _testKeyPair;
+        private readonly Client _testClient;
 
         public TokenControllerTests()
         {
@@ -41,17 +42,22 @@ namespace IdentityProvider.Test.Controllers
             _userServiceMock = new Mock<IUserService>();
             _loggerMock = new Mock<ILogger<TokenController>>();
 
-            // Create test RSA key pair
+            // Create test client and RSA key pair
+            _testClient = new Client
+            {
+                ClientId = "test-client",
+                ClientSecret = "test-secret",
+                AppName = "Test App"
+            };
+            
             _testKeyPair = new RsaKeyPair
             {
-                Id = Guid.NewGuid(),
-                KeyId = "test-key-id",
                 PublicKey = GenerateTestPublicKey(),
                 PrivateKey = GenerateTestPrivateKey(),
-                CreatedAt = DateTime.UtcNow,
-                ExpiresAt = DateTime.UtcNow.AddYears(1),
-                IsActive = true
+                Client = _testClient
             };
+            
+            _testClient.RsaKeyPair = _testKeyPair;
 
             // Setup test data
             SetupTestData();
@@ -79,7 +85,8 @@ namespace IdentityProvider.Test.Controllers
 
         private void SetupTestData()
         {
-            // Add test key pair
+            // Add test client and key pair
+            _context.Clients.Add(_testClient);
             _context.RsaKeyPairs.Add(_testKeyPair);
 
             // Add test organization

--- a/IdentityProvider.Test/Controllers/TokenControllerTests.cs
+++ b/IdentityProvider.Test/Controllers/TokenControllerTests.cs
@@ -1,0 +1,416 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using IdentityProvider.Controllers;
+using IdentityProvider.Models;
+using IdentityProvider.Services;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace IdentityProvider.Test.Controllers
+{
+    public class TokenControllerTests : IDisposable
+    {
+        private readonly EcAuthDbContext _context;
+        private readonly Mock<IHostEnvironment> _environmentMock;
+        private readonly Mock<IAuthorizationCodeService> _authCodeServiceMock;
+        private readonly Mock<IUserService> _userServiceMock;
+        private readonly Mock<ILogger<TokenController>> _loggerMock;
+        private readonly TokenController _controller;
+        private readonly RsaKeyPair _testKeyPair;
+
+        public TokenControllerTests()
+        {
+            // Setup in-memory database
+            var options = new DbContextOptionsBuilder<EcAuthDbContext>()
+                .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+                .Options;
+            _context = new EcAuthDbContext(options);
+
+            // Setup mocks
+            _environmentMock = new Mock<IHostEnvironment>();
+            _authCodeServiceMock = new Mock<IAuthorizationCodeService>();
+            _userServiceMock = new Mock<IUserService>();
+            _loggerMock = new Mock<ILogger<TokenController>>();
+
+            // Create test RSA key pair
+            _testKeyPair = new RsaKeyPair
+            {
+                Id = Guid.NewGuid(),
+                KeyId = "test-key-id",
+                PublicKey = GenerateTestPublicKey(),
+                PrivateKey = GenerateTestPrivateKey(),
+                CreatedAt = DateTime.UtcNow,
+                ExpiresAt = DateTime.UtcNow.AddYears(1),
+                IsActive = true
+            };
+
+            // Setup test data
+            SetupTestData();
+
+            _controller = new TokenController(
+                _context,
+                _environmentMock.Object,
+                _authCodeServiceMock.Object,
+                _userServiceMock.Object,
+                _loggerMock.Object);
+
+            // Setup HttpContext
+            _controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            };
+            _controller.HttpContext.Request.Host = new HostString("localhost", 8081);
+            _controller.HttpContext.Request.Scheme = "http";
+        }
+
+        public void Dispose()
+        {
+            _context.Dispose();
+        }
+
+        private void SetupTestData()
+        {
+            // Add test key pair
+            _context.RsaKeyPairs.Add(_testKeyPair);
+
+            // Add test organization
+            var organization = new Organization
+            {
+                Id = "test-org-id",
+                TenantId = "test-tenant",
+                Name = "Test Organization"
+            };
+            _context.Organizations.Add(organization);
+
+            // Add test client
+            var client = new Client
+            {
+                Id = "test-client-id",
+                Secret = "test-client-secret",
+                Name = "Test Client",
+                OrganizationId = organization.Id
+            };
+            _context.Clients.Add(client);
+
+            // Add redirect URI
+            var redirectUri = new RedirectUri
+            {
+                Id = Guid.NewGuid(),
+                ClientId = client.Id,
+                Uri = "https://example.com/callback"
+            };
+            _context.RedirectUris.Add(redirectUri);
+
+            _context.SaveChanges();
+        }
+
+        [Fact]
+        public async Task Token_ReturnsError_WhenGrantTypeNotAuthorizationCode()
+        {
+            // Arrange
+            var formData = new FormCollection(new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>
+            {
+                ["grant_type"] = "client_credentials",
+                ["code"] = "test-code",
+                ["redirect_uri"] = "https://example.com/callback",
+                ["client_id"] = "test-client-id",
+                ["client_secret"] = "test-client-secret"
+            });
+            _controller.HttpContext.Request.Form = formData;
+
+            // Act
+            var result = await _controller.Token(
+                "client_credentials", "test-code", "https://example.com/callback", 
+                "test-client-id", "test-client-secret");
+
+            // Assert
+            var jsonResult = Assert.IsType<JsonResult>(result);
+            dynamic error = jsonResult.Value!;
+            Assert.Equal("unsupported_grant_type", (string)error.error);
+        }
+
+        [Fact]
+        public async Task Token_ReturnsError_WhenCodeMissing()
+        {
+            // Arrange
+            var formData = new FormCollection(new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>
+            {
+                ["grant_type"] = "authorization_code",
+                ["redirect_uri"] = "https://example.com/callback",
+                ["client_id"] = "test-client-id",
+                ["client_secret"] = "test-client-secret"
+            });
+            _controller.HttpContext.Request.Form = formData;
+
+            // Act
+            var result = await _controller.Token(
+                "authorization_code", "", "https://example.com/callback",
+                "test-client-id", "test-client-secret");
+
+            // Assert
+            var jsonResult = Assert.IsType<JsonResult>(result);
+            dynamic error = jsonResult.Value!;
+            Assert.Equal("invalid_request", (string)error.error);
+        }
+
+        [Fact]
+        public async Task Token_ReturnsError_WhenClientNotFound()
+        {
+            // Arrange
+            var formData = new FormCollection(new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>
+            {
+                ["grant_type"] = "authorization_code",
+                ["code"] = "test-code",
+                ["redirect_uri"] = "https://example.com/callback",
+                ["client_id"] = "non-existent-client",
+                ["client_secret"] = "wrong-secret"
+            });
+            _controller.HttpContext.Request.Form = formData;
+
+            // Act
+            var result = await _controller.Token(
+                "authorization_code", "test-code", "https://example.com/callback",
+                "non-existent-client", "wrong-secret");
+
+            // Assert
+            var jsonResult = Assert.IsType<JsonResult>(result);
+            dynamic error = jsonResult.Value!;
+            Assert.Equal("invalid_client", (string)error.error);
+        }
+
+        [Fact]
+        public async Task Token_ReturnsError_WhenClientSecretInvalid()
+        {
+            // Arrange
+            var formData = new FormCollection(new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>
+            {
+                ["grant_type"] = "authorization_code",
+                ["code"] = "test-code",
+                ["redirect_uri"] = "https://example.com/callback",
+                ["client_id"] = "test-client-id",
+                ["client_secret"] = "wrong-secret"
+            });
+            _controller.HttpContext.Request.Form = formData;
+
+            // Act
+            var result = await _controller.Token(
+                "authorization_code", "test-code", "https://example.com/callback",
+                "test-client-id", "wrong-secret");
+
+            // Assert
+            var jsonResult = Assert.IsType<JsonResult>(result);
+            dynamic error = jsonResult.Value!;
+            Assert.Equal("invalid_client", (string)error.error);
+        }
+
+        [Fact]
+        public async Task Token_ReturnsError_WhenCodeInvalid()
+        {
+            // Arrange
+            var formData = new FormCollection(new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>
+            {
+                ["grant_type"] = "authorization_code",
+                ["code"] = "invalid-code",
+                ["redirect_uri"] = "https://example.com/callback",
+                ["client_id"] = "test-client-id",
+                ["client_secret"] = "test-client-secret"
+            });
+            _controller.HttpContext.Request.Form = formData;
+
+            _authCodeServiceMock
+                .Setup(x => x.ValidateAuthorizationCodeAsync(
+                    "invalid-code", It.IsAny<int>(), "https://example.com/callback"))
+                .ReturnsAsync((AuthorizationCode?)null);
+
+            // Act
+            var result = await _controller.Token(
+                "authorization_code", "invalid-code", "https://example.com/callback",
+                "test-client-id", "test-client-secret");
+
+            // Assert
+            var jsonResult = Assert.IsType<JsonResult>(result);
+            dynamic error = jsonResult.Value!;
+            Assert.Equal("invalid_grant", (string)error.error);
+        }
+
+        [Fact]
+        public async Task Token_ReturnsTokens_WhenRequestValid()
+        {
+            // Arrange
+            var formData = new FormCollection(new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>
+            {
+                ["grant_type"] = "authorization_code",
+                ["code"] = "valid-code",
+                ["redirect_uri"] = "https://example.com/callback",
+                ["client_id"] = "test-client-id",
+                ["client_secret"] = "test-client-secret"
+            });
+            _controller.HttpContext.Request.Form = formData;
+
+            var authCode = new AuthorizationCode
+            {
+                Code = "valid-code",
+                ClientId = 1, // This should match a real client ID in the database
+                EcAuthUserId = 1,
+                RedirectUri = "https://example.com/callback",
+                Scope = "openid profile email",
+                CreatedAt = DateTime.UtcNow,
+                ExpiresAt = DateTime.UtcNow.AddMinutes(10),
+                IsUsed = false
+            };
+
+            _authCodeServiceMock
+                .Setup(x => x.ValidateAuthorizationCodeAsync(
+                    "valid-code", It.IsAny<int>(), "https://example.com/callback"))
+                .ReturnsAsync(authCode);
+
+            var user = new EcAuthUser
+            {
+                Id = 1,
+                Subject = "user-subject",
+                EmailHash = "hash",
+                OrganizationId = 1
+            };
+
+            _userServiceMock
+                .Setup(x => x.GetUserBySubjectAsync(user.Subject))
+                .ReturnsAsync(user);
+
+            _authCodeServiceMock
+                .Setup(x => x.MarkCodeAsUsedAsync("valid-code"))
+                .Returns(Task.CompletedTask);
+
+            // Act
+            var result = await _controller.Token(
+                "authorization_code", "valid-code", "https://example.com/callback",
+                "test-client-id", "test-client-secret");
+
+            // Assert
+            var jsonResult = Assert.IsType<JsonResult>(result);
+            dynamic response = jsonResult.Value!;
+            
+            Assert.NotNull(response.access_token);
+            Assert.NotNull(response.id_token);
+            Assert.Equal("Bearer", (string)response.token_type);
+            Assert.Equal(3600, (int)response.expires_in);
+            Assert.Equal("openid profile email", (string)response.scope);
+
+            // Verify services were called
+            _authCodeServiceMock.Verify(x => x.ValidateAuthorizationCodeAsync(
+                "valid-code", It.IsAny<int>(), "https://example.com/callback"), Times.Once);
+            _userServiceMock.Verify(x => x.GetUserBySubjectAsync(user.Subject), Times.Once);
+            _authCodeServiceMock.Verify(x => x.MarkCodeAsUsedAsync("valid-code"), Times.Once);
+        }
+
+        [Fact]
+        public async Task Token_HandlesOptionalScopes_WhenNotRequested()
+        {
+            // Arrange
+            var formData = new FormCollection(new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>
+            {
+                ["grant_type"] = "authorization_code",
+                ["code"] = "valid-code",
+                ["redirect_uri"] = "https://example.com/callback",
+                ["client_id"] = "test-client-id",
+                ["client_secret"] = "test-client-secret"
+            });
+            _controller.HttpContext.Request.Form = formData;
+
+            var authCode = new AuthorizationCode
+            {
+                Code = "valid-code",
+                ClientId = 1,
+                EcAuthUserId = 1,
+                RedirectUri = "https://example.com/callback",
+                Scope = "openid", // Only openid scope
+                CreatedAt = DateTime.UtcNow,
+                ExpiresAt = DateTime.UtcNow.AddMinutes(10),
+                IsUsed = false
+            };
+
+            _authCodeServiceMock
+                .Setup(x => x.ValidateAuthorizationCodeAsync(
+                    "valid-code", It.IsAny<int>(), "https://example.com/callback"))
+                .ReturnsAsync(authCode);
+
+            var user = new EcAuthUser
+            {
+                Id = 1,
+                Subject = "user-subject",
+                EmailHash = "hash",
+                OrganizationId = 1
+            };
+
+            _userServiceMock
+                .Setup(x => x.GetUserBySubjectAsync(user.Subject))
+                .ReturnsAsync(user);
+
+            // Act
+            var result = await _controller.Token(
+                "authorization_code", "valid-code", "https://example.com/callback",
+                "test-client-id", "test-client-secret");
+
+            // Assert
+            var jsonResult = Assert.IsType<JsonResult>(result);
+            dynamic response = jsonResult.Value!;
+            
+            Assert.NotNull(response.id_token);
+            Assert.Equal("openid", (string)response.scope);
+        }
+
+        private string GenerateTestPublicKey()
+        {
+            // This is a test RSA public key in PEM format
+            return @"-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu1SU1LfVLPHCozMxH2Mo
+4lgOEePzNm0tRgeLezV6ffAt0gunVTLw7onLRnrq0/IzW7yWR7QkrmBL7jTKEn5u
++qKhbwKfBstIs+bMY2Zkp18gnTxKLxoS2tFczGkPLPgizskuemMghRniWaoLcyeh
+kd3qqGElvW/VDL5AaWTg0nLVkjRo9z+40RQzuVaE8AkAFmxZzow3x+VJYKdjykkJ
+0iT9wCS0DRTXu269V264Vf/3jvredZiKRkgwlL9xNAwxXFg0x/XFw005UWVRIkdg
+cKWTjpBP2dPwVZ4WWC+9aGVd+Gyn1o0CLelf4rEjGoXbAAEgAqeGUxrcIlbjXfbc
+mwIDAQAB
+-----END PUBLIC KEY-----";
+        }
+
+        private string GenerateTestPrivateKey()
+        {
+            // This is a test RSA private key in PEM format
+            return @"-----BEGIN RSA PRIVATE KEY-----
+MIIEogIBAAKCAQEAu1SU1LfVLPHCozMxH2Mo4lgOEePzNm0tRgeLezV6ffAt0gun
+VTLw7onLRnrq0/IzW7yWR7QkrmBL7jTKEn5u+qKhbwKfBstIs+bMY2Zkp18gnTxK
+LxoS2tFczGkPLPgizskuemMghRniWaoLcyehkd3qqGElvW/VDL5AaWTg0nLVkjRo
+9z+40RQzuVaE8AkAFmxZzow3x+VJYKdjykkJ0iT9wCS0DRTXu269V264Vf/3jvre
+dZiKRkgwlL9xNAwxXFg0x/XFw005UWVRIkdgcKWTjpBP2dPwVZ4WWC+9aGVd+Gyn
+1o0CLelf4rEjGoXbAAEgAqeGUxrcIlbjXfbcmwIDAQABAoIBACiARq2wkltjtcjs
+kFvZ7w1JAORHbEufEO1Eu27zOIlqbgyAcAl7q+/1bip4Z/x1IVES84/yTaM8p0go
+amMhvgry/mS8vNi1BN2SAZEnb/7xSxbflb70bX9RHLJqKnp5GZe2jexw+wyXlwaM
++bclUCrh9e1ltH7IvUrRrQnFJfh+is1fRon9Co9Li0GwoN0x0byrrngU8Ak3Y6D9
+D8GjQA4Elm94ST3izJv8iCOLSDBmzsPsXfcCUZfmTfZ5DbUDMbMxRnSo3nQeoKGC
+0Lj9FkWcfmLcpGlSXTO+Ww1L7EGq+PT3NtRae1FZPwjddQ1/4V905kyQFLamAA5Y
+lSpE2wkCgYEAy1OPLQcZt4NQnQzPz2SBJqQN2P5u3vXl+zNVKP8w4eBv0vWuJJF+
+hkGNnSxXQrTkvDOIUddSKOzHHgSg4nY6K02ecyT0PPm/UZvtRpWrnBjcEVtHEJNp
+bU9pLD5iZ0J9sbzPU/LxPmuAP2Bs8JmTn6aFRspFrP7W0s1Nmk2jsm0CgYEA7WwI
+UVeRkzHMFJmm9dv0IaKJqkYRUHgvJjZ1AuK3z0hT7jEsSGi6+8XHKP0ZqM8MdPZX
+E/hROXrIwg9FfFFMQysAm1qyW6+pQZ2W9QdqYJLrcTQQ4VvnAYreUeqVvDUqnDy5
+uAuAjCkqHKkrZjLNHqmGJqPbmyc3VIgEaGVpYlcCgYAdy5xz8qrPXHh+XYapQsrO
+Ss7cHqH2TXSdNPR2q6LjqSFwmY5h8nGb9F1w5J6L2nrHMkrAe+wgIk8vcKLjjPRr
+hgmAQdVVoFCCJnBF7T3vubZKwBn5Kc2VdYpNMC6W+wjX5qHGF8cH5zEC7EYYmsay
+SfIK6rVWHl1wXN7F7qxqKQKBgBzwq1lc1y1dHCxj7KcmY7QPVD24nkfEZcvu4M06
+YjAD/ksf0D6iAcQVV29rJ+MsHXNZQbB8YNP3i5Qc0y7NL7cNRQiPnhZjBtVqpQNC
+f8Y2g6KhT9E8E3darWssLpANNL8DvGpFBmGwftnPEzPS6qkMxT1hFBN7vT2XwMUn
+VcNzAoGAXCJTdPX72pNVLEHIIbWJh1hPVqgFxD5HAYuHPPsxe/OWjd1qfAKgQPXR
+A6CZn3RJ4J+dmt5DylCqELpnVGsBhTkUNqAHqYXmvOPelLrm8buFFMUQQh2RI0U0
+UtWvu+lzGV9oIKNLXnX4L5s/UZXEb5VHFWXMXGLh0D3vcVOyFe0=
+-----END RSA PRIVATE KEY-----";
+        }
+    }
+}

--- a/IdentityProvider.Test/Helpers/IronTestHelper.cs
+++ b/IdentityProvider.Test/Helpers/IronTestHelper.cs
@@ -1,0 +1,25 @@
+using IdpUtilities;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace IdentityProvider.Test.Helpers
+{
+    public static class IronTestHelper
+    {
+        public const string TestPassword = "test-password-32-characters-long!";
+
+        public static async Task<string> SealStateAsync<T>(T data)
+        {
+            var json = JsonSerializer.Serialize(data);
+            var options = new Iron.Options();
+            return await Iron.Seal(json, TestPassword, options);
+        }
+
+        public static async Task<T> UnsealStateAsync<T>(string sealedData)
+        {
+            var options = new Iron.Options();
+            var json = await Iron.Unseal<string>(sealedData, TestPassword, options);
+            return JsonSerializer.Deserialize<T>(json)!;
+        }
+    }
+}

--- a/IdentityProvider.Test/Helpers/TestDbContextFactory.cs
+++ b/IdentityProvider.Test/Helpers/TestDbContextFactory.cs
@@ -1,0 +1,23 @@
+using System;
+using IdentityProvider.Models;
+using IdentityProvider.Services;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+
+namespace IdentityProvider.Test.Helpers
+{
+    public static class TestDbContextFactory
+    {
+        public static EcAuthDbContext CreateTestDbContext()
+        {
+            var options = new DbContextOptionsBuilder<EcAuthDbContext>()
+                .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+                .Options;
+
+            var tenantServiceMock = new Mock<ITenantService>();
+            tenantServiceMock.Setup(x => x.GetTenantId()).Returns("test-tenant");
+
+            return new EcAuthDbContext(options, tenantServiceMock.Object);
+        }
+    }
+}

--- a/IdentityProvider.Test/IdentityProvider.Test.csproj
+++ b/IdentityProvider.Test/IdentityProvider.Test.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\IdentityProvider\IdentityProvider.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/IdentityProvider.Test/IdentityProvider.Test.csproj
+++ b/IdentityProvider.Test/IdentityProvider.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -19,9 +19,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.4" />
     <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.3.1" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/IdentityProvider.Test/Services/AuthorizationCodeServiceTests.cs
+++ b/IdentityProvider.Test/Services/AuthorizationCodeServiceTests.cs
@@ -1,0 +1,239 @@
+using System;
+using System.Threading.Tasks;
+using IdentityProvider.Models;
+using IdentityProvider.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace IdentityProvider.Test.Services
+{
+    public class AuthorizationCodeServiceTests : IDisposable
+    {
+        private readonly EcAuthDbContext _context;
+        private readonly AuthorizationCodeService _authCodeService;
+        private readonly Mock<ILogger<AuthorizationCodeService>> _loggerMock;
+        private readonly Client _testClient;
+        private readonly EcAuthUser _testUser;
+
+        public AuthorizationCodeServiceTests()
+        {
+            var options = new DbContextOptionsBuilder<EcAuthDbContext>()
+                .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+                .Options;
+            _context = new EcAuthDbContext(options);
+            _loggerMock = new Mock<ILogger<AuthorizationCodeService>>();
+            _authCodeService = new AuthorizationCodeService(_context, _loggerMock.Object);
+
+            // Setup test data
+            var organization = new Organization
+            {
+                Id = "test-org",
+                TenantId = "test-tenant",
+                Name = "Test Organization"
+            };
+            _context.Organizations.Add(organization);
+
+            _testClient = new Client
+            {
+                Id = "test-client-id",
+                Secret = "test-secret",
+                Name = "Test Client",
+                OrganizationId = organization.Id
+            };
+            _context.Clients.Add(_testClient);
+
+            _testUser = new EcAuthUser
+            {
+                Subject = Guid.NewGuid().ToString(),
+                EmailHash = "test-hash",
+                OrganizationId = 1
+            };
+            _context.EcAuthUsers.Add(_testUser);
+
+            _context.SaveChanges();
+        }
+
+        public void Dispose()
+        {
+            _context.Dispose();
+        }
+
+        [Fact]
+        public async Task GenerateAuthorizationCodeAsync_CreatesValidCode()
+        {
+            // Arrange
+            var clientId = 1; // Using int based on actual implementation
+            var ecAuthUserId = _testUser.Id;
+            var redirectUri = "https://example.com/callback";
+            var scope = "openid profile email";
+
+            // Act
+            var code = await _authCodeService.GenerateAuthorizationCodeAsync(
+                clientId, ecAuthUserId, redirectUri, scope);
+
+            // Assert
+            Assert.NotNull(code);
+            Assert.NotEmpty(code);
+
+            // Verify code was saved to database
+            var savedCode = await _context.AuthorizationCodes
+                .FirstOrDefaultAsync(c => c.Code == code);
+            Assert.NotNull(savedCode);
+            Assert.Equal(clientId, savedCode.ClientId);
+            Assert.Equal(ecAuthUserId, savedCode.EcAuthUserId);
+            Assert.Equal(redirectUri, savedCode.RedirectUri);
+            Assert.Equal(scope, savedCode.Scope);
+            Assert.False(savedCode.IsUsed);
+            Assert.True(savedCode.ExpiresAt > DateTime.UtcNow);
+        }
+
+        [Fact]
+        public async Task GenerateAuthorizationCodeAsync_CreatesUniqueCode()
+        {
+            // Arrange
+            var clientId = 1;
+            var ecAuthUserId = _testUser.Id;
+            var redirectUri = "https://example.com/callback";
+
+            // Act
+            var code1 = await _authCodeService.GenerateAuthorizationCodeAsync(
+                clientId, ecAuthUserId, redirectUri, null);
+            var code2 = await _authCodeService.GenerateAuthorizationCodeAsync(
+                clientId, ecAuthUserId, redirectUri, null);
+
+            // Assert
+            Assert.NotEqual(code1, code2);
+        }
+
+        [Fact]
+        public async Task ValidateAuthorizationCodeAsync_ReturnsCode_WhenValid()
+        {
+            // Arrange
+            var clientId = 1;
+            var ecAuthUserId = _testUser.Id;
+            var redirectUri = "https://example.com/callback";
+
+            var code = await _authCodeService.GenerateAuthorizationCodeAsync(
+                clientId, ecAuthUserId, redirectUri, null);
+
+            // Act
+            var validatedCode = await _authCodeService.ValidateAuthorizationCodeAsync(
+                code, clientId, redirectUri);
+
+            // Assert
+            Assert.NotNull(validatedCode);
+            Assert.Equal(clientId, validatedCode.ClientId);
+            Assert.Equal(ecAuthUserId, validatedCode.EcAuthUserId);
+        }
+
+        [Fact]
+        public async Task ValidateAuthorizationCodeAsync_ReturnsNull_WhenCodeDoesNotExist()
+        {
+            // Act
+            var validatedCode = await _authCodeService.ValidateAuthorizationCodeAsync(
+                "invalid-code", 1, "redirect-uri");
+
+            // Assert
+            Assert.Null(validatedCode);
+        }
+
+        [Fact]
+        public async Task ValidateAuthorizationCodeAsync_ReturnsNull_WhenClientIdMismatch()
+        {
+            // Arrange
+            var code = await _authCodeService.GenerateAuthorizationCodeAsync(
+                1, _testUser.Id, "https://example.com/callback", null);
+
+            // Act
+            var validatedCode = await _authCodeService.ValidateAuthorizationCodeAsync(
+                code, 2, "https://example.com/callback");
+
+            // Assert
+            Assert.Null(validatedCode);
+        }
+
+        [Fact]
+        public async Task ValidateAuthorizationCodeAsync_ReturnsNull_WhenRedirectUriMismatch()
+        {
+            // Arrange
+            var code = await _authCodeService.GenerateAuthorizationCodeAsync(
+                1, _testUser.Id, "https://example.com/callback", null);
+
+            // Act
+            var validatedCode = await _authCodeService.ValidateAuthorizationCodeAsync(
+                code, 1, "https://different.com/callback");
+
+            // Assert
+            Assert.Null(validatedCode);
+        }
+
+        [Fact]
+        public async Task ValidateAuthorizationCodeAsync_ReturnsNull_WhenCodeIsUsed()
+        {
+            // Arrange
+            var code = await _authCodeService.GenerateAuthorizationCodeAsync(
+                1, _testUser.Id, "https://example.com/callback", null);
+            
+            // Mark as used
+            await _authCodeService.MarkCodeAsUsedAsync(code);
+
+            // Act
+            var validatedCode = await _authCodeService.ValidateAuthorizationCodeAsync(
+                code, 1, "https://example.com/callback");
+
+            // Assert
+            Assert.Null(validatedCode);
+        }
+
+        [Fact]
+        public async Task ValidateAuthorizationCodeAsync_ReturnsNull_WhenCodeIsExpired()
+        {
+            // Arrange
+            var authCode = new AuthorizationCode
+            {
+                Code = "expired-code",
+                ClientId = 1,
+                EcAuthUserId = _testUser.Id,
+                RedirectUri = "https://example.com/callback",
+                CreatedAt = DateTime.UtcNow.AddMinutes(-15),
+                ExpiresAt = DateTime.UtcNow.AddMinutes(-5), // Expired 5 minutes ago
+                IsUsed = false
+            };
+            _context.AuthorizationCodes.Add(authCode);
+            await _context.SaveChangesAsync();
+
+            // Act
+            var validatedCode = await _authCodeService.ValidateAuthorizationCodeAsync(
+                "expired-code", 1, "https://example.com/callback");
+
+            // Assert
+            Assert.Null(validatedCode);
+        }
+
+        [Fact]
+        public async Task MarkCodeAsUsedAsync_MarksCodeAsUsed()
+        {
+            // Arrange
+            var code = await _authCodeService.GenerateAuthorizationCodeAsync(
+                1, _testUser.Id, "redirect", null);
+
+            // Act
+            await _authCodeService.MarkCodeAsUsedAsync(code);
+
+            // Assert
+            var savedCode = await _context.AuthorizationCodes
+                .FirstOrDefaultAsync(c => c.Code == code);
+            Assert.NotNull(savedCode);
+            Assert.True(savedCode.IsUsed);
+        }
+
+        [Fact]
+        public async Task MarkCodeAsUsedAsync_DoesNotThrow_WhenCodeDoesNotExist()
+        {
+            // Act & Assert - Should not throw
+            await _authCodeService.MarkCodeAsUsedAsync("non-existent-code");
+        }
+    }
+}

--- a/IdentityProvider.Test/Services/ExternalIdpServiceTests.cs
+++ b/IdentityProvider.Test/Services/ExternalIdpServiceTests.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using IdentityProvider.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace IdentityProvider.Test.Services
+{
+    public class ExternalIdpServiceTests
+    {
+        private readonly Mock<IHttpClientFactory> _httpClientFactoryMock;
+        private readonly Mock<ILogger<ExternalIdpService>> _loggerMock;
+        private readonly ExternalIdpService _externalIdpService;
+
+        public ExternalIdpServiceTests()
+        {
+            _httpClientFactoryMock = new Mock<IHttpClientFactory>();
+            _loggerMock = new Mock<ILogger<ExternalIdpService>>();
+            _externalIdpService = new ExternalIdpService(_httpClientFactoryMock.Object, _loggerMock.Object);
+        }
+
+        [Fact]
+        public async Task GetExternalUserInfoAsync_ReturnsMockData_ForMockProvider()
+        {
+            // Arrange
+            var providerId = "mock";
+            var authorizationCode = "test-code";
+            var idpClientId = "test-client-id";
+            var idpClientSecret = "test-client-secret";
+
+            // Act
+            var userInfo = await _externalIdpService.GetExternalUserInfoAsync(
+                providerId, authorizationCode, idpClientId, idpClientSecret);
+
+            // Assert
+            Assert.NotNull(userInfo);
+            Assert.Equal("mock-user-sub", userInfo.Subject);
+            Assert.Equal("mock@example.com", userInfo.Email);
+            Assert.Equal("Mock User", userInfo.Name);
+        }
+
+        [Fact]
+        public async Task GetExternalUserInfoAsync_ReturnsMockData_ForMockOidProvider()
+        {
+            // Arrange
+            var providerId = "mockoidprovider";
+            var authorizationCode = "test-code";
+            var idpClientId = "test-client-id";
+            var idpClientSecret = "test-client-secret";
+
+            // Act
+            var userInfo = await _externalIdpService.GetExternalUserInfoAsync(
+                providerId, authorizationCode, idpClientId, idpClientSecret);
+
+            // Assert
+            Assert.NotNull(userInfo);
+            Assert.Equal("mock-user-sub", userInfo.Subject);
+            Assert.Equal("mock@example.com", userInfo.Email);
+            Assert.Equal("Mock User", userInfo.Name);
+        }
+
+        [Fact]
+        public async Task GetExternalUserInfoAsync_ThrowsNotImplementedException_ForUnknownProvider()
+        {
+            // Arrange
+            var providerId = "unknown-provider";
+            var authorizationCode = "test-code";
+            var idpClientId = "test-client-id";
+            var idpClientSecret = "test-client-secret";
+
+            // Act & Assert
+            await Assert.ThrowsAsync<NotImplementedException>(async () =>
+                await _externalIdpService.GetExternalUserInfoAsync(
+                    providerId, authorizationCode, idpClientId, idpClientSecret));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData(null)]
+        public async Task GetExternalUserInfoAsync_ThrowsArgumentException_ForInvalidProviderId(string providerId)
+        {
+            // Act & Assert
+            await Assert.ThrowsAsync<ArgumentException>(async () =>
+                await _externalIdpService.GetExternalUserInfoAsync(
+                    providerId, "code", "clientId", "clientSecret"));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData(null)]
+        public async Task GetExternalUserInfoAsync_ThrowsArgumentException_ForInvalidAuthorizationCode(string authCode)
+        {
+            // Act & Assert
+            await Assert.ThrowsAsync<ArgumentException>(async () =>
+                await _externalIdpService.GetExternalUserInfoAsync(
+                    "mock", authCode, "clientId", "clientSecret"));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData(null)]
+        public async Task GetExternalUserInfoAsync_ThrowsArgumentException_ForInvalidClientId(string clientId)
+        {
+            // Act & Assert
+            await Assert.ThrowsAsync<ArgumentException>(async () =>
+                await _externalIdpService.GetExternalUserInfoAsync(
+                    "mock", "code", clientId, "clientSecret"));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData(null)]
+        public async Task GetExternalUserInfoAsync_ThrowsArgumentException_ForInvalidClientSecret(string clientSecret)
+        {
+            // Act & Assert
+            await Assert.ThrowsAsync<ArgumentException>(async () =>
+                await _externalIdpService.GetExternalUserInfoAsync(
+                    "mock", "code", "clientId", clientSecret));
+        }
+
+        // This test demonstrates how external IdP integration would work when implemented
+        [Fact]
+        public async Task GetExternalUserInfoAsync_WouldCallExternalApi_WhenImplemented()
+        {
+            // Arrange - Setup for future implementation
+            var mockHttpMessageHandler = new Mock<HttpMessageHandler>();
+            var expectedResponse = new
+            {
+                sub = "external-user-123",
+                email = "external@example.com",
+                name = "External User"
+            };
+
+            mockHttpMessageHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(JsonSerializer.Serialize(expectedResponse), Encoding.UTF8, "application/json")
+                });
+
+            var httpClient = new HttpClient(mockHttpMessageHandler.Object);
+            _httpClientFactoryMock.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+            // Note: This test demonstrates the expected behavior when external IdP integration is implemented
+            // Currently, it will throw NotImplementedException for non-mock providers
+        }
+    }
+}

--- a/IdentityProvider.Test/Services/UserServiceTests.cs
+++ b/IdentityProvider.Test/Services/UserServiceTests.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using IdentityProvider.Models;
+using IdentityProvider.Services;
+using IdentityProvider.Test.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace IdentityProvider.Test.Services
+{
+    public class UserServiceTests : IDisposable
+    {
+        private readonly EcAuthDbContext _context;
+        private readonly UserService _userService;
+        private readonly Mock<ILogger<UserService>> _loggerMock;
+        private readonly Organization _testOrganization;
+
+        public UserServiceTests()
+        {
+            _context = TestDbContextFactory.CreateTestDbContext();
+            _loggerMock = new Mock<ILogger<UserService>>();
+            _userService = new UserService(_context, _loggerMock.Object);
+
+            // Setup test organization
+            _testOrganization = new Organization
+            {
+                Code = "test-org",
+                Name = "Test Organization",
+                TenantName = "test-tenant"
+            };
+            _context.Organizations.Add(_testOrganization);
+            _context.SaveChanges();
+        }
+
+        public void Dispose()
+        {
+            _context.Dispose();
+        }
+
+        [Fact]
+        public async Task GetOrCreateUserAsync_CreatesNewUser_WhenUserDoesNotExist()
+        {
+            // Arrange
+            var request = new UserCreationRequest
+            {
+                ExternalProvider = "test-provider",
+                ExternalSubject = "external-subject-123",
+                Email = "test@example.com",
+                OrganizationId = _testOrganization.Id
+            };
+
+            // Act
+            var user = await _userService.GetOrCreateUserAsync(request);
+
+            // Assert
+            Assert.NotNull(user);
+            Assert.NotEmpty(user.Subject);
+            Assert.Equal(_userService.HashEmail(request.Email), user.EmailHash);
+            Assert.Equal(request.OrganizationId, user.OrganizationId);
+
+            // Verify user was saved to database
+            var savedUser = await _context.EcAuthUsers
+                .Include(u => u.ExternalIdpMappings)
+                .FirstOrDefaultAsync(u => u.Subject == user.Subject);
+            Assert.NotNull(savedUser);
+            Assert.Single(savedUser.ExternalIdpMappings);
+            Assert.Equal(request.ExternalProvider, savedUser.ExternalIdpMappings.First().ExternalProvider);
+            Assert.Equal(request.ExternalSubject, savedUser.ExternalIdpMappings.First().ExternalSubject);
+        }
+
+        [Fact]
+        public async Task GetOrCreateUserAsync_ReturnsExistingUser_WhenUserExists()
+        {
+            // Arrange
+            var request = new UserCreationRequest
+            {
+                ExternalProvider = "test-provider",
+                ExternalSubject = "external-subject-123",
+                Email = "test@example.com",
+                OrganizationId = _testOrganization.Id
+            };
+
+            // Create user first
+            var firstUser = await _userService.GetOrCreateUserAsync(request);
+
+            // Act - Try to create same user again
+            var secondUser = await _userService.GetOrCreateUserAsync(request);
+
+            // Assert
+            Assert.Equal(firstUser.Subject, secondUser.Subject);
+            Assert.Equal(firstUser.EmailHash, secondUser.EmailHash);
+
+            // Verify only one user exists
+            var userCount = await _context.EcAuthUsers.CountAsync();
+            Assert.Equal(1, userCount);
+        }
+
+        [Fact]
+        public async Task GetUserBySubjectAsync_ReturnsUser_WhenUserExists()
+        {
+            // Arrange
+            var request = new UserCreationRequest
+            {
+                ExternalProvider = "test-provider",
+                ExternalSubject = "external-subject-123",
+                Email = "test@example.com",
+                OrganizationId = _testOrganization.Id
+            };
+
+            var createdUser = await _userService.GetOrCreateUserAsync(request);
+
+            // Act
+            var retrievedUser = await _userService.GetUserBySubjectAsync(createdUser.Subject);
+
+            // Assert
+            Assert.NotNull(retrievedUser);
+            Assert.Equal(createdUser.Subject, retrievedUser.Subject);
+            Assert.Equal(createdUser.EmailHash, retrievedUser.EmailHash);
+            Assert.Equal(createdUser.OrganizationId, retrievedUser.OrganizationId);
+        }
+
+        [Fact]
+        public async Task GetUserBySubjectAsync_ReturnsNull_WhenUserDoesNotExist()
+        {
+            // Act
+            var user = await _userService.GetUserBySubjectAsync("non-existent-subject");
+
+            // Assert
+            Assert.Null(user);
+        }
+
+        [Fact]
+        public async Task GetUserByExternalProviderAsync_ReturnsUser_WhenMappingExists()
+        {
+            // Arrange
+            var request = new UserCreationRequest
+            {
+                ExternalProvider = "test-provider",
+                ExternalSubject = "external-subject-123",
+                Email = "test@example.com",
+                OrganizationId = _testOrganization.Id
+            };
+
+            await _userService.GetOrCreateUserAsync(request);
+
+            // Act
+            var user = await _userService.GetUserByExternalProviderAsync(
+                request.ExternalProvider, request.ExternalSubject);
+
+            // Assert
+            Assert.NotNull(user);
+            Assert.Equal(_userService.HashEmail(request.Email), user.EmailHash);
+        }
+
+        [Fact]
+        public async Task GetUserByExternalProviderAsync_ReturnsNull_WhenMappingDoesNotExist()
+        {
+            // Act
+            var user = await _userService.GetUserByExternalProviderAsync(
+                "provider", "subject");
+
+            // Assert
+            Assert.Null(user);
+        }
+
+        [Theory]
+        [InlineData("test@example.com", "TEST@EXAMPLE.COM")]
+        [InlineData("User@Domain.Com", "user@domain.com")]
+        public void HashEmail_NormalizesEmailToLowerCase(string email1, string email2)
+        {
+            // Act
+            var hash1 = _userService.HashEmail(email1);
+            var hash2 = _userService.HashEmail(email2);
+
+            // Assert
+            Assert.Equal(hash1, hash2);
+        }
+
+        [Fact]
+        public void HashEmail_ProducesDifferentHashesForDifferentEmails()
+        {
+            // Arrange
+            var email1 = "user1@example.com";
+            var email2 = "user2@example.com";
+
+            // Act
+            var hash1 = _userService.HashEmail(email1);
+            var hash2 = _userService.HashEmail(email2);
+
+            // Assert
+            Assert.NotEqual(hash1, hash2);
+        }
+    }
+}

--- a/IdentityProvider/Controllers/TokenController.cs
+++ b/IdentityProvider/Controllers/TokenController.cs
@@ -1,8 +1,14 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
 using IdentityProvider.Models;
+using IdentityProvider.Services;
 using IdpUtilities;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
+using Microsoft.IdentityModel.Tokens;
 
 namespace IdentityProvider.Controllers
 {
@@ -12,58 +18,197 @@ namespace IdentityProvider.Controllers
     {
         private readonly EcAuthDbContext _context;
         private readonly IHostEnvironment _environment;
+        private readonly IAuthorizationCodeService _authCodeService;
+        private readonly IUserService _userService;
+        private readonly ILogger<TokenController> _logger;
 
-        public TokenController(EcAuthDbContext context, IHostEnvironment environment)
+        public TokenController(
+            EcAuthDbContext context, 
+            IHostEnvironment environment,
+            IAuthorizationCodeService authCodeService,
+            IUserService userService,
+            ILogger<TokenController> logger)
         {
             _context = context;
             _environment = environment;
+            _authCodeService = authCodeService;
+            _userService = userService;
+            _logger = logger;
         }
 
         /// <summary>
-        /// IdP の Token endpoint にリクエストを送信し、アクセストークンを取得します。
-        /// 取得したアクセストークンを返却します。
+        /// OpenID Connect Token Endpoint
+        /// Authorization Codeを検証し、IDトークンとアクセストークンを発行します。
         /// </summary>
-        /// <param name="code"></param>
-        /// <param name="state"></param>
-        /// <param name="scope"></param>
-        /// <returns></returns>
         [HttpPost]
-        public async Task<IActionResult> Exchange([FromForm] string code, [FromForm] string state, [FromForm] string scope)
+        public async Task<IActionResult> Token(
+            [FromForm] string grant_type,
+            [FromForm] string code,
+            [FromForm] string redirect_uri,
+            [FromForm] string client_id,
+            [FromForm] string client_secret)
         {
-            var password = Environment.GetEnvironmentVariable("STATE_PASSWORD");
-            var options = new Iron.Options();
-            var State = await Iron.Unseal<State>(state, password, options);
-            var IdentityProviderId = State.OpenIdProviderId;
-            var IdentityProvider = await _context.OpenIdProviders
-                .Where(p => p.Id == IdentityProviderId)
-                .FirstOrDefaultAsync();
-
-            var handler = _environment.IsDevelopment()
-                ? new HttpClientHandler
-                {
-                    ServerCertificateCustomValidationCallback
-                        = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
-                }
-                : new HttpClientHandler();
-
-            using (var client = new HttpClient(handler))
+            try
             {
-                var response = await client.PostAsync(
-                    IdentityProvider.TokenEndpoint,
-                    new FormUrlEncodedContent(new Dictionary<string, string>
+                // grant_typeの検証
+                if (grant_type != "authorization_code")
+                {
+                    return BadRequest(new
                     {
-                        { "grant_type", "authorization_code" },
-                        { "code", code },
-                        { "redirect_uri", "https://localhost:8081/auth/callback" },
-                        { "client_id", IdentityProvider.IdpClientId },
-                        { "client_secret", IdentityProvider.IdpClientSecret },
-                        { "state", state }
-                    })
+                        error = "unsupported_grant_type",
+                        error_description = "Only authorization_code grant type is supported"
+                    });
+                }
+
+                // クライアント認証
+                var client = await _context.Clients
+                    .Include(c => c.Organization)
+                    .Include(c => c.RsaKeyPair)
+                    .FirstOrDefaultAsync(c => c.ClientId == client_id && c.ClientSecret == client_secret);
+
+                if (client == null)
+                {
+                    return Unauthorized(new
+                    {
+                        error = "invalid_client",
+                        error_description = "Client authentication failed"
+                    });
+                }
+
+                // 認可コードの検証
+                var authCode = await _authCodeService.ValidateAuthorizationCodeAsync(code, client_id);
+                if (authCode == null)
+                {
+                    return BadRequest(new
+                    {
+                        error = "invalid_grant",
+                        error_description = "Invalid or expired authorization code"
+                    });
+                }
+
+                // redirect_uriの検証（保存されている場合）
+                if (!string.IsNullOrEmpty(authCode.RedirectUri) && authCode.RedirectUri != redirect_uri)
+                {
+                    return BadRequest(new
+                    {
+                        error = "invalid_grant",
+                        error_description = "Redirect URI mismatch"
+                    });
+                }
+
+                // 認可コードを使用済みにマーク
+                await _authCodeService.MarkCodeAsUsedAsync(authCode.Id);
+
+                // ユーザー情報を取得
+                var user = authCode.EcAuthUser;
+
+                // IDトークンの生成
+                var idToken = GenerateIdToken(user, client, authCode.Scope);
+
+                // アクセストークンの生成（簡易実装）
+                var accessToken = GenerateAccessToken(user, client, authCode.Scope);
+
+                // レスポンスの作成
+                var response = new
+                {
+                    access_token = accessToken,
+                    token_type = "Bearer",
+                    expires_in = 3600,
+                    id_token = idToken,
+                    scope = authCode.Scope ?? "openid"
+                };
+
+                _logger.LogInformation("Issued tokens for user {UserId} and client {ClientId}", 
+                    user.Id, client.Id);
+
+                return Ok(response);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error processing token request");
+                return StatusCode(500, new
+                {
+                    error = "server_error",
+                    error_description = "An unexpected error occurred"
+                });
+            }
+        }
+
+        private string GenerateIdToken(EcAuthUser user, Client client, string? scope)
+        {
+            var claims = new List<Claim>
+            {
+                new Claim("sub", user.Subject),
+                new Claim("aud", client.ClientId),
+                new Claim("iss", $"https://{Request.Host}"),
+                new Claim("iat", DateTimeOffset.Now.ToUnixTimeSeconds().ToString(), ClaimValueTypes.Integer64),
+                new Claim("exp", DateTimeOffset.Now.AddHours(1).ToUnixTimeSeconds().ToString(), ClaimValueTypes.Integer64)
+            };
+
+            // スコープに応じて追加のクレームを含める
+            if (!string.IsNullOrEmpty(scope))
+            {
+                var scopes = scope.Split(' ');
+                if (scopes.Contains("email") && !string.IsNullOrEmpty(user.EmailHash))
+                {
+                    // 実際の実装では、ハッシュではなく実際のメールアドレスを含める必要があります
+                    // ここでは開発用にダミーのメールアドレスを設定
+                    claims.Add(new Claim("email", "user@example.com"));
+                    claims.Add(new Claim("email_verified", "true", ClaimValueTypes.Boolean));
+                }
+            }
+
+            // RSA秘密鍵を使用してJWTに署名
+            if (client.RsaKeyPair != null)
+            {
+                var key = new RsaSecurityKey(System.Security.Cryptography.RSA.Create());
+                key.Rsa.ImportFromPem(client.RsaKeyPair.PrivateKey);
+
+                var credentials = new SigningCredentials(key, SecurityAlgorithms.RsaSha256);
+                
+                var token = new JwtSecurityToken(
+                    issuer: $"https://{Request.Host}",
+                    audience: client.ClientId,
+                    claims: claims,
+                    expires: DateTimeOffset.Now.AddHours(1).DateTime,
+                    signingCredentials: credentials
                 );
 
-                var content = await response.Content.ReadAsStringAsync();
-                return Ok(content);
+                var handler = new JwtSecurityTokenHandler();
+                return handler.WriteToken(token);
             }
+            else
+            {
+                // 開発用の対称鍵での署名（本番環境では使用しない）
+                var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes("temporary-development-key-do-not-use-in-production"));
+                var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+                
+                var token = new JwtSecurityToken(
+                    issuer: $"https://{Request.Host}",
+                    audience: client.ClientId,
+                    claims: claims,
+                    expires: DateTimeOffset.Now.AddHours(1).DateTime,
+                    signingCredentials: credentials
+                );
+
+                var handler = new JwtSecurityTokenHandler();
+                return handler.WriteToken(token);
+            }
+        }
+
+        private string GenerateAccessToken(EcAuthUser user, Client client, string? scope)
+        {
+            // 簡易的なアクセストークン生成（実際の実装では適切なトークン管理が必要）
+            var tokenData = new
+            {
+                sub = user.Subject,
+                client_id = client.ClientId,
+                scope = scope ?? "openid",
+                exp = DateTimeOffset.Now.AddHours(1).ToUnixTimeSeconds()
+            };
+
+            var tokenJson = JsonSerializer.Serialize(tokenData);
+            return Convert.ToBase64String(Encoding.UTF8.GetBytes(tokenJson));
         }
     }
 }

--- a/IdentityProvider/Migrations/20250619002509_AddEcAuthUserAndExternalIdpMapping.Designer.cs
+++ b/IdentityProvider/Migrations/20250619002509_AddEcAuthUserAndExternalIdpMapping.Designer.cs
@@ -4,6 +4,7 @@ using IdentityProvider.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace IdentityProvider.Migrations
 {
     [DbContext(typeof(EcAuthDbContext))]
-    partial class EcAuthDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250619002509_AddEcAuthUserAndExternalIdpMapping")]
+    partial class AddEcAuthUserAndExternalIdpMapping
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -52,60 +55,6 @@ namespace IdentityProvider.Migrations
                     b.HasKey("Id");
 
                     b.ToTable("account");
-                });
-
-            modelBuilder.Entity("IdentityProvider.Models.AuthorizationCode", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int")
-                        .HasColumnName("id");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
-
-                    b.Property<int>("ClientId")
-                        .HasColumnType("int")
-                        .HasColumnName("client_id");
-
-                    b.Property<string>("Code")
-                        .IsRequired()
-                        .HasMaxLength(255)
-                        .HasColumnType("nvarchar(255)")
-                        .HasColumnName("code");
-
-                    b.Property<DateTimeOffset>("CreatedAt")
-                        .HasColumnType("datetimeoffset")
-                        .HasColumnName("created_at");
-
-                    b.Property<int>("EcAuthUserId")
-                        .HasColumnType("int")
-                        .HasColumnName("ecauth_user_id");
-
-                    b.Property<DateTimeOffset>("ExpiresAt")
-                        .HasColumnType("datetimeoffset")
-                        .HasColumnName("expires_at");
-
-                    b.Property<string>("RedirectUri")
-                        .HasMaxLength(500)
-                        .HasColumnType("nvarchar(500)")
-                        .HasColumnName("redirect_uri");
-
-                    b.Property<string>("Scope")
-                        .HasMaxLength(500)
-                        .HasColumnType("nvarchar(500)")
-                        .HasColumnName("scope");
-
-                    b.Property<bool>("Used")
-                        .HasColumnType("bit")
-                        .HasColumnName("used");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("ClientId");
-
-                    b.HasIndex("EcAuthUserId");
-
-                    b.ToTable("authorization_code");
                 });
 
             modelBuilder.Entity("IdentityProvider.Models.Client", b =>
@@ -428,25 +377,6 @@ namespace IdentityProvider.Migrations
                         .IsUnique();
 
                     b.ToTable("rsa_key_pair");
-                });
-
-            modelBuilder.Entity("IdentityProvider.Models.AuthorizationCode", b =>
-                {
-                    b.HasOne("IdentityProvider.Models.Client", "Client")
-                        .WithMany()
-                        .HasForeignKey("ClientId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.HasOne("IdentityProvider.Models.EcAuthUser", "EcAuthUser")
-                        .WithMany()
-                        .HasForeignKey("EcAuthUserId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Client");
-
-                    b.Navigation("EcAuthUser");
                 });
 
             modelBuilder.Entity("IdentityProvider.Models.Client", b =>

--- a/IdentityProvider/Migrations/20250619002509_AddEcAuthUserAndExternalIdpMapping.cs
+++ b/IdentityProvider/Migrations/20250619002509_AddEcAuthUserAndExternalIdpMapping.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace IdentityProvider.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEcAuthUserAndExternalIdpMapping : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ecauth_user",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    subject = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: false),
+                    email_hash = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: true),
+                    organization_id = table.Column<int>(type: "int", nullable: false),
+                    created_at = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ecauth_user", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_ecauth_user_organization_organization_id",
+                        column: x => x.organization_id,
+                        principalTable: "organization",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "external_idp_mapping",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    ecauth_user_id = table.Column<int>(type: "int", nullable: false),
+                    external_provider = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    external_subject = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: false),
+                    created_at = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_external_idp_mapping", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_external_idp_mapping_ecauth_user_ecauth_user_id",
+                        column: x => x.ecauth_user_id,
+                        principalTable: "ecauth_user",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ecauth_user_organization_id",
+                table: "ecauth_user",
+                column: "organization_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_external_idp_mapping_ecauth_user_id",
+                table: "external_idp_mapping",
+                column: "ecauth_user_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "external_idp_mapping");
+
+            migrationBuilder.DropTable(
+                name: "ecauth_user");
+        }
+    }
+}

--- a/IdentityProvider/Migrations/20250619003158_AddAuthorizationCodeTable.Designer.cs
+++ b/IdentityProvider/Migrations/20250619003158_AddAuthorizationCodeTable.Designer.cs
@@ -4,6 +4,7 @@ using IdentityProvider.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace IdentityProvider.Migrations
 {
     [DbContext(typeof(EcAuthDbContext))]
-    partial class EcAuthDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250619003158_AddAuthorizationCodeTable")]
+    partial class AddAuthorizationCodeTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/IdentityProvider/Migrations/20250619003158_AddAuthorizationCodeTable.cs
+++ b/IdentityProvider/Migrations/20250619003158_AddAuthorizationCodeTable.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace IdentityProvider.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAuthorizationCodeTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "authorization_code",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    code = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: false),
+                    client_id = table.Column<int>(type: "int", nullable: false),
+                    ecauth_user_id = table.Column<int>(type: "int", nullable: false),
+                    redirect_uri = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true),
+                    scope = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true),
+                    expires_at = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    used = table.Column<bool>(type: "bit", nullable: false),
+                    created_at = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_authorization_code", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_authorization_code_client_client_id",
+                        column: x => x.client_id,
+                        principalTable: "client",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_authorization_code_ecauth_user_ecauth_user_id",
+                        column: x => x.ecauth_user_id,
+                        principalTable: "ecauth_user",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_authorization_code_client_id",
+                table: "authorization_code",
+                column: "client_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_authorization_code_ecauth_user_id",
+                table: "authorization_code",
+                column: "ecauth_user_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "authorization_code");
+        }
+    }
+}

--- a/IdentityProvider/Models/AuthorizationCode.cs
+++ b/IdentityProvider/Models/AuthorizationCode.cs
@@ -1,0 +1,50 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace IdentityProvider.Models
+{
+    [Table("authorization_code")]
+    public class AuthorizationCode
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        [Column("id")]
+        public int Id { get; set; }
+
+        [Required]
+        [Column("code")]
+        [StringLength(255)]
+        public string Code { get; set; } = null!;
+
+        [Required]
+        [Column("client_id")]
+        public int ClientId { get; set; }
+
+        [ForeignKey(nameof(ClientId))]
+        public Client Client { get; set; } = null!;
+
+        [Required]
+        [Column("ecauth_user_id")]
+        public int EcAuthUserId { get; set; }
+
+        [ForeignKey(nameof(EcAuthUserId))]
+        public EcAuthUser EcAuthUser { get; set; } = null!;
+
+        [Column("redirect_uri")]
+        [StringLength(500)]
+        public string? RedirectUri { get; set; }
+
+        [Column("scope")]
+        [StringLength(500)]
+        public string? Scope { get; set; }
+
+        [Column("expires_at")]
+        public DateTimeOffset ExpiresAt { get; set; }
+
+        [Column("used")]
+        public bool Used { get; set; } = false;
+
+        [Column("created_at")]
+        public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.Now;
+    }
+}

--- a/IdentityProvider/Models/EcAuthDbContext.cs
+++ b/IdentityProvider/Models/EcAuthDbContext.cs
@@ -20,6 +20,9 @@ namespace IdentityProvider.Models
         public DbSet<RedirectUri> RedirectUris { get; set; }
         public DbSet<OpenIdProvider> OpenIdProviders { get; set; }
         public DbSet<OpenIdProviderScope> OpenIdProviderScopes { get; set; }
+        public DbSet<EcAuthUser> EcAuthUsers { get; set; }
+        public DbSet<ExternalIdpMapping> ExternalIdpMappings { get; set; }
+        public DbSet<AuthorizationCode> AuthorizationCodes { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/IdentityProvider/Models/EcAuthUser.cs
+++ b/IdentityProvider/Models/EcAuthUser.cs
@@ -1,0 +1,39 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace IdentityProvider.Models
+{
+    [Table("ecauth_user")]
+    public class EcAuthUser
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        [Column("id")]
+        public int Id { get; set; }
+
+        [Required]
+        [Column("subject")]
+        [StringLength(255)]
+        public string Subject { get; set; } = null!; // EcAuth内部識別子（UUID）
+
+        [Column("email_hash")]
+        [StringLength(255)]
+        public string? EmailHash { get; set; } // ハッシュ化メールアドレス
+
+        [Required]
+        [Column("organization_id")]
+        public int OrganizationId { get; set; } // テナント識別
+
+        [ForeignKey(nameof(OrganizationId))]
+        public Organization Organization { get; set; } = null!;
+
+        [Column("created_at")]
+        public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.Now;
+
+        [Column("updated_at")]
+        public DateTimeOffset UpdatedAt { get; set; } = DateTimeOffset.Now;
+
+        // ナビゲーションプロパティ
+        public ICollection<ExternalIdpMapping> ExternalIdpMappings { get; set; } = new List<ExternalIdpMapping>();
+    }
+}

--- a/IdentityProvider/Models/ExternalIdpMapping.cs
+++ b/IdentityProvider/Models/ExternalIdpMapping.cs
@@ -1,0 +1,34 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace IdentityProvider.Models
+{
+    [Table("external_idp_mapping")]
+    public class ExternalIdpMapping
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        [Column("id")]
+        public int Id { get; set; }
+
+        [Required]
+        [Column("ecauth_user_id")]
+        public int EcAuthUserId { get; set; }
+
+        [ForeignKey(nameof(EcAuthUserId))]
+        public EcAuthUser EcAuthUser { get; set; } = null!;
+
+        [Required]
+        [Column("external_provider")]
+        [StringLength(50)]
+        public string ExternalProvider { get; set; } = null!; // "google", "line", etc.
+
+        [Required]
+        [Column("external_subject")]
+        [StringLength(255)]
+        public string ExternalSubject { get; set; } = null!; // 外部IdPのsubject
+
+        [Column("created_at")]
+        public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.Now;
+    }
+}

--- a/IdentityProvider/Program.cs
+++ b/IdentityProvider/Program.cs
@@ -8,6 +8,10 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddScoped<ITenantService, TenantService>();
 builder.Services.AddScoped<OrganizationFilter>();
+builder.Services.AddScoped<IUserService, UserService>();
+builder.Services.AddScoped<IAuthorizationCodeService, AuthorizationCodeService>();
+builder.Services.AddScoped<IExternalIdpService, ExternalIdpService>();
+builder.Services.AddHttpClient();
 // Add services to the container.
 builder.Services.AddDbContext<EcAuthDbContext>((sp, options) =>
 {

--- a/IdentityProvider/Services/AuthorizationCodeService.cs
+++ b/IdentityProvider/Services/AuthorizationCodeService.cs
@@ -1,0 +1,88 @@
+using IdentityProvider.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace IdentityProvider.Services
+{
+    public class AuthorizationCodeService : IAuthorizationCodeService
+    {
+        private readonly EcAuthDbContext _context;
+        private readonly ILogger<AuthorizationCodeService> _logger;
+        private const int CODE_EXPIRATION_MINUTES = 10; // OAuth2 spec recommends maximum of 10 minutes
+
+        public AuthorizationCodeService(EcAuthDbContext context, ILogger<AuthorizationCodeService> logger)
+        {
+            _context = context;
+            _logger = logger;
+        }
+
+        public async Task<string> GenerateAuthorizationCodeAsync(
+            int clientId, 
+            int ecAuthUserId, 
+            string? redirectUri = null, 
+            string? scope = null)
+        {
+            var code = Guid.NewGuid().ToString("N"); // Remove hyphens for cleaner code
+            
+            var authCode = new AuthorizationCode
+            {
+                Code = code,
+                ClientId = clientId,
+                EcAuthUserId = ecAuthUserId,
+                RedirectUri = redirectUri,
+                Scope = scope,
+                ExpiresAt = DateTimeOffset.Now.AddMinutes(CODE_EXPIRATION_MINUTES),
+                Used = false,
+                CreatedAt = DateTimeOffset.Now
+            };
+
+            _context.AuthorizationCodes.Add(authCode);
+            await _context.SaveChangesAsync();
+
+            _logger.LogInformation("Generated authorization code for client {ClientId} and user {UserId}", 
+                clientId, ecAuthUserId);
+
+            return code;
+        }
+
+        public async Task<AuthorizationCode?> ValidateAuthorizationCodeAsync(string code, string clientId)
+        {
+            var authCode = await _context.AuthorizationCodes
+                .Include(ac => ac.Client)
+                .Include(ac => ac.EcAuthUser)
+                    .ThenInclude(u => u.Organization)
+                .FirstOrDefaultAsync(ac => ac.Code == code && ac.Client.ClientId == clientId);
+
+            if (authCode == null)
+            {
+                _logger.LogWarning("Authorization code not found for code {Code} and client {ClientId}", 
+                    code, clientId);
+                return null;
+            }
+
+            if (authCode.Used)
+            {
+                _logger.LogWarning("Authorization code {Code} has already been used", code);
+                return null;
+            }
+
+            if (authCode.ExpiresAt < DateTimeOffset.Now)
+            {
+                _logger.LogWarning("Authorization code {Code} has expired", code);
+                return null;
+            }
+
+            return authCode;
+        }
+
+        public async Task MarkCodeAsUsedAsync(int codeId)
+        {
+            var authCode = await _context.AuthorizationCodes.FindAsync(codeId);
+            if (authCode != null)
+            {
+                authCode.Used = true;
+                await _context.SaveChangesAsync();
+                _logger.LogInformation("Marked authorization code {CodeId} as used", codeId);
+            }
+        }
+    }
+}

--- a/IdentityProvider/Services/ExternalIdpService.cs
+++ b/IdentityProvider/Services/ExternalIdpService.cs
@@ -1,0 +1,44 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+
+namespace IdentityProvider.Services
+{
+    public class ExternalIdpService : IExternalIdpService
+    {
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly ILogger<ExternalIdpService> _logger;
+
+        public ExternalIdpService(IHttpClientFactory httpClientFactory, ILogger<ExternalIdpService> logger)
+        {
+            _httpClientFactory = httpClientFactory;
+            _logger = logger;
+        }
+
+        public async Task<ExternalUserInfo?> GetExternalUserInfoAsync(
+            string provider, 
+            string authorizationCode, 
+            string idpClientId, 
+            string idpClientSecret)
+        {
+            // 開発環境用のモック実装
+            // 実際の実装では、各プロバイダーのトークンエンドポイントとユーザー情報エンドポイントを呼び出す
+            if (provider.ToLower() == "mock" || provider.ToLower() == "mockoidprovider")
+            {
+                // MockOpenIdProviderの場合、簡単なモックデータを返す
+                return new ExternalUserInfo
+                {
+                    Subject = $"mock-user-{Guid.NewGuid():N}",
+                    Email = "test@example.com",
+                    Name = "Test User"
+                };
+            }
+
+            // TODO: 実際の外部IdP実装
+            // 1. トークンエンドポイントを呼び出してアクセストークンを取得
+            // 2. ユーザー情報エンドポイントを呼び出してユーザー情報を取得
+            
+            _logger.LogWarning("External IdP {Provider} is not implemented yet", provider);
+            return null;
+        }
+    }
+}

--- a/IdentityProvider/Services/IAuthorizationCodeService.cs
+++ b/IdentityProvider/Services/IAuthorizationCodeService.cs
@@ -1,0 +1,26 @@
+using IdentityProvider.Models;
+
+namespace IdentityProvider.Services
+{
+    public interface IAuthorizationCodeService
+    {
+        /// <summary>
+        /// 認可コードを生成する
+        /// </summary>
+        Task<string> GenerateAuthorizationCodeAsync(
+            int clientId, 
+            int ecAuthUserId, 
+            string? redirectUri = null, 
+            string? scope = null);
+
+        /// <summary>
+        /// 認可コードを検証し、取得する
+        /// </summary>
+        Task<AuthorizationCode?> ValidateAuthorizationCodeAsync(string code, string clientId);
+
+        /// <summary>
+        /// 認可コードを使用済みにする
+        /// </summary>
+        Task MarkCodeAsUsedAsync(int codeId);
+    }
+}

--- a/IdentityProvider/Services/IExternalIdpService.cs
+++ b/IdentityProvider/Services/IExternalIdpService.cs
@@ -1,0 +1,22 @@
+namespace IdentityProvider.Services
+{
+    public interface IExternalIdpService
+    {
+        /// <summary>
+        /// 外部IdPから認可コードを使ってユーザー情報を取得する
+        /// </summary>
+        Task<ExternalUserInfo?> GetExternalUserInfoAsync(
+            string provider, 
+            string authorizationCode, 
+            string idpClientId, 
+            string idpClientSecret);
+    }
+
+    public class ExternalUserInfo
+    {
+        public string Subject { get; set; } = null!;
+        public string? Email { get; set; }
+        public string? Name { get; set; }
+        public Dictionary<string, object> AdditionalClaims { get; set; } = new();
+    }
+}

--- a/IdentityProvider/Services/IUserService.cs
+++ b/IdentityProvider/Services/IUserService.cs
@@ -1,0 +1,35 @@
+using IdentityProvider.Models;
+
+namespace IdentityProvider.Services
+{
+    public interface IUserService
+    {
+        /// <summary>
+        /// 外部IdPから取得した情報を基にEcAuthユーザーを取得または作成する（JITプロビジョニング）
+        /// </summary>
+        Task<EcAuthUser> GetOrCreateUserAsync(UserCreationRequest request);
+
+        /// <summary>
+        /// Subjectからユーザーを取得する
+        /// </summary>
+        Task<EcAuthUser?> GetUserBySubjectAsync(string subject);
+
+        /// <summary>
+        /// 外部IdPのsubjectからユーザーを取得する
+        /// </summary>
+        Task<EcAuthUser?> GetUserByExternalProviderAsync(string provider, string externalSubject);
+
+        /// <summary>
+        /// メールアドレスをハッシュ化する
+        /// </summary>
+        string HashEmail(string email);
+    }
+
+    public class UserCreationRequest
+    {
+        public string ExternalProvider { get; set; } = null!;
+        public string ExternalSubject { get; set; } = null!;
+        public string? Email { get; set; }
+        public int OrganizationId { get; set; }
+    }
+}

--- a/IdentityProvider/Services/UserService.cs
+++ b/IdentityProvider/Services/UserService.cs
@@ -1,0 +1,93 @@
+using System.Security.Cryptography;
+using System.Text;
+using IdentityProvider.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace IdentityProvider.Services
+{
+    public class UserService : IUserService
+    {
+        private readonly EcAuthDbContext _context;
+        private readonly ILogger<UserService> _logger;
+
+        public UserService(EcAuthDbContext context, ILogger<UserService> logger)
+        {
+            _context = context;
+            _logger = logger;
+        }
+
+        public async Task<EcAuthUser> GetOrCreateUserAsync(UserCreationRequest request)
+        {
+            // まず外部IdPのsubjectで既存ユーザーを検索
+            var existingUser = await GetUserByExternalProviderAsync(request.ExternalProvider, request.ExternalSubject);
+            if (existingUser != null)
+            {
+                _logger.LogInformation("Existing user found for {Provider}/{Subject}", request.ExternalProvider, request.ExternalSubject);
+                return existingUser;
+            }
+
+            // 新規ユーザー作成（JITプロビジョニング）
+            var ecAuthSubject = Guid.NewGuid().ToString();
+            var emailHash = !string.IsNullOrEmpty(request.Email) ? HashEmail(request.Email) : null;
+
+            var newUser = new EcAuthUser
+            {
+                Subject = ecAuthSubject,
+                EmailHash = emailHash,
+                OrganizationId = request.OrganizationId,
+                CreatedAt = DateTimeOffset.Now,
+                UpdatedAt = DateTimeOffset.Now
+            };
+
+            _context.EcAuthUsers.Add(newUser);
+            await _context.SaveChangesAsync();
+
+            // 外部IdPとのマッピングを作成
+            var mapping = new ExternalIdpMapping
+            {
+                EcAuthUserId = newUser.Id,
+                ExternalProvider = request.ExternalProvider,
+                ExternalSubject = request.ExternalSubject,
+                CreatedAt = DateTimeOffset.Now
+            };
+
+            _context.ExternalIdpMappings.Add(mapping);
+            await _context.SaveChangesAsync();
+
+            _logger.LogInformation("New user created with subject {Subject} for {Provider}/{ExternalSubject}", 
+                ecAuthSubject, request.ExternalProvider, request.ExternalSubject);
+
+            return newUser;
+        }
+
+        public async Task<EcAuthUser?> GetUserBySubjectAsync(string subject)
+        {
+            return await _context.EcAuthUsers
+                .Include(u => u.Organization)
+                .Include(u => u.ExternalIdpMappings)
+                .FirstOrDefaultAsync(u => u.Subject == subject);
+        }
+
+        public async Task<EcAuthUser?> GetUserByExternalProviderAsync(string provider, string externalSubject)
+        {
+            var mapping = await _context.ExternalIdpMappings
+                .Include(m => m.EcAuthUser)
+                    .ThenInclude(u => u.Organization)
+                .FirstOrDefaultAsync(m => m.ExternalProvider == provider && m.ExternalSubject == externalSubject);
+
+            return mapping?.EcAuthUser;
+        }
+
+        public string HashEmail(string email)
+        {
+            if (string.IsNullOrEmpty(email))
+                throw new ArgumentNullException(nameof(email));
+
+            // 小文字に正規化してからハッシュ化
+            var normalizedEmail = email.Trim().ToLowerInvariant();
+            using var sha256 = SHA256.Create();
+            var hashBytes = sha256.ComputeHash(Encoding.UTF8.GetBytes(normalizedEmail));
+            return Convert.ToBase64String(hashBytes);
+        }
+    }
+}


### PR DESCRIPTION
## 概要

user-management-architecture.md の内容に基づいて、OpenID Connect IDフェデレーションにおけるユーザー管理機能を実装しました。

## 実装内容

### データモデル
- `EcAuthUser`: 最小限のユーザー情報（UUID、ハッシュ化メールアドレス）
- `ExternalIdpMapping`: 外部IdPとの紐付け管理
- `AuthorizationCode`: 認可コード管理

### サービス層
- `UserService`: JITプロビジョニングを含むユーザー管理
- `AuthorizationCodeService`: 認可コードの生成・検証
- `ExternalIdpService`: 外部IdPとの連携（現在はモック実装）

### コントローラーの更新
- `AuthorizationCallbackController`: 外部IdP認証後のユーザー作成/取得
- `TokenController`: OpenID Connect準拠のIDトークン発行

Fixes #23

Generated with [Claude Code](https://claude.ai/code)