### PR TITLE
feat: 1Password 環境変数テンプレートを追加

### DIFF
--- a/.env.dev.tpl
+++ b/.env.dev.tpl
@@ -1,0 +1,72 @@
+# 1Password テンプレートファイル（ローカル Docker 開発環境用）
+# 使用方法: op inject -i .env.dev.tpl -o .env
+#
+# EcAuth DB: Docker 内（固定値）
+# MockIdP: Azure dev 環境（1Password から取得）
+
+# =============================================================================
+# Database Configuration (Docker 内)
+# =============================================================================
+DB_HOST=db
+MIGRATION_DB_HOST=localhost
+DB_NAME=EcAuthDb
+DB_USER=SA
+DB_PASSWORD='<YourStrong@Passw0rd>'
+STATE_PASSWORD='<strong_password_string_of_at_least_32_characters>'
+
+# =============================================================================
+# Default Organization/Client Settings
+# =============================================================================
+DEFAULT_ORGANIZATION_CODE=example
+DEFAULT_ORGANIZATION_NAME=example
+DEFAULT_ORGANIZATION_TENANT_NAME=example
+DEFAULT_ORGANIZATION_REDIRECT_URI=http://127.0.0.1:8080/auth/callback
+DEFAULT_CLIENT_ID=client_id
+DEFAULT_CLIENT_SECRET=client_secret
+DEFAULT_APP_NAME=app_name
+
+# =============================================================================
+# Azure MockIdP (dev organization) Settings
+# =============================================================================
+MOCK_IDP_BASE_URL=op://EcAuth/mockidp-dev/base_url
+
+# dev organization の MockIdP クライアント設定
+MOCK_IDP_DEFAULT_CLIENT_ID=op://EcAuth/mockidp-dev/default_client_id
+MOCK_IDP_DEFAULT_CLIENT_SECRET=op://EcAuth/mockidp-dev/default_client_secret
+MOCK_IDP_DEFAULT_CLIENT_NAME=MockClient
+MOCK_IDP_DEFAULT_USER_EMAIL=op://EcAuth/mockidp-dev/default_user_email
+MOCK_IDP_DEFAULT_USER_PASSWORD=op://EcAuth/mockidp-dev/default_user_password
+
+# Federate クライアント設定（EcAuth -> Azure MockIdP 連携用）
+MOCK_IDP_FEDERATE_CLIENT_ID=op://EcAuth/mockidp-dev/federate_client_id
+MOCK_IDP_FEDERATE_CLIENT_SECRET=op://EcAuth/mockidp-dev/federate_client_secret
+MOCK_IDP_FEDERATE_CLIENT_NAME=FederateClient
+MOCK_IDP_FEDERATE_USER_EMAIL=federate@example.jp
+
+# =============================================================================
+# Federate OAuth2 Settings (EcAuth -> Azure MockIdP)
+# =============================================================================
+FEDERATE_OAUTH2_APP_NAME=federate-oauth2
+FEDERATE_OAUTH2_CLIENT_ID=op://EcAuth/mockidp-dev/federate_client_id
+FEDERATE_OAUTH2_CLIENT_SECRET=op://EcAuth/mockidp-dev/federate_client_secret
+FEDERATE_OAUTH2_AUTHORIZATION_ENDPOINT=op://EcAuth/mockidp-dev/authorization_endpoint
+FEDERATE_OAUTH2_TOKEN_ENDPOINT=op://EcAuth/mockidp-dev/token_endpoint
+FEDERATE_OAUTH2_USERINFO_ENDPOINT=op://EcAuth/mockidp-dev/userinfo_endpoint
+
+# =============================================================================
+# Google OAuth2 Settings (オプション)
+# =============================================================================
+GOOGLE_OAUTH2_APP_NAME=google-oauth2
+GOOGLE_OAUTH2_CLIENT_ID=<Google OAuth2 client_id>
+GOOGLE_OAUTH2_CLIENT_SECRET=<Google OAuth2 client_secret>
+GOOGLE_OAUTH2_DISCOVERY_URL=https://accounts.google.com/.well-known/openid-configuration
+
+# =============================================================================
+# Amazon OAuth2 Settings (オプション)
+# =============================================================================
+AMAZON_OAUTH2_APP_NAME=amazon-oauth2
+AMAZON_OAUTH2_CLIENT_ID=<Amazon OAuth2 client_id>
+AMAZON_OAUTH2_CLIENT_SECRET=<Amazon OAuth2 client_secret>
+AMAZON_OAUTH2_AUTHORIZATION_ENDPOINT=https://www.amazon.com/ap/oa
+AMAZON_OAUTH2_TOKEN_ENDPOINT=https://api.amazon.co.jp/auth/o2/token
+AMAZON_OAUTH2_USERINFO_ENDPOINT=https://api.amazon.com/user/profile

--- a/.env.dist
+++ b/.env.dist
@@ -1,3 +1,12 @@
+# EcAuth 環境変数テンプレート
+#
+# 詳細な環境構成と 1Password テンプレートの使用方法は docs/CLAUDE.md を参照してください。
+#
+# 簡易セットアップ:
+#   1Password 使用: op inject -i .env.dev.tpl -o .env
+#   完全ローカル:   cp .env.docker .env
+#
+
 DB_HOST=db
 MIGRATION_DB_HOST=localhost
 DB_NAME=EcAuthDb

