### PR TITLE
ci: add B2B passkey secrets to migrate-staging workflow

### DIFF
--- a/.github/workflows/migrate-staging.yml
+++ b/.github/workflows/migrate-staging.yml
@@ -58,6 +58,11 @@ jobs:
           # MockIdP test user credentials (for federation verification)
           MOCK_USER: op://EcAuth/mockidp-staging/default_user_email
           MOCK_PASS: op://EcAuth/mockidp-staging/default_user_password
+          # B2B Passkey settings
+          STAGING_B2B_USER_SUBJECT: op://EcAuth/ecauth-staging-app/b2b_user_subject
+          STAGING_B2B_USER_EXTERNAL_ID: op://EcAuth/ecauth-staging-app/b2b_user_external_id
+          STAGING_B2B_REDIRECT_URI: op://EcAuth/ecauth-staging-app/b2b_redirect_uri
+          STAGING_B2B_ALLOWED_RP_IDS: op://EcAuth/ecauth-staging-app/b2b_allowed_rp_ids
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5


### PR DESCRIPTION
## Summary

- `migrate-staging.yml` の 1Password シークレットロードに B2B パスキー用の環境変数 4 つを追加
- マイグレーション実行時に `B2BPasskeySeeder` がシードデータを投入するために必要

## 変更内容

`.github/workflows/migrate-staging.yml`:
- `STAGING_B2B_USER_SUBJECT`
- `STAGING_B2B_USER_EXTERNAL_ID`
- `STAGING_B2B_REDIRECT_URI`
- `STAGING_B2B_ALLOWED_RP_IDS`

## 関連 PR

- EcAuth/ecauth-infrastructure#28 (Terraform 側の環境変数追加)

## Test plan

- [ ] ワークフローの YAML 構文が正しいことを確認
- [ ] main マージ後、`migrate-staging.yml` を手動実行して 1Password からのシークレット読み込みが成功することを確認

Refs: EcAuth/EcAuthDocs#37

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ステージング環境にB2B Passkey設定の新しい環境変数を追加しました。設定には、ユーザーサブジェクト、外部ID、リダイレクトURI、許可されたRP IDsが含まれます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->