### PR TITLE
fix: verify-federation-auth.sh の provider_name を環境変数化

### DIFF
--- a/.github/scripts/verify-federation-auth.sh
+++ b/.github/scripts/verify-federation-auth.sh
@@ -82,7 +82,8 @@ main() {
 
   # Step 1: EcAuth 認可エンドポイント
   log_step "Step 1: EcAuth 認可エンドポイント"
-  MOCKIDP_URL=$(curl -s -i "${ECAUTH_BASE_URL}/authorization?client_id=${CLIENT_ID}&redirect_uri=https%3A%2F%2Flocalhost%3A8081%2Fauth%2Fcallback&response_type=code&scope=openid%20profile%20email&provider_name=staging-mockidp&state=test123" 2>/dev/null | grep -i "^location:" | sed 's/location: //i' | tr -d '\r')
+  PROVIDER_NAME="${MOCK_IDP_PROVIDER_NAME:-staging-mockidp}"
+  MOCKIDP_URL=$(curl -s -i "${ECAUTH_BASE_URL}/authorization?client_id=${CLIENT_ID}&redirect_uri=https%3A%2F%2Flocalhost%3A8081%2Fauth%2Fcallback&response_type=code&scope=openid%20profile%20email&provider_name=${PROVIDER_NAME}&state=test123" 2>/dev/null | grep -i "^location:" | sed 's/location: //i' | tr -d '\r')
 
   if [ -z "$MOCKIDP_URL" ]; then
     log_error "Failed to get MockIdP redirect URL"


### PR DESCRIPTION
## Summary

- `verify-federation-auth.sh` で `provider_name=staging-mockidp` がハードコードされていたため、Production 環境の verify ジョブが失敗していた
- `MOCK_IDP_PROVIDER_NAME` 環境変数を使用するように修正（未設定時は `staging-mockidp` にフォールバック）

## 背景

Production ワークフロー統合 (PR #303) で verify ジョブに `MOCK_IDP_PROVIDER_NAME` を 1Password から読み込むように設定したが、スクリプト側でハードコードが残っていた。

## 検証

Staging 環境で全ステップ（認可→MockIdP認証→承認→トークン→ユーザー情報）の成功を確認済み。

## 補足: Production verify の追加課題

MockIdP DB に production 組織のユーザー・クライアントが未登録のため、本修正だけでは Production の verify は成功しない。MockIdP の production シードデータ登録が別途必要。

## Test plan

- [ ] Staging 環境で `staging.yml` の verify ジョブが成功すること
- [ ] Production 環境で `MOCK_IDP_PROVIDER_NAME` が正しく解決されること（MockIdP データ登録後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チア**
  * 認証スクリプトの環境変数設定を改善しました。プロバイダー名を環境変数で上書き可能になり、スクリプトの柔軟性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->