### PR TITLE
ci: update GitHub Actions to use latest versions and add .NET setup steps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,56 @@
+version: 2
+updates:
+  # GitHub Actions の自動更新
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  # .NET NuGet パッケージの自動更新
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "dotnet"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    # セキュリティアップデートは即座に作成
+    allow:
+      - dependency-type: "all"
+
+  # E2ETests の npm パッケージの自動更新
+  - package-ecosystem: "npm"
+    directory: "/E2ETests"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "npm"
+      - "e2e-tests"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    # 開発依存関係も含める
+    allow:
+      - dependency-type: "all"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,6 +37,14 @@ jobs:
           path: docs
           fetch-depth: 1
           token: ${{ secrets.ORG_PAT }}
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+      - name: Restore .NET tools
+        run: dotnet tool restore
+      - name: Restore dependencies
+        run: dotnet restore ./EcAuth.sln
 
       - name: Run Claude Code Review
         id: claude-review

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,6 +39,14 @@ jobs:
           path: docs
           fetch-depth: 1
           token: ${{ secrets.ORG_PAT }}
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+      - name: Restore .NET tools
+        run: dotnet tool restore
+      - name: Restore dependencies
+        run: dotnet restore ./EcAuth.sln
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@beta

--- a/.github/workflows/dotnet_tests.yml
+++ b/.github/workflows/dotnet_tests.yml
@@ -10,12 +10,15 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '9.0.x'
+
+    - name: Restore .NET tools
+      run: dotnet tool restore
 
     - name: Restore dependencies
       run: dotnet restore ./EcAuth.sln

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - run: cat .env.dist >> $GITHUB_ENV
       - run: echo "DB_HOST=localhost" >> $GITHUB_ENV
@@ -40,7 +40,7 @@ jobs:
       - run: echo "FEDERATE_OAUTH2_USERINFO_ENDPOINT=https://localhost:9091/userinfo" >> $GITHUB_ENV
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '9.0.x'
       - name: Restore .NET tools
@@ -79,7 +79,7 @@ jobs:
           ASPNETCORE_ENVIRONMENT: Development
 
       - name: Install Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 22
 


### PR DESCRIPTION
Updated workflows to use the latest versions of actions, including `actions/checkout@v4`, `actions/setup-dotnet@v4`, and `actions/setup-node@v4`. Added steps to set up .NET tools and restore dependencies in relevant workflows.