### PR TITLE
feat(migrations): add user management tables with related models and filters

### DIFF
--- a/IdentityProvider.Test/Models/AuthorizationCodeTests.cs
+++ b/IdentityProvider.Test/Models/AuthorizationCodeTests.cs
@@ -11,7 +11,7 @@ namespace IdentityProvider.Test.Models
 
             Assert.Equal(string.Empty, authCode.Code);
             Assert.Equal(string.Empty, authCode.EcAuthSubject);
-            Assert.Equal(string.Empty, authCode.ClientId);
+            Assert.Equal(0, authCode.ClientId);
             Assert.Equal(string.Empty, authCode.RedirectUri);
             Assert.Null(authCode.Scope);
             Assert.Null(authCode.State);
@@ -28,7 +28,7 @@ namespace IdentityProvider.Test.Models
         {
             var code = "test-auth-code-123";
             var subject = "test-subject";
-            var clientId = "test-client";
+            var clientId = 1;
             var redirectUri = "https://example.com/callback";
             var scope = "openid profile";
             var state = "test-state";
@@ -134,11 +134,12 @@ namespace IdentityProvider.Test.Models
         public void AuthorizationCode_Relations_ShouldWork()
         {
             var user = new EcAuthUser { Subject = "test-subject" };
-            var client = new Client { ClientId = "test-client" };
+            var client = new Client { Id = 1, ClientId = "test-client" };
             var authCode = new AuthorizationCode 
             { 
                 EcAuthUser = user,
-                Client = client
+                Client = client,
+                ClientId = 1
             };
             
             Assert.Equal(user, authCode.EcAuthUser);

--- a/IdentityProvider.Test/Models/EntityRelationshipTests.cs
+++ b/IdentityProvider.Test/Models/EntityRelationshipTests.cs
@@ -115,7 +115,7 @@ namespace IdentityProvider.Test.Models
             {
                 Code = "auth-code-123",
                 EcAuthSubject = user.Subject,
-                ClientId = client.ClientId,
+                ClientId = client.Id,
                 RedirectUri = "https://example.com/callback",
                 ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(10),
                 EcAuthUser = user,

--- a/IdentityProvider/Migrations/20250808232244_AddUserManagementTables.Designer.cs
+++ b/IdentityProvider/Migrations/20250808232244_AddUserManagementTables.Designer.cs
@@ -4,6 +4,7 @@ using IdentityProvider.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace IdentityProvider.Migrations
 {
     [DbContext(typeof(EcAuthDbContext))]
-    partial class EcAuthDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250808232244_AddUserManagementTables")]
+    partial class AddUserManagementTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/IdentityProvider/Migrations/20250808232244_AddUserManagementTables.cs
+++ b/IdentityProvider/Migrations/20250808232244_AddUserManagementTables.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace IdentityProvider.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserManagementTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ecauth_user",
+                columns: table => new
+                {
+                    subject = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: false),
+                    email_hash = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: false),
+                    organization_id = table.Column<int>(type: "int", nullable: false),
+                    created_at = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ecauth_user", x => x.subject);
+                    table.ForeignKey(
+                        name: "FK_ecauth_user_organization_organization_id",
+                        column: x => x.organization_id,
+                        principalTable: "organization",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "authorization_code",
+                columns: table => new
+                {
+                    code = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: false),
+                    ecauth_subject = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: false),
+                    client_id = table.Column<int>(type: "int", nullable: false),
+                    redirect_uri = table.Column<string>(type: "nvarchar(2000)", maxLength: 2000, nullable: false),
+                    scope = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true),
+                    state = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true),
+                    expires_at = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    is_used = table.Column<bool>(type: "bit", nullable: false),
+                    created_at = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    used_at = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_authorization_code", x => x.code);
+                    table.ForeignKey(
+                        name: "FK_authorization_code_client_client_id",
+                        column: x => x.client_id,
+                        principalTable: "client",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_authorization_code_ecauth_user_ecauth_subject",
+                        column: x => x.ecauth_subject,
+                        principalTable: "ecauth_user",
+                        principalColumn: "subject",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "external_idp_mapping",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    ecauth_subject = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: false),
+                    external_provider = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    external_subject = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: false),
+                    created_at = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_external_idp_mapping", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_external_idp_mapping_ecauth_user_ecauth_subject",
+                        column: x => x.ecauth_subject,
+                        principalTable: "ecauth_user",
+                        principalColumn: "subject",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_authorization_code_client_id",
+                table: "authorization_code",
+                column: "client_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_authorization_code_ecauth_subject",
+                table: "authorization_code",
+                column: "ecauth_subject");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_authorization_code_expires_at",
+                table: "authorization_code",
+                column: "expires_at");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ecauth_user_email_hash",
+                table: "ecauth_user",
+                column: "email_hash",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ecauth_user_organization_id",
+                table: "ecauth_user",
+                column: "organization_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_external_idp_mapping_ecauth_subject",
+                table: "external_idp_mapping",
+                column: "ecauth_subject");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_external_idp_mapping_external_provider_external_subject",
+                table: "external_idp_mapping",
+                columns: new[] { "external_provider", "external_subject" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "authorization_code");
+
+            migrationBuilder.DropTable(
+                name: "external_idp_mapping");
+
+            migrationBuilder.DropTable(
+                name: "ecauth_user");
+        }
+    }
+}