--- a/.env.staging.tpl
+++ b/.env.staging.tpl
@@ -1,0 +1,42 @@
+# 1Password テンプレートファイル（staging 環境用）
+# 使用方法: op inject -i .env.staging.tpl -o .env
+#
+# EcAuth DB: Azure SQL Database（1Password から取得）
+# MockIdP: Azure staging 環境（1Password から取得）
+
+# =============================================================================
+# Database Configuration (Azure SQL Database)
+# =============================================================================
+# 接続文字列を個別フィールドから組み立てる場合は、以下を使用後にシェルで組み立て
+SQL_HOST=op://EcAuth/ecauth-staging-sql/hostname
+SQL_DATABASE=op://EcAuth/ecauth-staging-sql/database
+SQL_USERNAME=op://EcAuth/ecauth-staging-sql/username
+SQL_PASSWORD=op://EcAuth/ecauth-staging-sql/password
+
+# 注: ConnectionStrings__EcAuthDbContext は GitHub Actions ワークフローで組み立てます
+# export ConnectionStrings__EcAuthDbContext="Server=tcp:${SQL_HOST},1433;Initial Catalog=${SQL_DATABASE};User ID=${SQL_USERNAME};Password=${SQL_PASSWORD};Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+
+# =============================================================================
+# Staging Organization/Client Settings
+# =============================================================================
+STAGING_ORGANIZATION_CODE=op://EcAuth/ecauth-staging-app/organization_code
+STAGING_ORGANIZATION_NAME=op://EcAuth/ecauth-staging-app/organization_name
+STAGING_ORGANIZATION_TENANT_NAME=op://EcAuth/ecauth-staging-app/organization_tenant_name
+STAGING_CLIENT_ID=op://EcAuth/ecauth-staging-app/client_id
+STAGING_CLIENT_SECRET=op://EcAuth/ecauth-staging-app/client_secret
+STAGING_APP_NAME=op://EcAuth/ecauth-staging-app/app_name
+STAGING_REDIRECT_URI=op://EcAuth/ecauth-staging-app/redirect_uri
+
+# =============================================================================
+# Staging MockIdP Settings (Azure MockIdP との連携)
+# =============================================================================
+# EcAuth から Azure MockIdP への OAuth2 連携設定
+STAGING_MOCK_IDP_APP_NAME=op://EcAuth/ecauth-staging-mockidp/app_name
+STAGING_MOCK_IDP_CLIENT_ID=op://EcAuth/ecauth-staging-mockidp/client_id
+STAGING_MOCK_IDP_CLIENT_SECRET=op://EcAuth/ecauth-staging-mockidp/client_secret
+
+# MockIdP エンドポイント（Azure Container Apps）
+MOCK_IDP_BASE_URL=op://EcAuth/mockidp-staging/base_url
+STAGING_MOCK_IDP_AUTHORIZATION_ENDPOINT=op://EcAuth/mockidp-staging/authorization_endpoint
+STAGING_MOCK_IDP_TOKEN_ENDPOINT=op://EcAuth/mockidp-staging/token_endpoint
+STAGING_MOCK_IDP_USERINFO_ENDPOINT=op://EcAuth/mockidp-staging/userinfo_endpoint


### PR DESCRIPTION
## Summary
- ローカル Docker 開発用の `.env.dev.tpl` を追加（EcAuth DB: Docker, MockIdP: Azure dev）
- ステージング環境用の `.env.staging.tpl` を追加（EcAuth DB: Azure, MockIdP: Azure staging）
- `.env.dist` のコメントを簡略化し、docs への参照を追加

## 環境構成

| 環境 | EcAuth DB | MockIdP | テンプレート |
|------|-----------|---------|--------------|
| ローカル Docker | Docker 内 | Azure (dev) | `.env.dev.tpl` |
| ステージング | Azure | Azure (staging) | `.env.staging.tpl` |
| 完全ローカル | Docker 内 | Docker 内 | `.env.docker` |

## 使用方法

```bash
# 1Password にサインイン
eval $(op signin)

# ローカル Docker 開発
op inject -i .env.dev.tpl -o .env

# ステージング環境
op inject -i .env.staging.tpl -o .env
```

## 1Password アイテム構成

| アイテム名 | 用途 |
|-----------|------|
| `mockidp-dev` | Azure MockIdP dev 環境の接続情報 |
| `mockidp-staging` | Azure MockIdP staging 環境の接続情報 |
| `ecauth-staging-sql` | EcAuth ステージング環境の Azure SQL Database 接続情報 |
| `ecauth-staging-app` | ステージング環境の Organization/Client 設定 |
| `ecauth-staging-mockidp` | EcAuth から Azure MockIdP への連携設定 |

## Test plan
- [ ] `op inject -i .env.dev.tpl -o .env` でローカル開発用 `.env` が生成されることを確認
- [ ] `op inject -i .env.staging.tpl -o .env` でステージング用 `.env` が生成されることを確認

## 関連
- PR #191: feat: ステージング環境用のOrganizationとClientを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)