### PR TITLE
feat(platform): 共通API基盤の構築と Client ID テナント自動解決

### DIFF
--- a/E2ETests/tests/specs/platform_client_resolve.spec.ts
+++ b/E2ETests/tests/specs/platform_client_resolve.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect, APIRequestContext, request } from '@playwright/test';
+
+test.describe('Platform API: client-resolve エンドポイントのE2Eテスト', () => {
+  const baseUrl = process.env.E2E_BASE_URL || 'https://localhost:8081';
+  const clientResolveEndpoint = `${baseUrl}/platform/v1/client-resolve`;
+  const clientId = process.env.DEFAULT_CLIENT_ID || 'client_id';
+
+  let apiContext: APIRequestContext;
+
+  test.beforeAll(async () => {
+    apiContext = await request.newContext({
+      ignoreHTTPSErrors: true,
+    });
+  });
+
+  test.afterAll(async () => {
+    await apiContext.dispose();
+  });
+
+  test('正常系: 有効な client_id でテナント情報が返る', async () => {
+    const response = await apiContext.get(clientResolveEndpoint, {
+      params: { client_id: clientId },
+    });
+
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+    console.log('client-resolve response:', JSON.stringify(body, null, 2));
+
+    expect(body).toHaveProperty('tenant_name');
+    expect(body).toHaveProperty('base_url');
+    expect(body).toHaveProperty('organization_name');
+
+    expect(typeof body.tenant_name).toBe('string');
+    expect(body.tenant_name.length).toBeGreaterThan(0);
+    expect(body.base_url).toContain(body.tenant_name);
+    expect(body.base_url).toMatch(/^https:\/\//);
+  });
+
+  test('異常系: 存在しない client_id で 404 が返る', async () => {
+    const response = await apiContext.get(clientResolveEndpoint, {
+      params: { client_id: 'nonexistent-client-id-12345' },
+    });
+
+    expect(response.status()).toBe(404);
+
+    const body = await response.json();
+    expect(body).toHaveProperty('error', 'not_found');
+    expect(body).toHaveProperty('error_description');
+  });
+
+  test('バリデーション: client_id パラメータなしで 400 が返る', async () => {
+    const response = await apiContext.get(clientResolveEndpoint);
+
+    expect(response.status()).toBe(400);
+
+    const body = await response.json();
+    expect(body).toHaveProperty('error', 'invalid_request');
+    expect(body).toHaveProperty('error_description');
+  });
+
+  test('バリデーション: 空の client_id で 400 が返る', async () => {
+    const response = await apiContext.get(clientResolveEndpoint, {
+      params: { client_id: '' },
+    });
+
+    expect(response.status()).toBe(400);
+
+    const body = await response.json();
+    expect(body).toHaveProperty('error', 'invalid_request');
+  });
+
+  test('CORS: Origin ヘッダ付きリクエストで CORS レスポンスヘッダが返る', async () => {
+    const corsContext = await request.newContext({
+      ignoreHTTPSErrors: true,
+      extraHTTPHeaders: {
+        'Origin': 'https://ec-auth.io',
+      },
+    });
+
+    const response = await corsContext.get(clientResolveEndpoint, {
+      params: { client_id: clientId },
+    });
+
+    expect(response.status()).toBe(200);
+
+    const headers = response.headers();
+    console.log('CORS response headers:', JSON.stringify(headers, null, 2));
+
+    expect(headers['access-control-allow-origin']).toBe('https://ec-auth.io');
+
+    await corsContext.dispose();
+  });
+
+  test('テナントスコープAPI への影響がないことを確認', async () => {
+    // /platform/ 以外の既存エンドポイントが正常に動作することを確認
+    const tokenEndpoint = process.env.E2E_TOKEN_ENDPOINT || `${baseUrl}/v1/token`;
+    const response = await apiContext.post(tokenEndpoint, {
+      form: {
+        grant_type: 'authorization_code',
+        code: 'invalid-code',
+        redirect_uri: 'https://localhost:8081/callback',
+        client_id: clientId,
+      },
+    });
+
+    // invalid-code なので 400 が返るが、エンドポイント自体は動作している
+    expect(response.status()).toBe(400);
+    const body = await response.json();
+    expect(body).toHaveProperty('error');
+  });
+});

--- a/E2ETests/tests/specs/platform_client_resolve.spec.ts
+++ b/E2ETests/tests/specs/platform_client_resolve.spec.ts
@@ -71,10 +71,14 @@ test.describe('Platform API: client-resolve エンドポイントのE2Eテスト
   });
 
   test('CORS: Origin ヘッダ付きリクエストで CORS レスポンスヘッダが返る', async () => {
+    // CI 環境（Development）では AllowedOrigins に baseUrl が含まれる
+    // 本番環境では https://ec-auth.io が含まれる
+    const origin = new URL(baseUrl).origin;
+
     const corsContext = await request.newContext({
       ignoreHTTPSErrors: true,
       extraHTTPHeaders: {
-        'Origin': 'https://ec-auth.io',
+        'Origin': origin,
       },
     });
 
@@ -87,7 +91,7 @@ test.describe('Platform API: client-resolve エンドポイントのE2Eテスト
     const headers = response.headers();
     console.log('CORS response headers:', JSON.stringify(headers, null, 2));
 
-    expect(headers['access-control-allow-origin']).toBe('https://ec-auth.io');
+    expect(headers['access-control-allow-origin']).toBe(origin);
 
     await corsContext.dispose();
   });

--- a/IdentityProvider.Test/Controllers/Platform/ClientResolveControllerTests.cs
+++ b/IdentityProvider.Test/Controllers/Platform/ClientResolveControllerTests.cs
@@ -1,0 +1,159 @@
+using IdentityProvider.Controllers.Platform;
+using IdentityProvider.Models;
+using IdentityProvider.Test.TestHelpers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace IdentityProvider.Test.Controllers.Platform
+{
+    public class ClientResolveControllerTests : IDisposable
+    {
+        private readonly EcAuthDbContext _context;
+        private readonly IConfiguration _configuration;
+        private readonly Mock<ILogger<ClientResolveController>> _mockLogger;
+        private readonly ClientResolveController _controller;
+
+        public ClientResolveControllerTests()
+        {
+            _context = TestDbContextHelper.CreateInMemoryContext();
+            _configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    { "PlatformApi:BaseDomain", "ec-auth.io" }
+                })
+                .Build();
+            _mockLogger = new Mock<ILogger<ClientResolveController>>();
+            _controller = new ClientResolveController(_context, _configuration, _mockLogger.Object);
+
+            SeedTestData();
+        }
+
+        private void SeedTestData()
+        {
+            var organization = new Organization
+            {
+                Id = 1,
+                Code = "shop1",
+                Name = "ショップ1",
+                TenantName = "shop1",
+            };
+            _context.Organizations.Add(organization);
+
+            var client = new Client
+            {
+                Id = 1,
+                ClientId = "test-client-id",
+                ClientSecret = "test-secret",
+                AppName = "Test App",
+                OrganizationId = 1,
+            };
+            _context.Clients.Add(client);
+
+            var clientWithoutOrg = new Client
+            {
+                Id = 2,
+                ClientId = "orphan-client-id",
+                ClientSecret = "test-secret",
+                AppName = "Orphan App",
+                OrganizationId = null,
+            };
+            _context.Clients.Add(clientWithoutOrg);
+
+            _context.SaveChanges();
+        }
+
+        [Fact]
+        public async Task Resolve_ValidClientId_ReturnsOkWithTenantInfo()
+        {
+            var result = await _controller.Resolve("test-client-id");
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal(200, okResult.StatusCode);
+
+            var value = okResult.Value;
+            var tenantName = value!.GetType().GetProperty("tenant_name")!.GetValue(value)!.ToString();
+            var baseUrl = value.GetType().GetProperty("base_url")!.GetValue(value)!.ToString();
+            var orgName = value.GetType().GetProperty("organization_name")!.GetValue(value)!.ToString();
+
+            Assert.Equal("shop1", tenantName);
+            Assert.Equal("https://shop1.ec-auth.io", baseUrl);
+            Assert.Equal("ショップ1", orgName);
+        }
+
+        [Fact]
+        public async Task Resolve_UnknownClientId_ReturnsNotFound()
+        {
+            var result = await _controller.Resolve("nonexistent-client-id");
+
+            var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
+            Assert.Equal(404, notFoundResult.StatusCode);
+        }
+
+        [Fact]
+        public async Task Resolve_EmptyClientId_ReturnsBadRequest()
+        {
+            var result = await _controller.Resolve("");
+
+            var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Equal(400, badRequestResult.StatusCode);
+        }
+
+        [Fact]
+        public async Task Resolve_NullClientId_ReturnsBadRequest()
+        {
+            var result = await _controller.Resolve(null);
+
+            var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Equal(400, badRequestResult.StatusCode);
+        }
+
+        [Fact]
+        public async Task Resolve_ClientWithoutOrganization_ReturnsNotFound()
+        {
+            var result = await _controller.Resolve("orphan-client-id");
+
+            var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
+            Assert.Equal(404, notFoundResult.StatusCode);
+        }
+
+        [Fact]
+        public async Task Resolve_UsesConfiguredBaseDomain()
+        {
+            var customConfig = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    { "PlatformApi:BaseDomain", "staging.ec-auth.io" }
+                })
+                .Build();
+            var controller = new ClientResolveController(_context, customConfig, _mockLogger.Object);
+
+            var result = await controller.Resolve("test-client-id");
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var value = okResult.Value;
+            var baseUrl = value!.GetType().GetProperty("base_url")!.GetValue(value)!.ToString();
+            Assert.Equal("https://shop1.staging.ec-auth.io", baseUrl);
+        }
+
+        [Fact]
+        public async Task Resolve_DefaultBaseDomainWhenNotConfigured()
+        {
+            var emptyConfig = new ConfigurationBuilder().Build();
+            var controller = new ClientResolveController(_context, emptyConfig, _mockLogger.Object);
+
+            var result = await controller.Resolve("test-client-id");
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var value = okResult.Value;
+            var baseUrl = value!.GetType().GetProperty("base_url")!.GetValue(value)!.ToString();
+            Assert.Equal("https://shop1.ec-auth.io", baseUrl);
+        }
+
+        public void Dispose()
+        {
+            _context.Dispose();
+        }
+    }
+}

