### PR TITLE
feat: アクセストークンのDB保存・検証機能を追加 (#58の前提条件)

### DIFF
--- a/IdentityProvider/Migrations/20250927223928_AddAccessToken.Designer.cs
+++ b/IdentityProvider/Migrations/20250927223928_AddAccessToken.Designer.cs
@@ -4,6 +4,7 @@ using IdentityProvider.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace IdentityProvider.Migrations
 {
     [DbContext(typeof(EcAuthDbContext))]
-    partial class EcAuthDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250927223928_AddAccessToken")]
+    partial class AddAccessToken
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/IdentityProvider/Migrations/20250927223928_AddAccessToken.cs
+++ b/IdentityProvider/Migrations/20250927223928_AddAccessToken.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace IdentityProvider.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAccessToken : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "access_token",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    token = table.Column<string>(type: "nvarchar(512)", maxLength: 512, nullable: false),
+                    expires_at = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    client_id = table.Column<int>(type: "int", nullable: false),
+                    ecauth_subject = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: false),
+                    created_at = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    scopes = table.Column<string>(type: "nvarchar(1000)", maxLength: 1000, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_access_token", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_access_token_client_client_id",
+                        column: x => x.client_id,
+                        principalTable: "client",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_access_token_ecauth_user_ecauth_subject",
+                        column: x => x.ecauth_subject,
+                        principalTable: "ecauth_user",
+                        principalColumn: "subject",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_access_token_client_id",
+                table: "access_token",
+                column: "client_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_access_token_ecauth_subject",
+                table: "access_token",
+                column: "ecauth_subject");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_access_token_expires_at",
+                table: "access_token",
+                column: "expires_at");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_access_token_token",
+                table: "access_token",
+                column: "token",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "access_token");
+        }
+    }
+}

--- a/IdentityProvider/Models/AccessToken.cs
+++ b/IdentityProvider/Models/AccessToken.cs
@@ -1,0 +1,48 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace IdentityProvider.Models
+{
+    [Table("access_token")]
+    public class AccessToken
+    {
+        [Key]
+        [Column("id")]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int Id { get; set; }
+
+        [Column("token")]
+        [Required]
+        [MaxLength(512)]
+        public string Token { get; set; } = string.Empty;
+
+        [Column("expires_at")]
+        [Required]
+        public DateTime ExpiresAt { get; set; }
+
+        [Column("client_id")]
+        [Required]
+        public int ClientId { get; set; }
+
+        [ForeignKey(nameof(ClientId))]
+        public Client Client { get; set; } = null!;
+
+        [Column("ecauth_subject")]
+        [Required]
+        [MaxLength(255)]
+        public string EcAuthSubject { get; set; } = string.Empty;
+
+        [ForeignKey(nameof(EcAuthSubject))]
+        public EcAuthUser EcAuthUser { get; set; } = null!;
+
+        [Column("created_at")]
+        [Required]
+        public DateTime CreatedAt { get; set; }
+
+        [Column("scopes")]
+        [MaxLength(1000)]
+        public string? Scopes { get; set; }
+
+        public bool IsExpired => DateTime.UtcNow > ExpiresAt;
+    }
+}

--- a/IdentityProvider/Services/ITokenService.cs
+++ b/IdentityProvider/Services/ITokenService.cs
@@ -55,5 +55,19 @@ namespace IdentityProvider.Services
         /// <param name="clientId">クライアントID</param>
         /// <returns>検証に成功した場合、ユーザーのSubject</returns>
         Task<string?> ValidateTokenAsync(string token, int clientId);
+
+        /// <summary>
+        /// アクセストークンを検証する
+        /// </summary>
+        /// <param name="token">検証するアクセストークン</param>
+        /// <returns>検証に成功した場合、ユーザーのSubject</returns>
+        Task<string?> ValidateAccessTokenAsync(string token);
+
+        /// <summary>
+        /// アクセストークンを無効化する（リボケーション）
+        /// </summary>
+        /// <param name="token">無効化するアクセストークン</param>
+        /// <returns>無効化に成功したかどうか</returns>
+        Task<bool> RevokeAccessTokenAsync(string token);
     }
 }


### PR DESCRIPTION
## 概要

Issue #58 UserinfoController実装の前提条件として、アクセストークンをデータベースで管理する機能を実装しました。

## 実装内容

### 🆕 新規追加
- **AccessTokenモデル**: アクセストークンのDB管理用エンティティ
  - Token, ExpiresAt, ClientId, EcAuthSubject, Scopes
  - 有効期限チェック機能 (`IsExpired` プロパティ)

### 🔧 機能拡張
- **TokenService**: アクセストークンDB操作機能
  - `GenerateAccessTokenAsync()`: トークン生成・DB保存
  - `ValidateAccessTokenAsync()`: トークン検証
  - `RevokeAccessTokenAsync()`: トークン無効化
- **EcAuthDbContext**: AccessTokenエンティティとリレーション追加
- **ITokenService**: 新機能のインターフェース定義

### 🧪 テスト
- 包括的なユニットテスト追加（6個の新規テストケース）
- 正常系・異常系・期限切れトークン等を網羅
- 全161個のテストが成功

### 📊 データベース
- マイグレーション作成・適用完了
- インデックス設定（Token一意制約、ExpiresAt性能最適化）

## 技術的詳細

### セキュリティ
- アクセストークンは32バイトランダム文字列
- 有効期限1時間
- テナント分離対応（マルチテナント）

### パフォーマンス
- Token列に一意インデックス（高速検索）
- ExpiresAt列にインデックス（期限切れトークン清浄用）

## テスト計画

- [x] ユニットテスト: 161個全て成功
- [x] データベースマイグレーション: 正常適用確認
- [ ] E2Eテスト: UserinfoController実装後に実施

## 関連Issue

- Issue #58: UserinfoControllerの新規作成（この実装は前提条件）

## 次のステップ

1. このPRマージ後、Issue #58のUserinfoController実装
2. E2Eテストでアクセストークン管理機能の統合テスト
3. UserInfo Endpoint実装完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)