### PR TITLE
feat(database): EcAuthUserテーブルにサロゲートキーを実装

### DIFF
--- a/IdentityProvider.Test/Models/EcAuthUserTests.cs
+++ b/IdentityProvider.Test/Models/EcAuthUserTests.cs
@@ -9,6 +9,7 @@ namespace IdentityProvider.Test.Models
         {
             var user = new EcAuthUser();
 
+            Assert.Equal(0, user.Id);
             Assert.Equal(string.Empty, user.Subject);
             Assert.Equal(string.Empty, user.EmailHash);
             Assert.Equal(0, user.OrganizationId);
@@ -21,6 +22,7 @@ namespace IdentityProvider.Test.Models
         [Fact]
         public void EcAuthUser_SetProperties_ShouldRetainValues()
         {
+            var id = 123;
             var subject = "test-subject-uuid";
             var emailHash = "testhash123";
             var organizationId = 1;
@@ -29,6 +31,7 @@ namespace IdentityProvider.Test.Models
 
             var user = new EcAuthUser
             {
+                Id = id,
                 Subject = subject,
                 EmailHash = emailHash,
                 OrganizationId = organizationId,
@@ -36,6 +39,7 @@ namespace IdentityProvider.Test.Models
                 UpdatedAt = updatedAt
             };
 
+            Assert.Equal(id, user.Id);
             Assert.Equal(subject, user.Subject);
             Assert.Equal(emailHash, user.EmailHash);
             Assert.Equal(organizationId, user.OrganizationId);
@@ -81,8 +85,19 @@ namespace IdentityProvider.Test.Models
         public void EcAuthUser_OrganizationId_ShouldAcceptValidValues(int organizationId)
         {
             var user = new EcAuthUser { OrganizationId = organizationId };
-            
+
             Assert.Equal(organizationId, user.OrganizationId);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(999999)]
+        public void EcAuthUser_Id_ShouldAcceptValidValues(int id)
+        {
+            var user = new EcAuthUser { Id = id };
+
+            Assert.Equal(id, user.Id);
         }
     }
 }

--- a/IdentityProvider.Test/Services/UserServiceTests.cs
+++ b/IdentityProvider.Test/Services/UserServiceTests.cs
@@ -2,6 +2,7 @@ using IdentityProvider.Models;
 using IdentityProvider.Services;
 using IdentityProvider.Test.TestHelpers;
 using IdpUtilities;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Moq;
 
@@ -39,7 +40,7 @@ namespace IdentityProvider.Test.Services
             Assert.Equal(request.OrganizationId, result.OrganizationId);
 
             // Verify user was created in database
-            var userInDb = await context.EcAuthUsers.FindAsync(result.Subject);
+            var userInDb = await context.EcAuthUsers.FirstOrDefaultAsync(u => u.Subject == result.Subject);
             Assert.NotNull(userInDb);
 
             // Verify external IdP mapping was created
@@ -95,7 +96,7 @@ namespace IdentityProvider.Test.Services
             Assert.Equal(existingUser.OrganizationId, result.OrganizationId);
 
             // Verify email hash was updated
-            var userInDb = await context.EcAuthUsers.FindAsync(existingUser.Subject);
+            var userInDb = await context.EcAuthUsers.FirstOrDefaultAsync(u => u.Subject == existingUser.Subject);
             Assert.NotNull(userInDb);
             Assert.Equal(request.EmailHash, userInDb.EmailHash);
         }