--- a/IdentityProvider.Test/Middlewares/TenantMiddlewareTests.cs
+++ b/IdentityProvider.Test/Middlewares/TenantMiddlewareTests.cs
@@ -1,0 +1,106 @@
+using IdentityProvider.Middlewares;
+using IdentityProvider.Test.TestHelpers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace IdentityProvider.Test.Middlewares
+{
+    public class TenantMiddlewareTests
+    {
+        private readonly Mock<ILogger<TenantMiddleware>> _mockLogger;
+
+        public TenantMiddlewareTests()
+        {
+            _mockLogger = new Mock<ILogger<TenantMiddleware>>();
+        }
+
+        [Fact]
+        public async Task InvokeAsync_PlatformPath_SkipsTenantResolution()
+        {
+            var tenantService = new MockTenantService();
+            var nextCalled = false;
+            RequestDelegate next = (context) =>
+            {
+                nextCalled = true;
+                return Task.CompletedTask;
+            };
+
+            var middleware = new TenantMiddleware(next, _mockLogger.Object);
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/platform/v1/client-resolve";
+            context.Request.Host = new HostString("tenant1.ec-auth.io");
+
+            await middleware.InvokeAsync(context, tenantService);
+
+            Assert.True(nextCalled);
+            // テナント解決がスキップされたため、デフォルト値のまま
+            Assert.Equal("test-tenant", tenantService.TenantName);
+        }
+
+        [Fact]
+        public async Task InvokeAsync_PlatformRootPath_SkipsTenantResolution()
+        {
+            var tenantService = new MockTenantService();
+            RequestDelegate next = (context) => Task.CompletedTask;
+
+            var middleware = new TenantMiddleware(next, _mockLogger.Object);
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/platform";
+            context.Request.Host = new HostString("tenant1.ec-auth.io");
+
+            await middleware.InvokeAsync(context, tenantService);
+
+            Assert.Equal("test-tenant", tenantService.TenantName);
+        }
+
+        [Fact]
+        public async Task InvokeAsync_NonPlatformPath_SetsTenant()
+        {
+            var tenantService = new MockTenantService();
+            RequestDelegate next = (context) => Task.CompletedTask;
+
+            var middleware = new TenantMiddleware(next, _mockLogger.Object);
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/v1/token";
+            context.Request.Host = new HostString("shop1.ec-auth.io");
+
+            await middleware.InvokeAsync(context, tenantService);
+
+            Assert.Equal("shop1", tenantService.TenantName);
+        }
+
+        [Fact]
+        public async Task InvokeAsync_PlatformXPath_DoesNotSkipTenantResolution()
+        {
+            var tenantService = new MockTenantService();
+            RequestDelegate next = (context) => Task.CompletedTask;
+
+            var middleware = new TenantMiddleware(next, _mockLogger.Object);
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/platformx/something";
+            context.Request.Host = new HostString("shop1.ec-auth.io");
+
+            await middleware.InvokeAsync(context, tenantService);
+
+            // /platformx はセグメント境界にマッチしないため、通常のテナント解決が実行される
+            Assert.Equal("shop1", tenantService.TenantName);
+        }
+
+        [Fact]
+        public async Task InvokeAsync_PlatformNestedPath_SkipsTenantResolution()
+        {
+            var tenantService = new MockTenantService();
+            RequestDelegate next = (context) => Task.CompletedTask;
+
+            var middleware = new TenantMiddleware(next, _mockLogger.Object);
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/platform/v1/signup/request";
+            context.Request.Host = new HostString("shop1.ec-auth.io");
+
+            await middleware.InvokeAsync(context, tenantService);
+
+            Assert.Equal("test-tenant", tenantService.TenantName);
+        }
+    }
+}

