### PR TITLE
ci(dependabot): update configuration to include multiple directories for NuGet packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,15 @@ updates:
 
   # .NET NuGet パッケージの自動更新
   - package-ecosystem: "nuget"
-    directory: "/"
+    directories:
+      - "/"
+      - "/IdentityProvider"
+      - "/MockOpenIdProvider"
+      - "/IdpUtilities"
+      - "/ConsoleApp"
+      - "/IdentityProvider.Test"
+      - "/MockOpenIdProvider.Test"
+      - "/IdpUtilities.Test"
     schedule:
       interval: "weekly"
       day: "tuesday"


### PR DESCRIPTION
This pull request updates the Dependabot configuration to improve automated dependency management for .NET NuGet packages. The main change is expanding the set of directories monitored for updates.

**Dependabot configuration improvements:**

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L21-R29): Changed the configuration to monitor multiple directories (including `/IdentityProvider`, `/MockOpenIdProvider`, `/IdpUtilities`, `/ConsoleApp`, and their corresponding test directories) for NuGet package updates, instead of just the root directory.