### PR TITLE
feat: add Entity Framework migration for composite unique constraint

### DIFF
--- a/IdentityProvider/Migrations/20250809000159_AddCompositeUniqueConstraintToEcAuthUser.Designer.cs
+++ b/IdentityProvider/Migrations/20250809000159_AddCompositeUniqueConstraintToEcAuthUser.Designer.cs
@@ -4,6 +4,7 @@ using IdentityProvider.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace IdentityProvider.Migrations
 {
     [DbContext(typeof(EcAuthDbContext))]
-    partial class EcAuthDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250809000159_AddCompositeUniqueConstraintToEcAuthUser")]
+    partial class AddCompositeUniqueConstraintToEcAuthUser
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/IdentityProvider/Migrations/20250809000159_AddCompositeUniqueConstraintToEcAuthUser.cs
+++ b/IdentityProvider/Migrations/20250809000159_AddCompositeUniqueConstraintToEcAuthUser.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace IdentityProvider.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCompositeUniqueConstraintToEcAuthUser : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ecauth_user_email_hash",
+                table: "ecauth_user");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ecauth_user_organization_id",
+                table: "ecauth_user");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ecauth_user_organization_id_email_hash",
+                table: "ecauth_user",
+                columns: new[] { "organization_id", "email_hash" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ecauth_user_organization_id_email_hash",
+                table: "ecauth_user");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ecauth_user_email_hash",
+                table: "ecauth_user",
+                column: "email_hash",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ecauth_user_organization_id",
+                table: "ecauth_user",
+                column: "organization_id");
+        }
+    }
+}

--- a/IdentityProvider/Models/EcAuthDbContext.cs
+++ b/IdentityProvider/Models/EcAuthDbContext.cs
@@ -72,7 +72,7 @@ namespace IdentityProvider.Models
 
             // インデックスの設定
             modelBuilder.Entity<EcAuthUser>()
-                .HasIndex(u => u.EmailHash)
+                .HasIndex(u => new { u.OrganizationId, u.EmailHash })
                 .IsUnique();
 
             modelBuilder.Entity<ExternalIdpMapping>()


### PR DESCRIPTION
Fixes #34

Add Entity Framework migration to implement composite unique constraint for organization_id and email_hash in EcAuthUser model to support multi-tenant architecture.

### Changes
- Updated EcAuthDbContext to use composite unique constraint (OrganizationId, EmailHash)
- Generated migration: AddCompositeUniqueConstraintToEcAuthUser
- Migration removes old single-field unique index and creates composite index

### Benefits
- Allows same email address across different organizations
- Supports proper multi-tenant architecture
- Maintains data integrity within each organization

Generated with [Claude Code](https://claude.ai/code)