--- a/IdentityProvider/Migrations/20250927214943_AddSurrogateKeyToEcAuthUser.Designer.cs
+++ b/IdentityProvider/Migrations/20250927214943_AddSurrogateKeyToEcAuthUser.Designer.cs
@@ -4,6 +4,7 @@ using IdentityProvider.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace IdentityProvider.Migrations
 {
     [DbContext(typeof(EcAuthDbContext))]
-    partial class EcAuthDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250927214943_AddSurrogateKeyToEcAuthUser")]
+    partial class AddSurrogateKeyToEcAuthUser
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/IdentityProvider/Migrations/20250927214943_AddSurrogateKeyToEcAuthUser.cs
+++ b/IdentityProvider/Migrations/20250927214943_AddSurrogateKeyToEcAuthUser.cs
@@ -1,0 +1,129 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace IdentityProvider.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSurrogateKeyToEcAuthUser : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // 外部キー制約を削除
+            migrationBuilder.DropForeignKey(
+                name: "FK_external_idp_mapping_ecauth_user_ecauth_subject",
+                table: "external_idp_mapping");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_authorization_code_ecauth_user_ecauth_subject",
+                table: "authorization_code");
+
+            // 既存のプライマリキーを削除
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_ecauth_user",
+                table: "ecauth_user");
+
+            // 新しいID列を追加（サロゲートキー）
+            migrationBuilder.AddColumn<int>(
+                name: "id",
+                table: "ecauth_user",
+                type: "int",
+                nullable: false,
+                defaultValue: 0)
+                .Annotation("SqlServer:Identity", "1, 1");
+
+            // Subject列をAlternate Keyとして設定
+            migrationBuilder.AddUniqueConstraint(
+                name: "AK_ecauth_user_subject",
+                table: "ecauth_user",
+                column: "subject");
+
+            // 新しいプライマリキーを追加
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_ecauth_user",
+                table: "ecauth_user",
+                column: "id");
+
+            // Subjectのユニークインデックスを追加
+            migrationBuilder.CreateIndex(
+                name: "IX_ecauth_user_subject",
+                table: "ecauth_user",
+                column: "subject",
+                unique: true);
+
+            // 外部キー制約を再作成（AlternateKeyを参照）
+            migrationBuilder.AddForeignKey(
+                name: "FK_external_idp_mapping_ecauth_user_ecauth_subject",
+                table: "external_idp_mapping",
+                column: "ecauth_subject",
+                principalTable: "ecauth_user",
+                principalColumn: "subject",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_authorization_code_ecauth_user_ecauth_subject",
+                table: "authorization_code",
+                column: "ecauth_subject",
+                principalTable: "ecauth_user",
+                principalColumn: "subject",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // 外部キー制約を削除
+            migrationBuilder.DropForeignKey(
+                name: "FK_external_idp_mapping_ecauth_user_ecauth_subject",
+                table: "external_idp_mapping");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_authorization_code_ecauth_user_ecauth_subject",
+                table: "authorization_code");
+
+            // Alternate Keyを削除
+            migrationBuilder.DropUniqueConstraint(
+                name: "AK_ecauth_user_subject",
+                table: "ecauth_user");
+
+            // プライマリキーを削除
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_ecauth_user",
+                table: "ecauth_user");
+
+            // インデックスを削除
+            migrationBuilder.DropIndex(
+                name: "IX_ecauth_user_subject",
+                table: "ecauth_user");
+
+            // ID列を削除
+            migrationBuilder.DropColumn(
+                name: "id",
+                table: "ecauth_user");
+
+            // 元のプライマリキーを復元
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_ecauth_user",
+                table: "ecauth_user",
+                column: "subject");
+
+            // 外部キー制約を復元
+            migrationBuilder.AddForeignKey(
+                name: "FK_external_idp_mapping_ecauth_user_ecauth_subject",
+                table: "external_idp_mapping",
+                column: "ecauth_subject",
+                principalTable: "ecauth_user",
+                principalColumn: "subject",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_authorization_code_ecauth_user_ecauth_subject",
+                table: "authorization_code",
+                column: "ecauth_subject",
+                principalTable: "ecauth_user",
+                principalColumn: "subject",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/IdentityProvider/Models/EcAuthDbContext.cs
+++ b/IdentityProvider/Models/EcAuthDbContext.cs
@@ -49,6 +49,10 @@ namespace IdentityProvider.Models
                 .HasForeignKey(u => u.OrganizationId)
                 .OnDelete(DeleteBehavior.Restrict);
 
+            // SubjectをユニークなAlternate Keyとして設定
+            modelBuilder.Entity<EcAuthUser>()
+                .HasAlternateKey(u => u.Subject);
+
             modelBuilder.Entity<EcAuthUser>()
                 .HasMany(u => u.ExternalIdpMappings)
                 .WithOne(m => m.EcAuthUser)
@@ -73,6 +77,10 @@ namespace IdentityProvider.Models
             // インデックスの設定
             modelBuilder.Entity<EcAuthUser>()
                 .HasIndex(u => new { u.OrganizationId, u.EmailHash })
+                .IsUnique();
+
+            modelBuilder.Entity<EcAuthUser>()
+                .HasIndex(u => u.Subject)
                 .IsUnique();
 
             modelBuilder.Entity<ExternalIdpMapping>()

--- a/IdentityProvider/Models/EcAuthUser.cs
+++ b/IdentityProvider/Models/EcAuthUser.cs
@@ -7,9 +7,13 @@ namespace IdentityProvider.Models
     public class EcAuthUser
     {
         [Key]
-        [DatabaseGenerated(DatabaseGeneratedOption.None)]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        [Column("id")]
+        public int Id { get; set; }
+
         [Column("subject")]
         [MaxLength(255)]
+        [Required]
         public string Subject { get; set; } = string.Empty;
 
         [Column("email_hash")]


### PR DESCRIPTION
## Summary
EcAuthUserテーブルにサロゲートキー（自動採番ID）を実装し、既存のsubjectを代替キーとして維持する構造に変更しました。

### 主な変更点
- **EcAuthUserモデル**: 自動採番される`Id`列を主キーとして追加
- **Subject列**: 必須のユニーク列（Alternate Key）として再定義
- **外部キー制約**: Subject列を参照する制約を適切に再構成
- **テストコード**: 新しい主キー構造に対応するよう修正

### データベース構造の変更
- 主キー: `subject` (string) → `id` (int, auto-increment)
- 代替キー: `subject` (unique, not null)
- 外部キー参照: 引き続きsubject列を参照

### 技術的詳細
- マイグレーション実行時に既存データを保持
- 外部キー制約の一時削除・再作成により安全に構造変更
- テストでは`FindAsync`から`FirstOrDefaultAsync`に変更してsubject検索に対応

### テスト結果
- IdpUtilities.Test: 21件すべて成功
- MockOpenIdProvider.Test: 11件すべて成功  
- IdentityProvider.Test: 158件すべて成功

### 破壊的変更
- `ecauth_user`テーブルの主キーが`subject`から`id`に変更
- 既存のデータとAPI互換性は維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)