### PR TITLE
fix: update health check endpoint path from /health to /healthz

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Health check
         env:
-          HEALTH_CHECK_URL: https://ecauth-staging-${{ secrets.WEB_APP_SUFFIX }}.azurewebsites.net/health
+          HEALTH_CHECK_URL: https://ecauth-staging-${{ secrets.WEB_APP_SUFFIX }}.azurewebsites.net/healthz
         run: |
           echo "Waiting for deployment to complete..."
           sleep 30


### PR DESCRIPTION
- Change health check URL path in staging deployment workflow
- Update HEALTH_CHECK_URL environment variable to use /healthz endpoint for proper health verification