### PR TITLE
ci(github-actions): skip Claude code review for Dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,8 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip Claude Code Review for Dependabot PRs
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
This pull request introduces a small but important change to the `claude-code-review.yml` GitHub Actions workflow. The update ensures that Claude Code Review is skipped for pull requests opened by Dependabot, preventing unnecessary automated reviews on dependency update PRs.

* Updated the workflow condition to skip Claude Code Review jobs for PRs created by `dependabot[bot]`.