### PR TITLE
chore(deps): .NET 10 へのメジャーバージョンアップグレードを無視

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,6 +55,20 @@ updates:
     # GitHub Packages の認証設定を参照
     registries:
       - github-packages
+    # .NET 10 へのメジャーバージョンアップグレードを無視
+    # プロジェクトが net9.0 をターゲットにしているため、ランタイムに含まれる
+    # パッケージは同じメジャーバージョンを維持する
+    ignore:
+      - dependency-name: "System.Text.Json"
+        versions: [">= 10.0.0"]
+      - dependency-name: "Microsoft.EntityFrameworkCore*"
+        versions: [">= 10.0.0"]
+      - dependency-name: "Microsoft.AspNetCore*"
+        versions: [">= 10.0.0"]
+      - dependency-name: "Microsoft.Extensions*"
+        versions: [">= 10.0.0"]
+      - dependency-name: "dotnet-ef"
+        versions: [">= 10.0.0"]
 
   # E2ETests の npm パッケージの自動更新
   - package-ecosystem: "npm"


### PR DESCRIPTION
## Summary
- プロジェクトが net9.0 をターゲットにしているため、.NET 10 系パッケージへのアップグレードを無視する設定を追加

## 対象パッケージ
- `System.Text.Json` - ランタイムに含まれる
- `Microsoft.EntityFrameworkCore*` - ランタイムバージョンに合わせる
- `Microsoft.AspNetCore*` - ランタイムに含まれる
- `Microsoft.Extensions*` - ランタイムに含まれる
- `dotnet-ef` - EF Core と同じバージョンを維持

## 背景
Dependabot が System.Text.Json 10.0.2 などの .NET 10 系パッケージへのアップグレード PR を作成していたが、.NET 9 プロジェクトでは互換性の問題が発生する可能性があるため、メジャーバージョンを固定する。

## Test plan
- [ ] Dependabot が .NET 10 系パッケージの PR を作成しなくなることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)