### PR TITLE
fix: マイグレーションの rsa_key_pair.client_id 参照を EXEC() でラップ

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -152,12 +152,13 @@ jobs:
       - name: Verify migration applied
         if: ${{ inputs.dry_run != true }}
         run: |
-          cd IdentityProvider
-          LATEST_MIGRATION=$(dotnet ef migrations list --no-build --configuration Release | tail -1)
-          echo "Latest migration: ${LATEST_MIGRATION}"
+          # マイグレーションファイル名からDB接続なしで最新のMigrationIdを取得
+          LATEST_MIGRATION=$(ls -1 IdentityProvider/Migrations/*.cs | grep -v Designer | grep -v Snapshot | sed 's/.*\///' | sed 's/_.*//' | sort | tail -1)
+          LATEST_MIGRATION_ID=$(ls -1 IdentityProvider/Migrations/${LATEST_MIGRATION}_*.cs | grep -v Designer | sed 's/.*\///' | sed 's/\.cs$//')
+          echo "Latest migration: ${LATEST_MIGRATION_ID}"
           sqlcmd -S "tcp:${SQL_HOST},1433" -d "${SQL_DATABASE}" -U "${SQL_USERNAME}" -P "${SQL_PASSWORD}" -C -b -Q \
-            "IF NOT EXISTS (SELECT 1 FROM [__EFMigrationsHistory] WHERE [MigrationId] = '${LATEST_MIGRATION}') THROW 50000, 'Migration ${LATEST_MIGRATION} was not applied', 1;"
-          echo "Migration verification passed: ${LATEST_MIGRATION} exists in __EFMigrationsHistory"
+            "IF NOT EXISTS (SELECT 1 FROM [__EFMigrationsHistory] WHERE [MigrationId] = '${LATEST_MIGRATION_ID}') THROW 50000, 'Migration ${LATEST_MIGRATION_ID} was not applied', 1;"
+          echo "Migration verification passed: ${LATEST_MIGRATION_ID} exists in __EFMigrationsHistory"
 
       - name: Dry run - Skip migration apply
         if: ${{ inputs.dry_run == true }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -142,12 +142,13 @@ jobs:
       - name: Verify migration applied
         if: ${{ (inputs.dry_run || false) != true }}
         run: |
-          cd IdentityProvider
-          LATEST_MIGRATION=$(dotnet ef migrations list --no-build --configuration Release | tail -1)
-          echo "Latest migration: ${LATEST_MIGRATION}"
+          # マイグレーションファイル名からDB接続なしで最新のMigrationIdを取得
+          LATEST_MIGRATION=$(ls -1 IdentityProvider/Migrations/*.cs | grep -v Designer | grep -v Snapshot | sed 's/.*\///' | sed 's/_.*//' | sort | tail -1)
+          LATEST_MIGRATION_ID=$(ls -1 IdentityProvider/Migrations/${LATEST_MIGRATION}_*.cs | grep -v Designer | sed 's/.*\///' | sed 's/\.cs$//')
+          echo "Latest migration: ${LATEST_MIGRATION_ID}"
           sqlcmd -S "tcp:${SQL_HOST},1433" -d "${SQL_DATABASE}" -U "${SQL_USERNAME}" -P "${SQL_PASSWORD}" -C -b -Q \
-            "IF NOT EXISTS (SELECT 1 FROM [__EFMigrationsHistory] WHERE [MigrationId] = '${LATEST_MIGRATION}') THROW 50000, 'Migration ${LATEST_MIGRATION} was not applied', 1;"
-          echo "Migration verification passed: ${LATEST_MIGRATION} exists in __EFMigrationsHistory"
+            "IF NOT EXISTS (SELECT 1 FROM [__EFMigrationsHistory] WHERE [MigrationId] = '${LATEST_MIGRATION_ID}') THROW 50000, 'Migration ${LATEST_MIGRATION_ID} was not applied', 1;"
+          echo "Migration verification passed: ${LATEST_MIGRATION_ID} exists in __EFMigrationsHistory"
 
       - name: Dry run - Skip migration apply
         if: ${{ (inputs.dry_run || false) == true }}

--- a/IdentityProvider/Migrations/20250920224843_InsertTestRsaKeyPairs.cs
+++ b/IdentityProvider/Migrations/20250920224843_InsertTestRsaKeyPairs.cs
@@ -21,22 +21,26 @@ namespace IdentityProvider.Migrations
             var publicKeyBase64 = Convert.ToBase64String(publicKeyBytes);
             var privateKeyBase64 = Convert.ToBase64String(privateKeyBytes);
 
+            // EXEC() でラップし、冪等スクリプトでのパース時カラム解決エラーを回避
+            // (後続マイグレーションで client_id → organization_id にリネームされるため)
             migrationBuilder.Sql($@"
-                IF NOT EXISTS (SELECT 1 FROM dbo.rsa_key_pair WHERE client_id = 1)
-                BEGIN
-                    EXEC(N'INSERT INTO [dbo].[rsa_key_pair] ([client_id], [public_key], [private_key])
-                    VALUES (1, N''{publicKeyBase64}'', N''{privateKeyBase64}'')')
-                END
+                EXEC(N'
+                    IF NOT EXISTS (SELECT 1 FROM dbo.rsa_key_pair WHERE client_id = 1)
+                    BEGIN
+                        INSERT INTO [dbo].[rsa_key_pair] ([client_id], [public_key], [private_key])
+                        VALUES (1, N''{publicKeyBase64}'', N''{privateKeyBase64}'')
+                    END
+                ')
             ");
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DeleteData(
-                table: "rsa_key_pair",
-                keyColumn: "client_id",
-                keyValue: 1);
+            // EXEC() でラップし、冪等スクリプトでのパース時カラム解決エラーを回避
+            migrationBuilder.Sql(@"
+                EXEC(N'DELETE FROM [dbo].[rsa_key_pair] WHERE [client_id] = 1')
+            ");
         }
     }
 }

--- a/IdentityProvider/Migrations/20251207070759_InsertStagingOrganizationAndClient.cs
+++ b/IdentityProvider/Migrations/20251207070759_InsertStagingOrganizationAndClient.cs
@@ -77,17 +77,21 @@ namespace IdentityProvider.Migrations
             var publicKeyBase64 = Convert.ToBase64String(publicKeyBytes);
             var privateKeyBase64 = Convert.ToBase64String(privateKeyBytes);
 
+            // EXEC() でラップし、冪等スクリプトでのパース時カラム解決エラーを回避
+            // (後続マイグレーションで rsa_key_pair.client_id → organization_id にリネームされるため)
             migrationBuilder.Sql($@"
-                IF NOT EXISTS (SELECT 1 FROM dbo.rsa_key_pair r INNER JOIN dbo.client c ON r.client_id = c.id WHERE c.client_id = '{STAGING_CLIENT_ID}')
-                BEGIN
-                    INSERT INTO dbo.rsa_key_pair (client_id, public_key, private_key)
-                    SELECT
-                        c.id,
-                        '{publicKeyBase64}',
-                        '{privateKeyBase64}'
-                    FROM dbo.client c
-                    WHERE c.client_id = '{STAGING_CLIENT_ID}'
-                END
+                EXEC(N'
+                    IF NOT EXISTS (SELECT 1 FROM dbo.rsa_key_pair r INNER JOIN dbo.client c ON r.client_id = c.id WHERE c.client_id = ''{STAGING_CLIENT_ID}'')
+                    BEGIN
+                        INSERT INTO dbo.rsa_key_pair (client_id, public_key, private_key)
+                        SELECT
+                            c.id,
+                            ''{publicKeyBase64}'',
+                            ''{privateKeyBase64}''
+                        FROM dbo.client c
+                        WHERE c.client_id = ''{STAGING_CLIENT_ID}''
+                    END
+                ')
             ");
 
             // 5. OpenIdProvider（MockIdP）を挿入

--- a/IdentityProvider/Migrations/20251228043929_InsertEcCube2PluginClient.cs
+++ b/IdentityProvider/Migrations/20251228043929_InsertEcCube2PluginClient.cs
@@ -65,15 +65,19 @@ namespace IdentityProvider.Migrations
             var publicKeyBase64 = Convert.ToBase64String(publicKeyBytes);
             var privateKeyBase64 = Convert.ToBase64String(privateKeyBytes);
 
+            // EXEC() でラップし、冪等スクリプトでのパース時カラム解決エラーを回避
+            // (後続マイグレーションで rsa_key_pair.client_id → organization_id にリネームされるため)
             migrationBuilder.Sql($@"
-                INSERT INTO dbo.rsa_key_pair (client_id, public_key, private_key)
-                SELECT
-                    c.id,
-                    '{publicKeyBase64}',
-                    '{privateKeyBase64}'
-                FROM dbo.client c
-                WHERE c.client_id = '{ECCUBE2_CLIENT_ID}'
-                AND NOT EXISTS (SELECT 1 FROM dbo.rsa_key_pair r WHERE r.client_id = c.id)
+                EXEC(N'
+                    INSERT INTO dbo.rsa_key_pair (client_id, public_key, private_key)
+                    SELECT
+                        c.id,
+                        ''{publicKeyBase64}'',
+                        ''{privateKeyBase64}''
+                    FROM dbo.client c
+                    WHERE c.client_id = ''{ECCUBE2_CLIENT_ID}''
+                    AND NOT EXISTS (SELECT 1 FROM dbo.rsa_key_pair r WHERE r.client_id = c.id)
+                ')
             ");
 
             // 4. OpenIdProvider（MockIdP）を挿入


### PR DESCRIPTION
## Summary
- 冪等スクリプト(`--idempotent`)で全マイグレーションが1バッチにまとめられた際、`ChangeRsaKeyPairToOrganization` で `client_id` が削除された後のスキーマでパース時にカラム解決エラーが発生していた
- `EXEC()` でラップして名前解決を実行時まで遅延させることで解決

## 対象マイグレーション
- `InsertTestRsaKeyPairs` — `rsa_key_pair.client_id` の IF NOT EXISTS + INSERT
- `InsertStagingOrganizationAndClient` — `rsa_key_pair.client_id` の JOIN + INSERT
- `InsertEcCube2PluginClient` — `rsa_key_pair.client_id` の INSERT + NOT EXISTS

## Test plan
- [x] `dotnet build` が成功すること
- [x] `dotnet ef migrations script --idempotent` がエラーなく生成できること
- [x] staging / production のマイグレーションワークフローが成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **その他（Chores）**
  * データベース移行スクリプトの実行プロセスを改善しました。テスト用キーペア、ステージング環境の設定、およびプラグインクライアント初期化に関連するデータベース移行の処理が最適化されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->