### PR TITLE
fix: デプロイワークフローに GitHub Packages 認証と OIDC 権限を追加

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -15,6 +15,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      packages: read
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -23,6 +27,15 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Add GitHub Packages source with credentials
+        run: |
+          dotnet nuget remove source github || true
+          dotnet nuget add source https://nuget.pkg.github.com/EcAuth/index.json \
+            --name github \
+            --username ${{ github.actor }} \
+            --password ${{ secrets.ORG_PAT || secrets.PACKAGES_READ_TOKEN }} \
+            --store-password-in-clear-text
 
       - name: Restore dependencies
         run: dotnet restore IdentityProvider/IdentityProvider.csproj
@@ -45,6 +58,10 @@ jobs:
     environment:
       name: staging
       url: https://ecauth-staging.azurewebsites.net
+
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Download artifact


### PR DESCRIPTION
## 概要

PR #185 でマージされたデプロイワークフローのビルドエラーを修正します。

## 問題

GitHub Packages から `EcAuth.IdpUtilities` NuGet パッケージを取得する際に 401 Unauthorized エラーが発生:

```
error NU1301: Failed to retrieve information about 'EcAuth.IdpUtilities' from remote source 'https://nuget.pkg.github.com/EcAuth/download/ecauth.idputilities/index.json'.
Response status code does not indicate success: 401 (Unauthorized).
```

## 修正内容

### build ジョブ
- `permissions: packages: read` を追加
- GitHub Packages の認証ステップを追加（`ORG_PAT` または `PACKAGES_READ_TOKEN` を使用）

### deploy ジョブ
- `permissions: id-token: write` を追加（Azure OIDC 認証用）

## 関連

- #185 feat: staging 環境へのデプロイワークフローを追加
- https://github.com/EcAuth/EcAuth/actions/runs/19981742759/job/57309284455

🤖 Generated with [Claude Code](https://claude.com/claude-code)