### PR TITLE
docs: update CLA workflow to include test failure merge recommendation

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -51,6 +51,7 @@ jobs:
           direct_prompt: |
             Please review this pull request and provide feedback on:
             - 日本語で回答してください
+            - テストが失敗している場合はマージを推奨しないでください
             - Code quality and best practices
             - Potential bugs or issues
             - Performance considerations


### PR DESCRIPTION
This pull request makes a minor update to the code review workflow instructions for Claude. The change adds a guideline to avoid recommending a merge if tests are failing.