### PR TITLE
fix(TenantMiddleware): Azure プラットフォームドメインをテナント抽出から除外

### DIFF
--- a/IdentityProvider/Middlewares/TenantMiddleware.cs
+++ b/IdentityProvider/Middlewares/TenantMiddleware.cs
@@ -44,6 +44,14 @@ namespace IdentityProvider.Middlewares
                 return string.Empty;
             }
 
+            // Azure プラットフォームドメインの場合は空文字列を返す（デフォルトテナントにフォールバック）
+            // これらのドメインはテナント名を含まないため除外する
+            if (host.EndsWith(".azurewebsites.net", StringComparison.OrdinalIgnoreCase) ||
+                host.EndsWith(".azurecontainerapps.io", StringComparison.OrdinalIgnoreCase))
+            {
+                return string.Empty;
+            }
+
             // サブドメイン形式（tenant.example.com）からテナント名を抽出
             var segments = host.Split('.');
             if (segments.Length > 2)


### PR DESCRIPTION
## 概要

- `*.azurewebsites.net` と `*.azurecontainerapps.io` をテナント名抽出から除外
- これらの Azure プラットフォームドメインは `DEFAULT_ORGANIZATION_TENANT_NAME` にフォールバックするように修正

## 背景

EcAuth を Azure Web Apps ステージング環境にデプロイした際、自動生成されたホスト名 `ecauth-staging-w4bctmxhutunk9kc.azurewebsites.net` がサブドメイン形式のテナント名として誤って解釈されていました：

```
Host: ecauth-staging-w4bctmxhutunk9kc.azurewebsites.net
Segments: ["ecauth-staging-w4bctmxhutunk9kc", "azurewebsites", "net"]
抽出されたテナント: "ecauth-staging-w4bctmxhutunk9kc"  ← 間違い！
```

これにより `DEFAULT_ORGANIZATION_TENANT_NAME=staging` へのフォールバックが機能せず、「Organization not found」エラーが発生していました。

## 変更内容

`ExtractTenantNameFromHost()` に Azure プラットフォームドメインの明示的なチェックを追加し、空文字列を返すことでデフォルトテナントへのフォールバックをトリガーするように修正しました。

## テスト計画

- [x] ビルド成功
- [x] 全 219 ユニットテストがパス
- [ ] ステージング環境にデプロイし、MockIdP とのフェデレーション動作を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)