### PR TITLE
feat(ci): ステージング環境のWeb App名を動的に設定

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -7,7 +7,6 @@ on:
   workflow_dispatch:
 
 env:
-  AZURE_WEBAPP_NAME: ecauth-staging
   AZURE_WEBAPP_PACKAGE_PATH: ./publish
   DOTNET_VERSION: '9.0.x'
 
@@ -57,7 +56,7 @@ jobs:
     needs: build
     environment:
       name: staging
-      url: https://ecauth-staging.azurewebsites.net
+      url: https://ecauth-staging-${{ secrets.WEB_APP_SUFFIX }}.azurewebsites.net
 
     permissions:
       id-token: write
@@ -80,15 +79,17 @@ jobs:
       - name: Deploy to Azure Web App
         uses: azure/webapps-deploy@v3
         with:
-          app-name: ${{ env.AZURE_WEBAPP_NAME }}
+          app-name: ecauth-staging-${{ secrets.WEB_APP_SUFFIX }}
           package: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
 
       - name: Health check
+        env:
+          HEALTH_CHECK_URL: https://ecauth-staging-${{ secrets.WEB_APP_SUFFIX }}.azurewebsites.net/health
         run: |
           echo "Waiting for deployment to complete..."
           sleep 30
           for i in {1..10}; do
-            response=$(curl -s -o /dev/null -w "%{http_code}" https://ecauth-staging.azurewebsites.net/health || echo "000")
+            response=$(curl -s -o /dev/null -w "%{http_code}" "$HEALTH_CHECK_URL" || echo "000")
             if [ "$response" = "200" ]; then
               echo "Health check passed!"
               exit 0


### PR DESCRIPTION
## 概要

ステージング環境のデプロイワークフローを、推測されにくいランダムサフィックスを使用したWeb App名に対応させます。

## 変更内容

### deploy-staging.yml

- `AZURE_WEBAPP_NAME` 環境変数を削除（トップレベルenvではsecretsが使えないため）
- Web App名に `secrets.WEB_APP_SUFFIX` を使用
  - `app-name: ecauth-staging-${{ secrets.WEB_APP_SUFFIX }}`
- Environment URLも動的生成
  - `url: https://ecauth-staging-${{ secrets.WEB_APP_SUFFIX }}.azurewebsites.net`
- Health check URLも動的生成
  - ステップレベルのenvで `HEALTH_CHECK_URL` を設定

## 必要な設定

### GitHub Secrets

**Repository**: `EcAuth/EcAuth`

| Secret Name | Value | 説明 |
|-------------|-------|------|
| `WEB_APP_SUFFIX` | ランダム文字列（例: a7b3c9d2） | Terraform Cloudの値と同じ |

ランダム文字列生成:
```bash
openssl rand -hex 4
```

## セキュリティ上の利点

✅ URL が推測されにくくなる  
✅ GitHub Secrets で機密管理  
✅ Health check でも環境変数を使用し、ログへの直接出力を最小化

## デプロイフロー

1. インフラ変更を先にデプロイ（ecauth-infrastructure #16）
2. Terraform Cloudで `web_app_suffix` を設定
3. `terraform apply` で新しいWeb Appを作成
4. GitHub Secretsに `WEB_APP_SUFFIX` を設定
5. このPRをマージしてデプロイ

## 関連PR

- EcAuth/ecauth-infrastructure#16: Terraform設定の対応

## テスト

- [x] GitHub Secretsに `WEB_APP_SUFFIX` を設定
- [ ] ワークフローが正常に実行されることを確認
- [ ] Health checkが成功することを確認