### PR TITLE
test: フェデレーション認証フローE2EテストにUserInfoエンドポイント検証を追加

### DIFF
--- a/E2ETests/tests/specs/federate_authorization_code_flow.spec.ts
+++ b/E2ETests/tests/specs/federate_authorization_code_flow.spec.ts
@@ -5,7 +5,8 @@ test.describe.serial('認可コードフローフェデレーションのテス�
   // 環境変数から動的にエンドポイントを取得（デフォルト値はGitHub Actions用）
   const authorizationEndpoint = process.env.E2E_AUTHORIZATION_ENDPOINT || 'https://localhost:8081/authorization';
   const tokenEndpoint = process.env.E2E_TOKEN_ENDPOINT || 'https://localhost:8081/token';
-  const userInfoEndpoint = process.env.E2E_USERINFO_ENDPOINT || 'https://localhost:9091/userinfo';
+  const ecAuthUserInfoEndpoint = process.env.E2E_ECAUTH_USERINFO_ENDPOINT || 'https://localhost:8081/userinfo';
+  const externalIdpUserInfoEndpoint = process.env.E2E_USERINFO_ENDPOINT || 'https://localhost:9091/userinfo';
   const redirectUri = process.env.E2E_REDIRECT_URI || 'https://localhost:8081/auth/callback';
   const clientId = 'client_id';
   const clientSecret = 'client_secret';
@@ -121,14 +122,32 @@ test.describe.serial('認可コードフローフェデレーションのテス�
     expect(responseBody.access_token).toBeTruthy();
     expect(responseBody.token_type).toBe('Bearer');
 
-    // const userInfoRequest = await request.newContext();
-    // const userInfoResponse = await userInfoRequest.get(userInfoEndpoint, {
-    //   headers: {
-    //     Authorization: `Bearer ${(await response.json()).access_token}`
-    //   }
-    // });
+    // UserInfo エンドポイントのテスト
+    console.log('📤 Sending UserInfo request to:', ecAuthUserInfoEndpoint);
+    console.log('🔑 Using access token:', responseBody.access_token.substring(0, 20) + '...');
 
-    // // console.log(await userInfoResponse.json());
-    // expect((await userInfoResponse.json()).sub).toBeTruthy();
+    const userInfoRequest = await request.newContext();
+    const userInfoResponse = await userInfoRequest.get(ecAuthUserInfoEndpoint, {
+      headers: {
+        Authorization: `Bearer ${responseBody.access_token}`
+      }
+    });
+
+    console.log('📥 UserInfo response status:', userInfoResponse.status());
+    console.log('📥 UserInfo response headers:', userInfoResponse.headers());
+
+    const userInfoBody = await userInfoResponse.json();
+    console.log('📥 UserInfo response body:', JSON.stringify(userInfoBody, null, 2));
+
+    if (userInfoBody.error) {
+      console.log('❌ UserInfo request failed with error:', userInfoBody.error);
+      console.log('❌ Error description:', userInfoBody.error_description);
+    } else {
+      console.log('✅ UserInfo request successful');
+    }
+
+    expect(userInfoResponse.status()).toBe(200);
+    expect(userInfoBody.sub).toBeTruthy();
+    console.log('✅ UserInfo endpoint test completed successfully');
   });
 });


### PR DESCRIPTION
## Summary

PR #119でUserInfoエンドポイント実装が完了しましたが、フェデレーション認証フローのE2EテストにはUserInfo取得の検証が含まれていませんでした。

この問題を解決し、**OpenID Connect準拠の完全な認証フロー**（Authorization → Token → UserInfo）をE2Eテストで検証できるようにしました。

## 実装内容

### E2Eテストの拡張

**ファイル**: `E2ETests/tests/specs/federate_authorization_code_flow.spec.ts`

1. **コメントアウトされていたUserInfoテストを有効化**
   - 以前は124-132行目がコメントアウトされていた
   - 完全な実装に置き換え

2. **エンドポイントの明確な区別**
   - `ecAuthUserInfoEndpoint`: EcAuthのUserInfoエンドポイント（`https://localhost:8081/userinfo`）
   - `externalIdpUserInfoEndpoint`: 外部IdPのUserInfoエンドポイント（`https://localhost:9091/userinfo`）

3. **包括的な検証ロジック**
   - Bearer Token認証を使用したリクエスト
   - HTTPステータスコード200の確認
   - レスポンスボディの`sub`クレームの存在確認
   - 詳細なログ出力（デバッグ用）

## テスト実行結果

```
✅ Token request successful
📤 Sending UserInfo request to: https://localhost:8081/userinfo
🔑 Using access token: 954E20AB3949F7323EB7...
📥 UserInfo response status: 200
📥 UserInfo response body: {
  "sub": "cddb0c9e-9b44-4b6b-be7e-613f0581086c"
}
✅ UserInfo request successful
✅ UserInfo endpoint test completed successfully
✓ 1 passed (5.3s)
```

## 完全な認証フロー検証

これにより、E2Eテストで以下の**完全な認証フロー**が検証されるようになりました：

```
1. Client → EcAuth /authorization ✅
2. EcAuth → External IdP (redirect) ✅
3. User authenticates at External IdP ✅
4. External IdP → EcAuth /auth/callback ✅
5. EcAuth: JIT provisioning ✅
6. EcAuth generates authorization code ✅
7. EcAuth → Client (redirect with code) ✅
8. Client → EcAuth /token ✅
9. EcAuth returns ID token + Access token ✅
10. Client → EcAuth /userinfo ✅ **NEW!**
11. EcAuth returns user info (sub claim) ✅ **NEW!**
```

## 影響範囲

- **E2Eテストのみ**: 実装コードへの変更なし
- **後方互換性**: 既存のテストに影響なし
- **CI/CD**: 自動テストで完全な認証フローが検証される

## 関連Issue/PR

- PR #119: UserInfoエンドポイント実装
- Issue #58: UserinfoControllerの新規作成
- Issue #23: user-management-architecture の実装

## Test plan

- [x] ローカル環境でE2Eテスト実行（1 passed）
- [x] UserInfo endpoint レスポンス検証
- [x] Bearer Token認証動作確認
- [x] `sub` クレーム存在確認
- [ ] CI/CD環境でのテスト確認（自動実行）

🤖 Generated with [Claude Code](https://claude.com/claude-code)