### PR TITLE
chore: ignore Swashbuckle.AspNetCore major version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -69,6 +69,11 @@ updates:
         versions: [">= 10.0.0"]
       - dependency-name: "dotnet-ef"
         versions: [">= 10.0.0"]
+      # Swashbuckle 10.x は Microsoft.OpenApi 2.x を要求するが、
+      # Microsoft.AspNetCore.OpenApi 9.x（.NET 9）は Microsoft.OpenApi 1.x に依存するため競合する。
+      # .NET 10 移行時にまとめて対応する（ref: PR #298）
+      - dependency-name: "Swashbuckle.AspNetCore"
+        update-types: ["version-update:semver-major"]
 
   # E2ETests の npm パッケージの自動更新
   - package-ecosystem: "npm"


### PR DESCRIPTION
## Summary

- Swashbuckle.AspNetCore のメジャーバージョン自動更新を dependabot の ignore に追加
- Swashbuckle 10.x は Microsoft.OpenApi 2.x を要求するが、Microsoft.AspNetCore.OpenApi 9.x（.NET 9）は Microsoft.OpenApi 1.x に依存するため競合する
- .NET 10 移行時にまとめて対応する

## Background

- PR #298（dependabot による 8.1.1 → 10.1.3 アップグレード）で `ReflectionTypeLoadException` が発生し E2E テストが失敗
- パッチ・マイナーアップデート（8.1.x 系）は引き続き自動 PR が作成されます

## Test plan

- [ ] dependabot が Swashbuckle のメジャーバージョン PR を作成しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 依存関係管理の設定を更新し、特定のNuGetパッケージの大バージョン更新を除外するルールを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->