--- a/IdentityProvider/Constants/PlatformApiConstants.cs
+++ b/IdentityProvider/Constants/PlatformApiConstants.cs
@@ -1,0 +1,9 @@
+namespace IdentityProvider.Constants
+{
+    public static class PlatformApiConstants
+    {
+        public const string PathPrefix = "/platform";
+        public const string RoutePrefix = "platform";
+        public const string CorsPolicy = "PlatformApiCors";
+    }
+}

--- a/IdentityProvider/Controllers/Platform/ClientResolveController.cs
+++ b/IdentityProvider/Controllers/Platform/ClientResolveController.cs
@@ -1,0 +1,73 @@
+using IdentityProvider.Constants;
+using IdentityProvider.Models;
+using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace IdentityProvider.Controllers.Platform
+{
+    [Route(PlatformApiConstants.RoutePrefix + "/v{version:apiVersion}/client-resolve")]
+    [ApiController]
+    [ApiVersion("1.0")]
+    public class ClientResolveController : ControllerBase
+    {
+        private readonly EcAuthDbContext _context;
+        private readonly IConfiguration _configuration;
+        private readonly ILogger<ClientResolveController> _logger;
+
+        public ClientResolveController(
+            EcAuthDbContext context,
+            IConfiguration configuration,
+            ILogger<ClientResolveController> logger)
+        {
+            _context = context;
+            _configuration = configuration;
+            _logger = logger;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Resolve([FromQuery] string? client_id)
+        {
+            if (string.IsNullOrWhiteSpace(client_id))
+            {
+                return BadRequest(new
+                {
+                    error = "invalid_request",
+                    error_description = "client_id パラメータは必須です。"
+                });
+            }
+
+            var result = await _context.Clients
+                .IgnoreQueryFilters()
+                .Where(c => c.ClientId == client_id)
+                .Select(c => new
+                {
+                    TenantName = c.Organization != null ? c.Organization.TenantName : null,
+                    OrganizationName = c.Organization != null ? c.Organization.Name : null,
+                })
+                .FirstOrDefaultAsync();
+
+            if (result == null || result.TenantName == null)
+            {
+                _logger.LogWarning("Client not found or has no organization: client_id={ClientId}", client_id);
+                return NotFound(new
+                {
+                    error = "not_found",
+                    error_description = "指定された client_id に対応するテナントが見つかりません。"
+                });
+            }
+
+            var baseDomain = _configuration["PlatformApi:BaseDomain"] ?? "ec-auth.io";
+            var baseUrl = $"https://{result.TenantName}.{baseDomain}";
+
+            _logger.LogInformation("Client resolved: client_id={ClientId}, tenant={TenantName}", client_id, result.TenantName);
+
+            return Ok(new
+            {
+                tenant_name = result.TenantName,
+                base_url = baseUrl,
+                organization_name = result.OrganizationName
+            });
+        }
+    }
+}

--- a/IdentityProvider/Middlewares/TenantMiddleware.cs
+++ b/IdentityProvider/Middlewares/TenantMiddleware.cs
@@ -1,3 +1,4 @@
+using IdentityProvider.Constants;
 using IdentityProvider.Services;
 using System.Net;
 
@@ -16,6 +17,13 @@ namespace IdentityProvider.Middlewares
 
         public async Task InvokeAsync(HttpContext context, ITenantService tenantService)
         {
+            // 共通APIパスはテナント解決をスキップ
+            if (context.Request.Path.StartsWithSegments(PlatformApiConstants.PathPrefix))
+            {
+                await _next(context);
+                return;
+            }
+
             var host = context.Request.Host.Host;
             var tenantName = ExtractTenantNameFromHost(host);
             var defaultOrganizationTenantName = Environment.GetEnvironmentVariable("DEFAULT_ORGANIZATION_TENANT_NAME") ?? string.Empty;

--- a/IdentityProvider/Program.cs
+++ b/IdentityProvider/Program.cs
@@ -72,12 +72,12 @@ builder.Services.AddCors(options =>
 {
     options.AddPolicy(PlatformApiConstants.CorsPolicy, policy =>
     {
-        var allowedOrigins = builder.Configuration.GetSection("PlatformApi:AllowedOrigins")
-            .Get<string[]>() ?? new[] { "https://ec-auth.io", "https://*.ec-auth.io" };
+        var allowedOrigins = builder.Configuration.GetSection("PlatformApi:AllowedOrigins").Get<string[]>()
+            ?? throw new InvalidOperationException("PlatformApi:AllowedOrigins が appsettings に定義されていません。");
         policy.WithOrigins(allowedOrigins)
               .SetIsOriginAllowedToAllowWildcardSubdomains()
               .AllowAnyHeader()
-              .AllowAnyMethod();
+              .WithMethods("GET", "OPTIONS");
     });
 });
 builder.Services.AddControllers();

--- a/IdentityProvider/Program.cs
+++ b/IdentityProvider/Program.cs
@@ -1,4 +1,5 @@
 using Fido2NetLib;
+using IdentityProvider.Constants;
 using IdentityProvider.Data;
 using IdentityProvider.Data.Seeders;
 using IdentityProvider.Filters;
@@ -66,6 +67,19 @@ builder.Services.AddApiVersioning(options =>
 {
     options.SubstituteApiVersionInUrl = true;
 });
+// Platform API（テナント横断）の CORS 設定
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy(PlatformApiConstants.CorsPolicy, policy =>
+    {
+        var allowedOrigins = builder.Configuration.GetSection("PlatformApi:AllowedOrigins")
+            .Get<string[]>() ?? new[] { "https://ec-auth.io", "https://*.ec-auth.io" };
+        policy.WithOrigins(allowedOrigins)
+              .SetIsOriginAllowedToAllowWildcardSubdomains()
+              .AllowAnyHeader()
+              .AllowAnyMethod();
+    });
+});
 builder.Services.AddControllers();
 builder.Services.AddMvc();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