--- a/IdentityProvider/Models/AuthorizationCode.cs
+++ b/IdentityProvider/Models/AuthorizationCode.cs
@@ -19,7 +19,7 @@ namespace IdentityProvider.Models
 
         [Column("client_id")]
         [Required]
-        public string ClientId { get; set; } = string.Empty;
+        public int ClientId { get; set; }
 
         [Column("redirect_uri")]
         [MaxLength(2000)]

--- a/IdentityProvider/Models/EcAuthDbContext.cs
+++ b/IdentityProvider/Models/EcAuthDbContext.cs
@@ -30,6 +30,18 @@ namespace IdentityProvider.Models
             modelBuilder.Entity<Organization>()
                 .HasQueryFilter(o => o.TenantName == _tenantService.TenantName);
 
+            // EcAuthUserにも同じグローバルクエリフィルターを適用
+            modelBuilder.Entity<EcAuthUser>()
+                .HasQueryFilter(u => u.Organization != null && u.Organization.TenantName == _tenantService.TenantName);
+
+            // ExternalIdpMappingにもグローバルクエリフィルターを適用
+            modelBuilder.Entity<ExternalIdpMapping>()
+                .HasQueryFilter(m => m.EcAuthUser != null && m.EcAuthUser.Organization != null && m.EcAuthUser.Organization.TenantName == _tenantService.TenantName);
+
+            // AuthorizationCodeにもグローバルクエリフィルターを適用
+            modelBuilder.Entity<AuthorizationCode>()
+                .HasQueryFilter(ac => ac.EcAuthUser != null && ac.EcAuthUser.Organization != null && ac.EcAuthUser.Organization.TenantName == _tenantService.TenantName);
+
             // EcAuthUser関連の設定
             modelBuilder.Entity<EcAuthUser>()
                 .HasOne(u => u.Organization)
@@ -53,14 +65,9 @@ namespace IdentityProvider.Models
 
             // AuthorizationCode関連の設定
             modelBuilder.Entity<AuthorizationCode>()
-                .Property(ac => ac.ClientId)
-                .HasMaxLength(450);
-
-            modelBuilder.Entity<AuthorizationCode>()
                 .HasOne(ac => ac.Client)
                 .WithMany()
                 .HasForeignKey(ac => ac.ClientId)
-                .HasPrincipalKey(c => c.ClientId)
                 .OnDelete(DeleteBehavior.Restrict);
 
             // インデックスの設定


### PR DESCRIPTION
Added new tables `ecauth_user`, `authorization_code`, and `external_idp_mapping` with their respective relationships and constraints. Updated `AuthorizationCode` model to use `int` for `ClientId`. Applied global query filters for tenant-based filtering in `EcAuthDbContext`.