### PR TITLE
fix(ci): environment.urlからsecretsの参照を削除

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -56,7 +56,6 @@ jobs:
     needs: build
     environment:
       name: staging
-      url: https://ecauth-staging-${{ secrets.WEB_APP_SUFFIX }}.azurewebsites.net
 
     permissions:
       id-token: write


### PR DESCRIPTION
## 概要

GitHub Actionsの`environment.url`で`secrets`コンテキストが使用できないため、ワークフローバリデーションエラーが発生していた問題を修正します。

## 問題

PR #187 をマージ後、以下のエラーが発生：

```
Invalid workflow file: .github/workflows/deploy-staging.yml#L1
(Line: 59, Col: 12): Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.WEB_APP_SUFFIX
```

## 原因

GitHub Actionsの制限により、`environment.url`では`secrets`コンテキストが使用できません。

参考: https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability

## 修正内容

`environment.url`の行を削除：

```yaml
# 修正前
environment:
  name: staging
  url: https://ecauth-staging-${{ secrets.WEB_APP_SUFFIX }}.azurewebsites.net

# 修正後
environment:
  name: staging
```

## 影響

- ✅ ワークフローバリデーションエラーが解消
- ℹ️ GitHub環境ページに自動的にURLが表示されなくなる
- ℹ️ デプロイURLは引き続きワークフローログで確認可能
- ℹ️ 必要に応じて、GitHub Settings > Environments > staging で手動設定可能

## その他の変更なし

- ✅ デプロイロジックは変更なし
- ✅ `secrets.WEB_APP_SUFFIX`は引き続き使用（app-name、health check等）

## 関連PR

- #187: ステージング環境のWeb App名を動的に設定（マージ済み）