### PR TITLE
fix: Health check エンドポイントを /healthz に修正

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Health check
         env:
-          HEALTH_CHECK_URL: https://ecauth-staging-${{ secrets.WEB_APP_SUFFIX }}.azurewebsites.net/health
+          HEALTH_CHECK_URL: https://ecauth-staging-${{ secrets.WEB_APP_SUFFIX }}.azurewebsites.net/healthz
         run: |
           echo "Waiting for deployment to complete..."
           sleep 30


### PR DESCRIPTION
## Summary

- deploy-staging.yml の Health check URL を `/health` から `/healthz` に修正

IdentityProvider の実際のヘルスチェックエンドポイントは `/healthz` であるため、ワークフローの設定を修正しました。

## Related

- Fixes #189
- 関連 PR: https://github.com/EcAuth/ecauth-infrastructure/pull/new/fix/staging-deployment-189

## Test plan

- [x] ecauth-infrastructure の PR をマージし Terraform apply 実行
- [ ] この PR をマージしてデプロイワークフローを再実行
- [ ] `/healthz` エンドポイントが 200 を返すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)