### PR TITLE
fix(migration): idempotent スクリプトのバッチコンパイルエラーを回避

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,3 +35,4 @@ cd E2ETests && yarn install && npx playwright test
   - `EXEC()` でラップすることで名前解決を実行時まで遅延させる
 - 破壊的変更（カラム削除・リネーム）を伴うマイグレーションのデータ移行 SQL には `IF EXISTS` でカラム存在チェックを追加すること
   - これにより、関連するカラムを削除する後続のマイグレーションが既に適用されている環境でも、冪等スクリプトがエラーなく実行できるようになります。
+- カラム存在チェックには `INFORMATION_SCHEMA.COLUMNS` ではなく `sys.columns` + `OBJECT_ID(N'dbo.table_name')` を使用し、DML でもスキーマ修飾（`dbo.`）を明示すること

--- a/IdentityProvider/Migrations/20260124233551_AddSubjectTypeToTokens.cs
+++ b/IdentityProvider/Migrations/20260124233551_AddSubjectTypeToTokens.cs
@@ -41,10 +41,12 @@ namespace IdentityProvider.Migrations
             // バッチコンパイルエラーを回避（subject カラムの遅延名前解決）
             // IF EXISTS で RemoveLegacySubjectColumns 適用済みの場合にも対応
             migrationBuilder.Sql(@"
-                IF EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
-                           WHERE TABLE_NAME = 'access_token' AND COLUMN_NAME = 'ecauth_subject')
+                IF EXISTS (SELECT 1
+                           FROM sys.columns
+                           WHERE object_id = OBJECT_ID(N'dbo.access_token')
+                             AND name = 'ecauth_subject')
                 BEGIN
-                    EXEC(N'UPDATE access_token
+                    EXEC(N'UPDATE dbo.access_token
                     SET subject = ecauth_subject, subject_type = 0
                     WHERE ecauth_subject IS NOT NULL;');
                 END
@@ -52,10 +54,12 @@ namespace IdentityProvider.Migrations
 
             // 既存データの変換: AuthorizationCode (B2C)
             migrationBuilder.Sql(@"
-                IF EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
-                           WHERE TABLE_NAME = 'authorization_code' AND COLUMN_NAME = 'ecauth_subject')
+                IF EXISTS (SELECT 1
+                           FROM sys.columns
+                           WHERE object_id = OBJECT_ID(N'dbo.authorization_code')
+                             AND name = 'ecauth_subject')
                 BEGIN
-                    EXEC(N'UPDATE authorization_code
+                    EXEC(N'UPDATE dbo.authorization_code
                     SET subject_new = ecauth_subject, subject_type = 0
                     WHERE ecauth_subject IS NOT NULL;');
                 END
@@ -63,10 +67,12 @@ namespace IdentityProvider.Migrations
 
             // 既存データの変換: AuthorizationCode (B2B)
             migrationBuilder.Sql(@"
-                IF EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
-                           WHERE TABLE_NAME = 'authorization_code' AND COLUMN_NAME = 'b2b_subject')
+                IF EXISTS (SELECT 1
+                           FROM sys.columns
+                           WHERE object_id = OBJECT_ID(N'dbo.authorization_code')
+                             AND name = 'b2b_subject')
                 BEGIN
-                    EXEC(N'UPDATE authorization_code
+                    EXEC(N'UPDATE dbo.authorization_code
                     SET subject_new = b2b_subject, subject_type = 1
                     WHERE b2b_subject IS NOT NULL;');
                 END


### PR DESCRIPTION
## Summary

- `AddSubjectTypeToTokens` マイグレーションの DML を `EXEC()` 動的 SQL でラップし、`--idempotent` スクリプト生成時の `Invalid column name` エラーを回避
- `IF EXISTS` でソースカラムの存在チェックを追加し、`RemoveLegacySubjectColumns` 適用済み環境にも対応
- CLAUDE.md にマイグレーション設計ルールを追記

## 根本原因

SQL Server はバッチ（`GO` 間）を実行前に一括コンパイルする。EF Core の `--idempotent` スクリプトは全マイグレーションを 1 つのバッチにまとめるため、同一マイグレーション内で `ALTER TABLE ... ADD` したカラムを参照する `UPDATE` 文がコンパイル時に `Invalid column name` エラーになる。

`dotnet ef database update` では各 `migrationBuilder.Sql()` が個別の ADO.NET コマンドとして実行されるため問題は起きない。CI/CD の `--idempotent` スクリプト方式でのみ発生する。

## Changes

### `IdentityProvider/Migrations/20260124233551_AddSubjectTypeToTokens.cs`

3 つの `migrationBuilder.Sql()` を以下のようにラップ：

| 防御 | 対処するケース |
|------|---------------|
| `EXEC()` | バッチコンパイル時に新カラムが未存在でも名前解決エラーを回避 |
| `IF EXISTS` | `RemoveLegacySubjectColumns` が先に適用済みでソースカラムが削除済みの場合にスキップ |

### `CLAUDE.md`

注意事項セクションに「マイグレーション設計ルール」を追記し、今後同様の問題を防止。

## Test plan

- [x] `dotnet build EcAuth.sln` — ビルド成功（0 エラー）
- [x] `dotnet test IdentityProvider.Test/IdentityProvider.Test.csproj` — 全 443 テスト合格
- [x] `dotnet ef migrations script --idempotent` で生成されるスクリプトに `EXEC` と `IF EXISTS` が含まれることを確認
- [x] Docker 環境で idempotent スクリプトの適用テスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * 「マイグレーション設計ルール」を追加しました（idempotent スクリプト、実行時名解決と列存在チェックに関する指針を含む）。

* **バグ修正**
  * マイグレーションの実行時安全性と idempotency を強化しました（列存在確認と遅延名解決によるエラー耐性向上）。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->