### PR TITLE
fix: enable static files serving in Staging environment

### DIFF
--- a/IdentityProvider/Program.cs
+++ b/IdentityProvider/Program.cs
@@ -94,7 +94,11 @@ if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
     app.UseSwaggerUI();
-    // 開発環境でのみ静的ファイルを有効化（B2Bパスキーテストページ用）
+}
+
+// Development/Staging 環境で静的ファイルを有効化（B2Bパスキーテストページ用）
+if (!app.Environment.IsProduction())
+{
     app.UseStaticFiles();
 }
 


### PR DESCRIPTION
## Summary

- `UseStaticFiles()` を Development だけでなく Staging 環境でも有効化
- Production 環境では `IsProduction()` チェックにより引き続き無効

## 背景

Staging 環境で `b2b-passkey-test.html` にアクセスすると 404 が返却されていた。
`UseStaticFiles()` が `IsDevelopment()` 条件内にのみ配置されていたため。

## 変更内容

```csharp
// Before: Development のみ
if (app.Environment.IsDevelopment())
{
    app.UseStaticFiles();
}

// After: Production 以外で有効
if (!app.Environment.IsProduction())
{
    app.UseStaticFiles();
}
```

## Test plan

- [ ] Staging デプロイ後、`/b2b-passkey-test.html` にアクセスして 200 が返ることを確認
- [ ] Production 環境では静的ファイルが配信されないことを確認

Refs: EcAuth/EcAuthDocs#37

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **機能改善**
  * ステージング環境で静的ファイルの配信が有効になりました。本番環境では引き続き無効化されています。これにより、開発環境とステージング環境での静的コンテンツの処理が改善されます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->