### PR TITLE
ci(github-actions): update workflow to trigger on issue comments and refine conditions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -53,6 +53,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"


### PR DESCRIPTION
This pull request updates the workflow configuration for Claude Code Review to make it more flexible and responsive to user actions. The main changes allow the workflow to be triggered not only when a pull request is opened, but also when specific comments are added to pull requests, and improve the conditional logic for running the review job.

**Workflow trigger improvements:**

* The workflow now triggers on pull request creation only, instead of both creation and synchronization, making it more targeted.
* Added a new trigger for issue comments, enabling the workflow to run when a comment is created on a pull request.

**Conditional logic enhancements:**

* Updated the job condition to allow the review to run either when a pull request is opened by someone other than Dependabot, or when a comment containing `/review` or `@claude` is added to a pull request. This makes it possible to manually request a review via comments.