### PR TITLE
docs: update CLAUDE.md with architecture explanation and directory naming adjustments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,12 +2,14 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+アーキテクチャ等の説明は @docs/CLAUDE.md にあります.
+
 ## リポジトリ構成
 
 このプロジェクトは以下の2つのリポジトリで構成されています：
 
 - **./**: アプリケーションコードのみを管理
-- **docs/**: 全てのドキュメント、設計書、ガイドを管理
+- @docs/: 全てのドキュメント、設計書、ガイドを管理
 
 Claude Code Actions の制限で `working_directory` を変更できないため、このディレクトリ内に EcAuthDocs を clone しています。
 


### PR DESCRIPTION
This pull request updates the `CLAUDE.md` documentation to clarify the location of architecture explanations and standardize repository references. The changes mainly improve clarity for contributors regarding where to find architectural information and how documentation is organized.

Documentation improvements:

* Added a reference to `@docs/CLAUDE.md` for architecture and related explanations, making it easier for contributors to locate this information.
* Updated the description of the documentation directory from `docs/` to `@docs/`, ensuring consistent terminology throughout the document.