@@ -128,6 +142,12 @@ else
 {
     app.UseStaticFiles();
 }
+
+// Platform API の CORS ミドルウェア（/platform/ パスのみ適用）
+app.UseWhen(
+    context => context.Request.Path.StartsWithSegments(PlatformApiConstants.PathPrefix),
+    appBuilder => appBuilder.UseCors(PlatformApiConstants.CorsPolicy)
+);
 
 app.UseMiddleware<TenantMiddleware>();
 

--- a/IdentityProvider/appsettings.Development.json
+++ b/IdentityProvider/appsettings.Development.json
@@ -4,5 +4,9 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "PlatformApi": {
+    "BaseDomain": "localhost:8081",
+    "AllowedOrigins": ["http://localhost:3000", "https://localhost:8081"]
   }
 }

--- a/IdentityProvider/appsettings.json
+++ b/IdentityProvider/appsettings.json
@@ -5,5 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "PlatformApi": {
+    "BaseDomain": "ec-auth.io",
+    "AllowedOrigins": ["https://ec-auth.io", "https://*.ec-auth.io"]
+  }
 }


### PR DESCRIPTION
## Summary

- テナント横断で動作する共通API基盤を `/platform/` パスプレフィックスで構築
- `GET /platform/v1/client-resolve?client_id=xxx` エンドポイントで Client ID から Organization（テナント）情報を逆引き
- EC-CUBEプラグインの設定画面簡素化（Client ID + Client Secret のみで設定完了）の基盤

