### PR TITLE
feat: staging 環境へのデプロイワークフローを追加

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,83 @@
+name: Deploy to Staging
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  AZURE_WEBAPP_NAME: ecauth-staging
+  AZURE_WEBAPP_PACKAGE_PATH: ./publish
+  DOTNET_VERSION: '9.0.x'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore dependencies
+        run: dotnet restore IdentityProvider/IdentityProvider.csproj
+
+      - name: Build
+        run: dotnet build IdentityProvider/IdentityProvider.csproj --configuration Release --no-restore
+
+      - name: Publish
+        run: dotnet publish IdentityProvider/IdentityProvider.csproj --configuration Release --no-build --output ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: webapp
+          path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: staging
+      url: https://ecauth-staging.azurewebsites.net
+
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: webapp
+          path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+
+      - name: Login to Azure
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Deploy to Azure Web App
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: ${{ env.AZURE_WEBAPP_NAME }}
+          package: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+
+      - name: Health check
+        run: |
+          echo "Waiting for deployment to complete..."
+          sleep 30
+          for i in {1..10}; do
+            response=$(curl -s -o /dev/null -w "%{http_code}" https://ecauth-staging.azurewebsites.net/health || echo "000")
+            if [ "$response" = "200" ]; then
+              echo "Health check passed!"
+              exit 0
+            fi
+            echo "Attempt $i: Health check returned $response, retrying in 30 seconds..."
+            sleep 30
+          done
+          echo "Health check failed after 10 attempts"
+          exit 1


### PR DESCRIPTION
## 概要

GitHub Actions で main ブランチへの push 時に Azure App Service (ecauth-staging) へ自動デプロイするワークフローを追加します。

## 変更内容

### 新規ワークフロー: `.github/workflows/deploy-staging.yml`

**トリガー:**
- `main` ブランチへの push
- 手動実行 (`workflow_dispatch`)

**ジョブ:**
1. **build**: .NET アプリケーションのビルド・パブリッシュ
2. **deploy**: Azure App Service へのデプロイ

**認証方式:**
- Azure Workload Identity (OIDC) を使用
- Service Principal のシークレット管理が不要

## 必要な設定

### GitHub Secrets (Repository secrets)

| シークレット名 | 説明 |
|---------------|------|
| `AZURE_CLIENT_ID` | Workload Identity のクライアント ID |
| `AZURE_TENANT_ID` | Azure テナント ID |
| `AZURE_SUBSCRIPTION_ID` | Azure サブスクリプション ID |

### Azure AD フェデレーション資格情報

`ecauth-infrastructure` の `environments/identity` に `github-ecauth-main` として設定済み:
- Subject: `repo:EcAuth/EcAuth:ref:refs/heads/main`

## デプロイフロー

```
1. main ブランチに push
2. GitHub Actions がトリガー
3. IdentityProvider プロジェクトをビルド・パブリッシュ
4. Azure にログイン (OIDC)
5. App Service にデプロイ
6. ヘルスチェック (/health) で検証
```

## 注意事項

- Free プラン (F1) のため、初回アクセス時にコールドスタート（約1分15秒）が発生
- ヘルスチェックは最大10回（5分間）リトライ

🤖 Generated with [Claude Code](https://claude.com/claude-code)