### PR TITLE
fix: 重複クライアント削除時のFK制約違反を修正

### DIFF
--- a/IdentityProvider/Migrations/20260206230926_AddUniqueIndexToClientClientId.cs
+++ b/IdentityProvider/Migrations/20260206230926_AddUniqueIndexToClientClientId.cs
@@ -23,38 +23,23 @@ namespace IdentityProvider.Migrations
             // ユニークインデックス作成前に重複する client_id を持つレコードを削除（最小 id を残す）
             // FK Restrict の子テーブルを先に削除してから親テーブルを削除する
             migrationBuilder.Sql(@"
+                -- 削除対象の重複 client ID を一時テーブルに格納
+                SELECT id INTO #dup_clients FROM dbo.client
+                WHERE id NOT IN (SELECT MIN(id) FROM dbo.client GROUP BY client_id);
+
                 -- FK Restrict: access_token, authorization_code, webauthn_challenge
-                DELETE FROM dbo.access_token
-                WHERE client_id IN (
-                    SELECT id FROM dbo.client
-                    WHERE id NOT IN (SELECT MIN(id) FROM dbo.client GROUP BY client_id)
-                );
-
-                DELETE FROM dbo.authorization_code
-                WHERE client_id IN (
-                    SELECT id FROM dbo.client
-                    WHERE id NOT IN (SELECT MIN(id) FROM dbo.client GROUP BY client_id)
-                );
-
-                DELETE FROM dbo.webauthn_challenge
-                WHERE client_id IN (
-                    SELECT id FROM dbo.client
-                    WHERE id NOT IN (SELECT MIN(id) FROM dbo.client GROUP BY client_id)
-                );
+                DELETE FROM dbo.access_token       WHERE client_id IN (SELECT id FROM #dup_clients);
+                DELETE FROM dbo.authorization_code WHERE client_id IN (SELECT id FROM #dup_clients);
+                DELETE FROM dbo.webauthn_challenge  WHERE client_id IN (SELECT id FROM #dup_clients);
 
                 -- FK No Action (default): open_id_provider
                 -- open_id_provider_scope は open_id_provider に Cascade なので自動削除される
-                DELETE FROM dbo.open_id_provider
-                WHERE client_id IN (
-                    SELECT id FROM dbo.client
-                    WHERE id NOT IN (SELECT MIN(id) FROM dbo.client GROUP BY client_id)
-                );
+                DELETE FROM dbo.open_id_provider   WHERE client_id IN (SELECT id FROM #dup_clients);
 
                 -- redirect_uri, rsa_key_pair は Cascade なので自動削除される
-                DELETE FROM dbo.client
-                WHERE id NOT IN (
-                    SELECT MIN(id) FROM dbo.client GROUP BY client_id
-                );
+                DELETE FROM dbo.client             WHERE id IN (SELECT id FROM #dup_clients);
+
+                DROP TABLE #dup_clients;
             ");
 
             migrationBuilder.CreateIndex(


### PR DESCRIPTION
## Summary

- `AddUniqueIndexToClientClientId` マイグレーションで、重複 client レコード削除前に FK Restrict の子テーブルを先に削除するよう修正
- 本番マイグレーション実行時に `FK_open_id_provider_client_client_id` 制約違反で DELETE が失敗し、ユニークインデックス作成も失敗していた問題を解決

## 原因

環境変数未設定により `client_id=''` の重複レコードが作成され、そのうち1つに `open_id_provider` が紐付いた状態で DELETE を実行すると FK 制約違反が発生していた。

削除順序:
1. `access_token` (FK Restrict)
2. `authorization_code` (FK Restrict)
3. `web_authn_challenge` (FK Restrict)
4. `open_id_provider` (FK No Action) → `open_id_provider_scope` は Cascade で自動削除
5. `client` → `redirect_uri`, `rsa_key_pair` は Cascade で自動削除

## 本番DB状態

- `__EFMigrationsHistory`: 0 行（前回のトランザクションは全ロールバック済み）
- テーブル: `__EFMigrationsHistory` のみ（クリーンな状態）

## Test plan

- [x] ビルド成功（0 エラー）
- [x] 全 503 ユニットテスト合格
- [ ] マージ後、Migrate Production Database ワークフローを再実行して本番 DB マイグレーション成功を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * データベースの重複レコードをクリーンアップし、データの整合性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->