### PR TITLE
Add EcAuthDocs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -487,3 +487,6 @@ $RECYCLE.BIN/
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+# docs
+/EcAuthDocs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,4 +42,4 @@ npx playwright test
 
 ## 詳細情報
 
-詳細なアーキテクチャ情報や開発ガイドラインは `../EcAuthDocs/CLAUDE.md` を参照してください。
+詳細なアーキテクチャ情報や開発ガイドラインは @EcAuthDocs/CLAUDE.md を参照してください。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,22 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## リポジトリ構成
+
+このプロジェクトは以下の2つのリポジトリで構成されています：
+
+- **./**: アプリケーションコードのみを管理
+- **EcAuthDocs/**: 全てのドキュメント、設計書、ガイドを管理
+
+Claude Code Actions の制限で `working_directory` を変更できないため、このディレクトリ内に EcAuthDocs を clone しています。
+
+## 作業時の注意点
+
+- ドキュメント関連の作業は EcAuthDocs/ で実行
+- コード関連の作業はこのリポジトリで実行
+- 両リポジトリ間の整合性を保つ
+- 日本語で回答してください
+
 ## 概要
 
 OpenID Connect の ID フェデレーションに特化した Identity Provider システムです。


### PR DESCRIPTION
This pull request updates the `CLAUDE.md` file to provide clearer guidance on repository structure and operation, as well as corrects a reference to the documentation repository.

Repository structure and operation guidance:

* Added a new section describing the structure of the project, specifying that the application code is managed in the current repository (`./`) and all documentation is managed in the `EcAuthDocs/` repository. Included instructions for maintaining consistency between the two repositories and emphasized using Japanese for responses.

Documentation reference correction:

* Updated the reference to the documentation file from `../EcAuthDocs/CLAUDE.md` to `@EcAuthDocs/CLAUDE.md` for improved clarity and accuracy.