## Changes

- **`PlatformApiConstants`**: パスプレフィックス・CORSポリシー名の定数を一元管理
- **`TenantMiddleware`**: `/platform` パスでテナント解決をスキップ
- **`Program.cs`**: Platform API 用の CORS 設定（`ec-auth.io` からの API 呼び出し許可）
- **`ClientResolveController`**: `IgnoreQueryFilters()` でテナント横断クエリを実行し、`tenant_name`, `base_url`, `organization_name` を返却
- **`appsettings.json`**: `PlatformApi` セクション追加（`BaseDomain`, `AllowedOrigins`）
- **ユニットテスト**: TenantMiddleware テスト（5件）+ ClientResolveController テスト（7件）
- **E2Eテスト**: platform_client_resolve.spec.ts（6件）

## Test plan

- [x] `dotnet build` ビルド成功
- [x] `dotnet test` 全 515 テスト成功
- [x] Docker 環境で `curl -k https://localhost:8081/platform/v1/client-resolve?client_id=<client_id>` の動作確認
- [x] E2Eテスト `pnpm exec playwright test tests/specs/platform_client_resolve.spec.ts` の実行
- [x] 既存テナントスコープAPI（`/v1/token` 等）への影響がないことを確認

## Related issues

- Closes EcAuth/EcAuth#342
- Refs EcAuth/EcAuthDocs#58

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Platform API に `/platform/v1/client-resolve` エンドポイントを追加。クライアントIDでテナント名、ベースURL、組織名を取得可能。
  * Platform API リクエストではテナント解決処理をスキップするよう動作を調整。

* **設定**
  * Platform API 用のベースドメインと許可オリジンを設定で追加し、プラットフォーム専用のCORSポリシーを導入。

* **テスト**
  * 新エンドポイントとミドルウェア挙動を網羅する統合・単体テストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->