### PR TITLE
feat(b2b-passkey): external_id 自動同期と resolved_subject フィールドを追加 (#359 Phase 1)

### DIFF
--- a/IdentityProvider.Test/Controllers/B2BPasskeyControllerTests.cs
+++ b/IdentityProvider.Test/Controllers/B2BPasskeyControllerTests.cs
@@ -279,8 +279,11 @@ namespace IdentityProvider.Test.Controllers
             var error = response.GetType().GetProperty("error")?.GetValue(response);
             Assert.Equal("external_id_conflict", error);
 
-            var errorDescription = response.GetType().GetProperty("error_description")?.GetValue(response);
-            Assert.Contains("conflicting-id", (string?)errorDescription);
+            // レスポンスには external_id 値を含めず固定文言を返す（列挙攻撃対策）
+            var errorDescription = response.GetType().GetProperty("error_description")?.GetValue(response) as string;
+            Assert.NotNull(errorDescription);
+            Assert.DoesNotContain("conflicting-id", errorDescription);
+            Assert.Contains("another user", errorDescription);
         }
 
         [Fact]

--- a/IdentityProvider.Test/Controllers/B2BPasskeyControllerTests.cs
+++ b/IdentityProvider.Test/Controllers/B2BPasskeyControllerTests.cs
@@ -1,6 +1,7 @@
 using Fido2NetLib;
 using Fido2NetLib.Objects;
 using IdentityProvider.Controllers;
+using IdentityProvider.Exceptions;
 using IdentityProvider.Models;
 using IdentityProvider.Services;
 using Microsoft.AspNetCore.Http;
@@ -202,6 +203,84 @@ namespace IdentityProvider.Test.Controllers
 
             var error = response.GetType().GetProperty("error")?.GetValue(response);
             Assert.Equal("server_error", error);
+        }
+
+        [Fact]
+        public async Task RegisterOptions_ValidRequest_ReturnsResolvedSubjectAndResolution()
+        {
+            // Arrange
+            var client = await CreateTestClientAsync();
+
+            var request = new B2BPasskeyController.RegisterOptionsRequest
+            {
+                ClientId = client.ClientId,
+                ClientSecret = client.ClientSecret!,
+                RpId = "shop.example.com",
+                B2BSubject = "550e8400-e29b-41d4-a716-446655440000",
+                ExternalId = "test-admin"
+            };
+
+            var expectedResult = new RegistrationOptionsResult
+            {
+                SessionId = "sess-id",
+                Options = CreateMockCredentialCreateOptions(),
+                IsProvisioned = false,
+                ResolvedSubject = "550e8400-e29b-41d4-a716-446655440000",
+                SubjectResolution = SubjectResolutions.AsRequested
+            };
+
+            _mockPasskeyService.Setup(x => x.CreateRegistrationOptionsAsync(It.IsAny<RegistrationOptionsRequest>()))
+                .ReturnsAsync(expectedResult);
+
+            // Act
+            var result = await _controller.RegisterOptions(request);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var response = okResult.Value;
+            Assert.NotNull(response);
+
+            var resolvedSubject = response.GetType().GetProperty("resolved_subject")?.GetValue(response);
+            Assert.Equal("550e8400-e29b-41d4-a716-446655440000", resolvedSubject);
+
+            var subjectResolution = response.GetType().GetProperty("subject_resolution")?.GetValue(response);
+            Assert.Equal("as_requested", subjectResolution);
+        }
+
+        [Fact]
+        public async Task RegisterOptions_ExternalIdConflict_Returns409Conflict()
+        {
+            // Arrange
+            var client = await CreateTestClientAsync();
+
+            var request = new B2BPasskeyController.RegisterOptionsRequest
+            {
+                ClientId = client.ClientId,
+                ClientSecret = client.ClientSecret!,
+                RpId = "shop.example.com",
+                B2BSubject = "550e8400-e29b-41d4-a716-446655440000",
+                ExternalId = "conflicting-id"
+            };
+
+            _mockPasskeyService.Setup(x => x.CreateRegistrationOptionsAsync(It.IsAny<RegistrationOptionsRequest>()))
+                .ThrowsAsync(new ExternalIdConflictException(
+                    "ExternalId 'conflicting-id' is already used by another user in this organization."));
+
+            // Act
+            var result = await _controller.RegisterOptions(request);
+
+            // Assert
+            var conflictResult = Assert.IsType<ConflictObjectResult>(result);
+            Assert.Equal(409, conflictResult.StatusCode);
+
+            var response = conflictResult.Value;
+            Assert.NotNull(response);
+
+            var error = response.GetType().GetProperty("error")?.GetValue(response);
+            Assert.Equal("external_id_conflict", error);
+
+            var errorDescription = response.GetType().GetProperty("error_description")?.GetValue(response);
+            Assert.Contains("conflicting-id", (string?)errorDescription);
         }
 
         [Fact]

--- a/IdentityProvider.Test/Services/B2BPasskeyServiceTests.cs
+++ b/IdentityProvider.Test/Services/B2BPasskeyServiceTests.cs
@@ -1,5 +1,6 @@
 using Fido2NetLib;
 using Fido2NetLib.Objects;
+using IdentityProvider.Exceptions;
 using IdentityProvider.Models;
 using IdentityProvider.Services;
 using IdentityProvider.Test.TestHelpers;
@@ -511,6 +512,210 @@ namespace IdentityProvider.Test.Services
             // resolvedSubject（既存ユーザーのSubject）がチャレンジに使われること
             Assert.NotNull(capturedChallengeRequest);
             Assert.Equal(existingSubject, capturedChallengeRequest.Subject);
+        }
+
+        [Fact]
+        public async Task CreateRegistrationOptionsAsync_SubjectHit_ExternalIdMatches_ReturnsAsRequestedResolution()
+        {
+            // Arrange: subject 一致 + external_id 一致 → 同期なし、subject_resolution = "as_requested"
+            var request = new IB2BPasskeyService.RegistrationOptionsRequest
+            {
+                ClientId = "test-client-id",
+                RpId = "shop.example.com",
+                B2BSubject = TestB2BSubject,
+                ExternalId = "admin@example.com" // _testUser と一致
+            };
+
+            _mockUserService.Setup(x => x.GetBySubjectAsync(TestB2BSubject))
+                .ReturnsAsync(_testUser);
+
+            var challengeResult = new IWebAuthnChallengeService.ChallengeResult
+            {
+                SessionId = "sess-as-req",
+                Challenge = "dGVzdC1jaGFsbGVuZ2U",
+                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5)
+            };
+            _mockChallengeService.Setup(x => x.GenerateChallengeAsync(It.IsAny<IWebAuthnChallengeService.ChallengeRequest>()))
+                .ReturnsAsync(challengeResult);
+
+            // Act
+            var result = await _service.CreateRegistrationOptionsAsync(request);
+
+            // Assert
+            Assert.Equal(TestB2BSubject, result.ResolvedSubject);
+            Assert.Equal(IB2BPasskeyService.SubjectResolutions.AsRequested, result.SubjectResolution);
+            Assert.False(result.IsProvisioned);
+            // external_id が一致しているので UpdateAsync は呼ばれない
+            _mockUserService.Verify(x => x.UpdateAsync(It.IsAny<IB2BUserService.UpdateUserRequest>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task CreateRegistrationOptionsAsync_SubjectHit_ExternalIdDiffers_SyncsExternalId()
+        {
+            // Arrange: subject 一致 + external_id 差分 → UpdateAsync が呼ばれ external_id が新値に同期
+            var request = new IB2BPasskeyService.RegistrationOptionsRequest
+            {
+                ClientId = "test-client-id",
+                RpId = "shop.example.com",
+                B2BSubject = TestB2BSubject,
+                ExternalId = "renamed-admin@example.com" // _testUser.ExternalId = "admin@example.com" と異なる
+            };
+
+            _mockUserService.Setup(x => x.GetBySubjectAsync(TestB2BSubject))
+                .ReturnsAsync(_testUser);
+            // 衝突する他ユーザーはいない
+            _mockUserService.Setup(x => x.GetByExternalIdAsync("renamed-admin@example.com", 1))
+                .ReturnsAsync((B2BUser?)null);
+
+            var updatedUser = new B2BUser
+            {
+                Id = _testUser.Id,
+                Subject = _testUser.Subject,
+                ExternalId = "renamed-admin@example.com",
+                UserType = _testUser.UserType,
+                OrganizationId = _testUser.OrganizationId,
+                Organization = _organization
+            };
+            _mockUserService.Setup(x => x.UpdateAsync(It.IsAny<IB2BUserService.UpdateUserRequest>()))
+                .ReturnsAsync(updatedUser);
+
+            var challengeResult = new IWebAuthnChallengeService.ChallengeResult
+            {
+                SessionId = "sess-sync",
+                Challenge = "dGVzdC1jaGFsbGVuZ2U",
+                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5)
+            };
+            _mockChallengeService.Setup(x => x.GenerateChallengeAsync(It.IsAny<IWebAuthnChallengeService.ChallengeRequest>()))
+                .ReturnsAsync(challengeResult);
+
+            // Act
+            var result = await _service.CreateRegistrationOptionsAsync(request);
+
+            // Assert
+            Assert.Equal(TestB2BSubject, result.ResolvedSubject);
+            Assert.Equal(IB2BPasskeyService.SubjectResolutions.AsRequested, result.SubjectResolution);
+            _mockUserService.Verify(x => x.UpdateAsync(It.Is<IB2BUserService.UpdateUserRequest>(r =>
+                r.Subject == TestB2BSubject && r.ExternalId == "renamed-admin@example.com")), Times.Once);
+        }
+
+        [Fact]
+        public async Task CreateRegistrationOptionsAsync_SubjectHit_ExternalIdCollidesWithOtherUser_ThrowsExternalIdConflict()
+        {
+            // Arrange: subject A は external_id X、別ユーザー subject B が既に external_id Y を持っている。
+            // A に Y を同期しようとすると 409 相当の衝突
+            var otherUser = new B2BUser
+            {
+                Id = 2,
+                Subject = TestB2BSubject2,
+                ExternalId = "other-admin@example.com",
+                UserType = "admin",
+                OrganizationId = 1,
+                Organization = _organization
+            };
+
+            var request = new IB2BPasskeyService.RegistrationOptionsRequest
+            {
+                ClientId = "test-client-id",
+                RpId = "shop.example.com",
+                B2BSubject = TestB2BSubject,
+                ExternalId = "other-admin@example.com" // 既に otherUser が使用中
+            };
+
+            _mockUserService.Setup(x => x.GetBySubjectAsync(TestB2BSubject))
+                .ReturnsAsync(_testUser);
+            _mockUserService.Setup(x => x.GetByExternalIdAsync("other-admin@example.com", 1))
+                .ReturnsAsync(otherUser);
+
+            // Act & Assert
+            var ex = await Assert.ThrowsAsync<ExternalIdConflictException>(() =>
+                _service.CreateRegistrationOptionsAsync(request));
+            Assert.Contains("other-admin@example.com", ex.Message);
+            _mockUserService.Verify(x => x.UpdateAsync(It.IsAny<IB2BUserService.UpdateUserRequest>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task CreateRegistrationOptionsAsync_SubjectMissExternalIdHit_ReturnsFallbackResolution()
+        {
+            // Arrange: 新 subject UUID だが external_id は既存ユーザーに紐付いている
+            var newSubject = "770e8400-e29b-41d4-a716-446655440099";
+            var request = new IB2BPasskeyService.RegistrationOptionsRequest
+            {
+                ClientId = "test-client-id",
+                RpId = "shop.example.com",
+                B2BSubject = newSubject,
+                ExternalId = "admin@example.com"
+            };
+
+            _mockUserService.Setup(x => x.GetBySubjectAsync(newSubject))
+                .ReturnsAsync((B2BUser?)null);
+            _mockUserService.Setup(x => x.GetByExternalIdAsync("admin@example.com", 1))
+                .ReturnsAsync(_testUser);
+
+            var challengeResult = new IWebAuthnChallengeService.ChallengeResult
+            {
+                SessionId = "sess-fallback",
+                Challenge = "dGVzdC1jaGFsbGVuZ2U",
+                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5)
+            };
+            _mockChallengeService.Setup(x => x.GenerateChallengeAsync(It.IsAny<IWebAuthnChallengeService.ChallengeRequest>()))
+                .ReturnsAsync(challengeResult);
+
+            // Act
+            var result = await _service.CreateRegistrationOptionsAsync(request);
+
+            // Assert: resolved_subject はリクエストの新 UUID ではなく既存ユーザーの subject
+            Assert.Equal(TestB2BSubject, result.ResolvedSubject);
+            Assert.NotEqual(newSubject, result.ResolvedSubject);
+            Assert.Equal(IB2BPasskeyService.SubjectResolutions.FallbackByExternalId, result.SubjectResolution);
+            Assert.False(result.IsProvisioned);
+        }
+
+        [Fact]
+        public async Task CreateRegistrationOptionsAsync_SubjectMissExternalIdMiss_ReturnsProvisionedResolution()
+        {
+            // Arrange: JIT プロビジョニングで新規作成
+            var newSubject = "880e8400-e29b-41d4-a716-446655440099";
+            var request = new IB2BPasskeyService.RegistrationOptionsRequest
+            {
+                ClientId = "test-client-id",
+                RpId = "shop.example.com",
+                B2BSubject = newSubject,
+                ExternalId = "brand-new@example.com"
+            };
+
+            _mockUserService.Setup(x => x.GetBySubjectAsync(newSubject))
+                .ReturnsAsync((B2BUser?)null);
+            _mockUserService.Setup(x => x.GetByExternalIdAsync("brand-new@example.com", 1))
+                .ReturnsAsync((B2BUser?)null);
+
+            var newUser = new B2BUser
+            {
+                Id = 99,
+                Subject = newSubject,
+                ExternalId = "brand-new@example.com",
+                UserType = "admin",
+                OrganizationId = 1,
+                Organization = _organization
+            };
+            _mockUserService.Setup(x => x.CreateAsync(It.IsAny<IB2BUserService.CreateUserRequest>()))
+                .ReturnsAsync(new IB2BUserService.CreateUserResult { User = newUser });
+
+            var challengeResult = new IWebAuthnChallengeService.ChallengeResult
+            {
+                SessionId = "sess-provisioned",
+                Challenge = "dGVzdC1jaGFsbGVuZ2U",
+                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5)
+            };
+            _mockChallengeService.Setup(x => x.GenerateChallengeAsync(It.IsAny<IWebAuthnChallengeService.ChallengeRequest>()))
+                .ReturnsAsync(challengeResult);
+
+            // Act
+            var result = await _service.CreateRegistrationOptionsAsync(request);
+
+            // Assert
+            Assert.Equal(newSubject, result.ResolvedSubject);
+            Assert.Equal(IB2BPasskeyService.SubjectResolutions.Provisioned, result.SubjectResolution);
+            Assert.True(result.IsProvisioned);
         }
 
         [Fact]

--- a/IdentityProvider.Test/Services/B2BPasskeyServiceTests.cs
+++ b/IdentityProvider.Test/Services/B2BPasskeyServiceTests.cs
@@ -719,6 +719,77 @@ namespace IdentityProvider.Test.Services
         }
 
         [Fact]
+        public async Task CreateRegistrationOptionsAsync_JitRaceRefetch_SyncsExternalIdWhenDiffers()
+        {
+            // Arrange: 並行リクエストで先に別の external_id で user が作られ、
+            // 今回のリクエストは DbUpdateException → re-fetch で既存 user を取得するシナリオ。
+            // re-fetch で得た user.ExternalId が今回のリクエストと異なる場合、メインフロー同様に同期されること。
+            var contestedSubject = "990e8400-e29b-41d4-a716-446655440099";
+            var request = new IB2BPasskeyService.RegistrationOptionsRequest
+            {
+                ClientId = "test-client-id",
+                RpId = "shop.example.com",
+                B2BSubject = contestedSubject,
+                ExternalId = "winner@example.com" // re-fetch で取れる user の ExternalId と異なる
+            };
+
+            var preExistingUser = new B2BUser
+            {
+                Id = 50,
+                Subject = contestedSubject,
+                ExternalId = "loser@example.com", // 並行リクエストが先に書き込んだ値
+                UserType = "admin",
+                OrganizationId = 1,
+                Organization = _organization
+            };
+
+            // 1回目: null → JIT パスに入る。2回目(re-fetch): preExistingUser を返す。
+            _mockUserService.SetupSequence(x => x.GetBySubjectAsync(contestedSubject))
+                .ReturnsAsync((B2BUser?)null)
+                .ReturnsAsync(preExistingUser);
+
+            // JIT 前の external_id fallback 検索は null（まだ書かれていないタイミング）
+            _mockUserService.Setup(x => x.GetByExternalIdAsync("winner@example.com", 1))
+                .ReturnsAsync((B2BUser?)null);
+
+            // CreateAsync は並行リクエストが先に書いたため UNIQUE 違反
+            _mockUserService.Setup(x => x.CreateAsync(It.IsAny<IB2BUserService.CreateUserRequest>()))
+                .ThrowsAsync(new DbUpdateException("concurrent create", new Exception()));
+
+            // re-fetch 後の同期で呼ばれる UpdateAsync
+            var syncedUser = new B2BUser
+            {
+                Id = preExistingUser.Id,
+                Subject = contestedSubject,
+                ExternalId = "winner@example.com",
+                UserType = "admin",
+                OrganizationId = 1,
+                Organization = _organization
+            };
+            _mockUserService.Setup(x => x.UpdateAsync(It.IsAny<IB2BUserService.UpdateUserRequest>()))
+                .ReturnsAsync(syncedUser);
+
+            var challengeResult = new IWebAuthnChallengeService.ChallengeResult
+            {
+                SessionId = "sess-race-sync",
+                Challenge = "dGVzdC1jaGFsbGVuZ2U",
+                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5)
+            };
+            _mockChallengeService.Setup(x => x.GenerateChallengeAsync(It.IsAny<IWebAuthnChallengeService.ChallengeRequest>()))
+                .ReturnsAsync(challengeResult);
+
+            // Act
+            var result = await _service.CreateRegistrationOptionsAsync(request);
+
+            // Assert: race 経路でも external_id が同期され、AsRequested として返る
+            Assert.Equal(contestedSubject, result.ResolvedSubject);
+            Assert.Equal(IB2BPasskeyService.SubjectResolutions.AsRequested, result.SubjectResolution);
+            Assert.False(result.IsProvisioned);
+            _mockUserService.Verify(x => x.UpdateAsync(It.Is<IB2BUserService.UpdateUserRequest>(r =>
+                r.Subject == contestedSubject && r.ExternalId == "winner@example.com")), Times.Once);
+        }
+
+        [Fact]
         public async Task CreateRegistrationOptionsAsync_MissingExternalId_ShouldThrowArgumentException()
         {
             // Arrange

--- a/IdentityProvider.Test/Services/B2BPasskeyServiceTests.cs
+++ b/IdentityProvider.Test/Services/B2BPasskeyServiceTests.cs
@@ -396,7 +396,7 @@ namespace IdentityProvider.Test.Services
                 B2BSubject = TestB2BSubject,
                 DisplayName = "テスト管理者",
                 DeviceName = "MacBook Pro",
-                ExternalId = "test-admin"
+                ExternalId = "admin@example.com"
             };
 
             _mockUserService.Setup(x => x.GetBySubjectAsync(TestB2BSubject))
@@ -438,7 +438,7 @@ namespace IdentityProvider.Test.Services
                 B2BSubject = TestB2BSubject,
                 DisplayName = "テスト管理者",
                 DeviceName = "E2E Test Device",
-                ExternalId = "test-admin"
+                ExternalId = "admin@example.com"
             };
 
             _mockUserService.Setup(x => x.GetBySubjectAsync(TestB2BSubject))

--- a/IdentityProvider.Test/Services/B2BPasskeyServiceTests.cs
+++ b/IdentityProvider.Test/Services/B2BPasskeyServiceTests.cs
@@ -634,6 +634,49 @@ namespace IdentityProvider.Test.Services
         }
 
         [Fact]
+        public async Task CreateRegistrationOptionsAsync_SubjectHit_UserBelongsToDifferentOrganization_ThrowsInvalidOperation()
+        {
+            // Arrange: B2BUser の QueryFilter は TenantName ベースなので、
+            // 同一テナント内の別 Organization の subject が GetBySubjectAsync で返り得る。
+            // このクロス組織ケースで external_id の自動同期や credential 発行を許してはならない。
+            var crossOrgUser = new B2BUser
+            {
+                Id = 999,
+                Subject = TestB2BSubject,
+                ExternalId = "other-org-admin@example.com",
+                UserType = "admin",
+                OrganizationId = 999, // _client.OrganizationId = 1 とは異なる組織
+                Organization = new Organization
+                {
+                    Id = 999,
+                    Code = "other-org",
+                    Name = "別組織",
+                    TenantName = "test-tenant"
+                }
+            };
+
+            var request = new IB2BPasskeyService.RegistrationOptionsRequest
+            {
+                ClientId = "test-client-id",
+                RpId = "shop.example.com",
+                B2BSubject = TestB2BSubject,
+                ExternalId = "admin@example.com"
+            };
+
+            _mockUserService.Setup(x => x.GetBySubjectAsync(TestB2BSubject))
+                .ReturnsAsync(crossOrgUser);
+
+            // Act & Assert
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                _service.CreateRegistrationOptionsAsync(request));
+            Assert.Contains("not associated with this client's organization", ex.Message);
+
+            // 同期・衝突チェックは一切呼ばれないこと
+            _mockUserService.Verify(x => x.UpdateAsync(It.IsAny<IB2BUserService.UpdateUserRequest>()), Times.Never);
+            _mockUserService.Verify(x => x.GetByExternalIdAsync(It.IsAny<string>(), It.IsAny<int>()), Times.Never);
+        }
+
+        [Fact]
         public async Task CreateRegistrationOptionsAsync_SubjectMissExternalIdHit_ReturnsFallbackResolution()
         {
             // Arrange: 新 subject UUID だが external_id は既存ユーザーに紐付いている

--- a/IdentityProvider.Test/Services/B2BPasskeyServiceTests.cs
+++ b/IdentityProvider.Test/Services/B2BPasskeyServiceTests.cs
@@ -634,6 +634,82 @@ namespace IdentityProvider.Test.Services
         }
 
         [Fact]
+        public async Task CreateRegistrationOptionsAsync_SyncUpdateAsyncThrowsTransientError_RethrowsOriginalException()
+        {
+            // Arrange: UpdateAsync で DbUpdateException が発生するが、実状態再確認で
+            // 別ユーザーによる external_id の使用は無い（= 一意制約違反以外の過渡的障害）。
+            // このケースは 409 に吸収せず元の DbUpdateException を再スローすべき。
+            var request = new IB2BPasskeyService.RegistrationOptionsRequest
+            {
+                ClientId = "test-client-id",
+                RpId = "shop.example.com",
+                B2BSubject = TestB2BSubject,
+                ExternalId = "renamed-admin@example.com"
+            };
+
+            _mockUserService.Setup(x => x.GetBySubjectAsync(TestB2BSubject))
+                .ReturnsAsync(_testUser);
+
+            // 事前チェック・再確認の両方で別ユーザーは見つからない
+            _mockUserService.Setup(x => x.GetByExternalIdAsync("renamed-admin@example.com", 1))
+                .ReturnsAsync((B2BUser?)null);
+
+            var transientError = new DbUpdateException(
+                "transient DB error (e.g. timeout / deadlock)",
+                new Exception("inner"));
+            _mockUserService.Setup(x => x.UpdateAsync(It.IsAny<IB2BUserService.UpdateUserRequest>()))
+                .ThrowsAsync(transientError);
+
+            // Act & Assert: ExternalIdConflictException ではなく元の DbUpdateException が再スローされる
+            var ex = await Assert.ThrowsAsync<DbUpdateException>(() =>
+                _service.CreateRegistrationOptionsAsync(request));
+            Assert.Same(transientError, ex);
+        }
+
+        [Fact]
+        public async Task CreateRegistrationOptionsAsync_SyncUpdateAsyncThrowsRaceConflict_ConvertsToExternalIdConflict()
+        {
+            // Arrange: 事前チェック時点では衝突無し → UpdateAsync で DbUpdateException →
+            // 再確認したら別ユーザーが同じ external_id を取得していた（race condition）。
+            // このケースのみ ExternalIdConflictException にラップされる。
+            var request = new IB2BPasskeyService.RegistrationOptionsRequest
+            {
+                ClientId = "test-client-id",
+                RpId = "shop.example.com",
+                B2BSubject = TestB2BSubject,
+                ExternalId = "race-target@example.com"
+            };
+
+            var raceWinner = new B2BUser
+            {
+                Id = 77,
+                Subject = TestB2BSubject2,
+                ExternalId = "race-target@example.com",
+                UserType = "admin",
+                OrganizationId = 1,
+                Organization = _organization
+            };
+
+            _mockUserService.Setup(x => x.GetBySubjectAsync(TestB2BSubject))
+                .ReturnsAsync(_testUser);
+
+            // 1回目(事前チェック): null、2回目(DbUpdateException 後の再確認): raceWinner
+            _mockUserService.SetupSequence(x => x.GetByExternalIdAsync("race-target@example.com", 1))
+                .ReturnsAsync((B2BUser?)null)
+                .ReturnsAsync(raceWinner);
+
+            _mockUserService.Setup(x => x.UpdateAsync(It.IsAny<IB2BUserService.UpdateUserRequest>()))
+                .ThrowsAsync(new DbUpdateException("unique constraint violation", new Exception()));
+
+            // Act & Assert
+            var ex = await Assert.ThrowsAsync<ExternalIdConflictException>(() =>
+                _service.CreateRegistrationOptionsAsync(request));
+            Assert.Contains("another user", ex.Message);
+            // メッセージに external_id 値は含めない（情報漏洩対策）
+            Assert.DoesNotContain("race-target@example.com", ex.Message);
+        }
+
+        [Fact]
         public async Task CreateRegistrationOptionsAsync_SubjectHit_UserBelongsToDifferentOrganization_ThrowsInvalidOperation()
         {
             // Arrange: B2BUser の QueryFilter は TenantName ベースなので、

--- a/IdentityProvider/Controllers/B2BPasskeyController.cs
+++ b/IdentityProvider/Controllers/B2BPasskeyController.cs
@@ -1,4 +1,5 @@
 using Fido2NetLib;
+using IdentityProvider.Exceptions;
 using IdentityProvider.Models;
 using IdentityProvider.Services;
 using Asp.Versioning;
@@ -185,7 +186,18 @@ namespace IdentityProvider.Controllers
                 {
                     session_id = result.SessionId,
                     options = result.Options,
-                    is_provisioned = result.IsProvisioned
+                    is_provisioned = result.IsProvisioned,
+                    resolved_subject = result.ResolvedSubject,
+                    subject_resolution = result.SubjectResolution
+                });
+            }
+            catch (ExternalIdConflictException ex)
+            {
+                _logger.LogWarning("ExternalId conflict in RegisterOptions: {Message}", ex.Message);
+                return Conflict(new
+                {
+                    error = "external_id_conflict",
+                    error_description = ex.Message
                 });
             }
             catch (ArgumentException ex)

--- a/IdentityProvider/Controllers/B2BPasskeyController.cs
+++ b/IdentityProvider/Controllers/B2BPasskeyController.cs
@@ -193,11 +193,13 @@ namespace IdentityProvider.Controllers
             }
             catch (ExternalIdConflictException ex)
             {
+                // ex.Message には external_id 値が含まれるためサーバーログには残すが、
+                // レスポンスボディに返すとマルチテナント環境で external_id 列挙に悪用され得るので固定文言化する
                 _logger.LogWarning("ExternalId conflict in RegisterOptions: {Message}", ex.Message);
                 return Conflict(new
                 {
                     error = "external_id_conflict",
-                    error_description = ex.Message
+                    error_description = "The requested external_id is already associated with another user in this organization."
                 });
             }
             catch (ArgumentException ex)

--- a/IdentityProvider/Exceptions/ExternalIdConflictException.cs
+++ b/IdentityProvider/Exceptions/ExternalIdConflictException.cs
@@ -1,0 +1,12 @@
+namespace IdentityProvider.Exceptions
+{
+    /// <summary>
+    /// ExternalId の自動同期対象が、同一組織内の別ユーザーに既に使われている場合にスローされる例外。
+    /// HTTP API としては 409 Conflict に変換される。
+    /// </summary>
+    public class ExternalIdConflictException : Exception
+    {
+        public ExternalIdConflictException(string message, Exception? innerException = null)
+            : base(message, innerException) { }
+    }
+}

--- a/IdentityProvider/Services/B2BPasskeyService.cs
+++ b/IdentityProvider/Services/B2BPasskeyService.cs
@@ -96,40 +96,7 @@ namespace IdentityProvider.Services
             if (user != null)
             {
                 // Subject が一致: external_id が変わっていたら自動同期（EC-CUBE login_id 変更への追随）
-                if (!string.Equals(user.ExternalId, request.ExternalId, StringComparison.Ordinal))
-                {
-                    // 先行チェック: 同一 Organization 内で他ユーザーが既にその external_id を使っていれば 409
-                    var conflictingUser = await _userService.GetByExternalIdAsync(
-                        request.ExternalId, client.OrganizationId.Value);
-                    if (conflictingUser != null && conflictingUser.Subject != user.Subject)
-                    {
-                        throw new ExternalIdConflictException(
-                            $"ExternalId '{request.ExternalId}' is already used by another user in this organization.");
-                    }
-
-                    _logger.LogInformation(
-                        "Syncing ExternalId for B2BUser: Subject={Subject}, Old={OldExternalId}, New={NewExternalId}",
-                        user.Subject, user.ExternalId, request.ExternalId);
-
-                    try
-                    {
-                        var updated = await _userService.UpdateAsync(new IB2BUserService.UpdateUserRequest
-                        {
-                            Subject = user.Subject,
-                            ExternalId = request.ExternalId
-                        });
-                        if (updated != null)
-                        {
-                            user = updated;
-                        }
-                    }
-                    catch (DbUpdateException ex)
-                    {
-                        // 事前チェックと UpdateAsync の間に race で別ユーザーが同じ external_id を持った場合の保険
-                        throw new ExternalIdConflictException(
-                            $"ExternalId '{request.ExternalId}' conflict while syncing for Subject '{user.Subject}'.", ex);
-                    }
-                }
+                user = await SyncExternalIdIfChangedAsync(user, request.ExternalId, client.OrganizationId.Value);
                 subjectResolution = IB2BPasskeyService.SubjectResolutions.AsRequested;
             }
             else
@@ -182,6 +149,9 @@ namespace IdentityProvider.Services
                         }
                         else
                         {
+                            // 並行リクエストが先に書き込んだ external_id と、今回のリクエストの external_id が
+                            // 異なる場合があるため、メインフローと同じく同期ロジックを適用する。
+                            user = await SyncExternalIdIfChangedAsync(user, request.ExternalId, client.OrganizationId.Value);
                             subjectResolution = IB2BPasskeyService.SubjectResolutions.AsRequested;
                         }
                     }
@@ -253,6 +223,48 @@ namespace IdentityProvider.Services
                 ResolvedSubject = resolvedSubject,
                 SubjectResolution = subjectResolution
             };
+        }
+
+        /// <summary>
+        /// 既存 B2BUser の external_id が引数の requestedExternalId と異なる場合、
+        /// 同一 Organization 内の衝突を確認したうえで external_id を同期する。
+        /// 衝突がある場合は <see cref="ExternalIdConflictException"/> をスロー。
+        /// </summary>
+        private async Task<B2BUser> SyncExternalIdIfChangedAsync(
+            B2BUser user, string requestedExternalId, int organizationId)
+        {
+            if (string.Equals(user.ExternalId, requestedExternalId, StringComparison.Ordinal))
+            {
+                return user;
+            }
+
+            // 先行チェック: 同一 Organization 内で他ユーザーが既にその external_id を使っていれば 409
+            var conflictingUser = await _userService.GetByExternalIdAsync(requestedExternalId, organizationId);
+            if (conflictingUser != null && conflictingUser.Subject != user.Subject)
+            {
+                throw new ExternalIdConflictException(
+                    $"ExternalId '{requestedExternalId}' is already used by another user in this organization.");
+            }
+
+            _logger.LogInformation(
+                "Syncing ExternalId for B2BUser: Subject={Subject}, Old={OldExternalId}, New={NewExternalId}",
+                user.Subject, user.ExternalId, requestedExternalId);
+
+            try
+            {
+                var updated = await _userService.UpdateAsync(new IB2BUserService.UpdateUserRequest
+                {
+                    Subject = user.Subject,
+                    ExternalId = requestedExternalId
+                });
+                return updated ?? user;
+            }
+            catch (DbUpdateException ex)
+            {
+                // 事前チェックと UpdateAsync の間に race で別ユーザーが同じ external_id を持った場合の保険
+                throw new ExternalIdConflictException(
+                    $"ExternalId '{requestedExternalId}' conflict while syncing for Subject '{user.Subject}'.", ex);
+            }
         }
 
         /// <inheritdoc />

--- a/IdentityProvider/Services/B2BPasskeyService.cs
+++ b/IdentityProvider/Services/B2BPasskeyService.cs
@@ -1,5 +1,6 @@
 using Fido2NetLib;
 using Fido2NetLib.Objects;
+using IdentityProvider.Exceptions;
 using IdentityProvider.Models;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.EntityFrameworkCore;
@@ -90,51 +91,100 @@ namespace IdentityProvider.Services
             // B2Bユーザー取得、存在しない場合は JIT プロビジョニング
             var user = await _userService.GetBySubjectAsync(b2bSubject);
             bool isProvisioned = false;
-            if (user == null)
+            string subjectResolution;
+
+            if (user != null)
+            {
+                // Subject が一致: external_id が変わっていたら自動同期（EC-CUBE login_id 変更への追随）
+                if (!string.Equals(user.ExternalId, request.ExternalId, StringComparison.Ordinal))
+                {
+                    // 先行チェック: 同一 Organization 内で他ユーザーが既にその external_id を使っていれば 409
+                    var conflictingUser = await _userService.GetByExternalIdAsync(
+                        request.ExternalId, client.OrganizationId.Value);
+                    if (conflictingUser != null && conflictingUser.Subject != user.Subject)
+                    {
+                        throw new ExternalIdConflictException(
+                            $"ExternalId '{request.ExternalId}' is already used by another user in this organization.");
+                    }
+
+                    _logger.LogInformation(
+                        "Syncing ExternalId for B2BUser: Subject={Subject}, Old={OldExternalId}, New={NewExternalId}",
+                        user.Subject, user.ExternalId, request.ExternalId);
+
+                    try
+                    {
+                        var updated = await _userService.UpdateAsync(new IB2BUserService.UpdateUserRequest
+                        {
+                            Subject = user.Subject,
+                            ExternalId = request.ExternalId
+                        });
+                        if (updated != null)
+                        {
+                            user = updated;
+                        }
+                    }
+                    catch (DbUpdateException ex)
+                    {
+                        // 事前チェックと UpdateAsync の間に race で別ユーザーが同じ external_id を持った場合の保険
+                        throw new ExternalIdConflictException(
+                            $"ExternalId '{request.ExternalId}' conflict while syncing for Subject '{user.Subject}'.", ex);
+                    }
+                }
+                subjectResolution = IB2BPasskeyService.SubjectResolutions.AsRequested;
+            }
+            else
             {
                 // ExternalId で既存ユーザーを検索（EC-CUBEプラグイン再インストール時の復旧）
                 user = await _userService.GetByExternalIdAsync(request.ExternalId, client.OrganizationId.Value);
                 if (user != null)
                 {
                     _logger.LogInformation(
-                        "Found existing B2BUser by ExternalId: ExternalId={ExternalId}, Subject={Subject}",
-                        request.ExternalId, user.Subject);
+                        "Resolved B2BUser via ExternalId fallback: ExternalId={ExternalId}, RequestedSubject={RequestedSubject}, ResolvedSubject={ResolvedSubject}",
+                        request.ExternalId, b2bSubject, user.Subject);
+                    subjectResolution = IB2BPasskeyService.SubjectResolutions.FallbackByExternalId;
                 }
-            }
-
-            if (user == null)
-            {
-                try
+                else
                 {
-                    _logger.LogInformation(
-                        "JIT provisioning B2BUser: Subject={Subject}, ExternalId={ExternalId}, OrganizationId={OrganizationId}",
-                        b2bSubject, request.ExternalId, client.OrganizationId);
-
-                    var createResult = await _userService.CreateAsync(new IB2BUserService.CreateUserRequest
+                    try
                     {
-                        Subject = b2bSubject,
-                        ExternalId = request.ExternalId,
-                        UserType = "admin",
-                        OrganizationId = client.OrganizationId.Value
-                    });
-                    user = createResult.User;
-                    isProvisioned = true;
+                        _logger.LogInformation(
+                            "JIT provisioning B2BUser: Subject={Subject}, ExternalId={ExternalId}, OrganizationId={OrganizationId}",
+                            b2bSubject, request.ExternalId, client.OrganizationId);
 
-                    _logger.LogInformation(
-                        "JIT provisioned B2BUser: Subject={Subject}, OrganizationId={OrganizationId}",
-                        user.Subject, user.OrganizationId);
-                }
-                catch (DbUpdateException)
-                {
-                    // 並行リクエストで Subject または ExternalId の一意制約違反が発生した場合、再取得を試みる。
-                    _logger.LogInformation(
-                        "B2BUser already created by concurrent request, re-fetching: Subject={Subject}",
-                        b2bSubject);
-                    user = await _userService.GetBySubjectAsync(b2bSubject);
-                    if (user == null)
-                        user = await _userService.GetByExternalIdAsync(request.ExternalId, client.OrganizationId.Value);
-                    if (user == null)
-                        throw new InvalidOperationException($"Failed to create or retrieve B2BUser: {b2bSubject}");
+                        var createResult = await _userService.CreateAsync(new IB2BUserService.CreateUserRequest
+                        {
+                            Subject = b2bSubject,
+                            ExternalId = request.ExternalId,
+                            UserType = "admin",
+                            OrganizationId = client.OrganizationId.Value
+                        });
+                        user = createResult.User;
+                        isProvisioned = true;
+                        subjectResolution = IB2BPasskeyService.SubjectResolutions.Provisioned;
+
+                        _logger.LogInformation(
+                            "JIT provisioned B2BUser: Subject={Subject}, OrganizationId={OrganizationId}",
+                            user.Subject, user.OrganizationId);
+                    }
+                    catch (DbUpdateException)
+                    {
+                        // 並行リクエストで Subject または ExternalId の一意制約違反が発生した場合、再取得を試みる。
+                        _logger.LogInformation(
+                            "B2BUser already created by concurrent request, re-fetching: Subject={Subject}",
+                            b2bSubject);
+                        user = await _userService.GetBySubjectAsync(b2bSubject);
+                        if (user == null)
+                        {
+                            user = await _userService.GetByExternalIdAsync(request.ExternalId, client.OrganizationId.Value);
+                            subjectResolution = user != null
+                                ? IB2BPasskeyService.SubjectResolutions.FallbackByExternalId
+                                : throw new InvalidOperationException($"Failed to create or retrieve B2BUser: {b2bSubject}");
+                        }
+                        else
+                        {
+                            subjectResolution = IB2BPasskeyService.SubjectResolutions.AsRequested;
+                        }
+                    }
                 }
             }
 
@@ -199,7 +249,9 @@ namespace IdentityProvider.Services
             {
                 SessionId = challengeResult.SessionId,
                 Options = options,
-                IsProvisioned = isProvisioned
+                IsProvisioned = isProvisioned,
+                ResolvedSubject = resolvedSubject,
+                SubjectResolution = subjectResolution
             };
         }
 

--- a/IdentityProvider/Services/B2BPasskeyService.cs
+++ b/IdentityProvider/Services/B2BPasskeyService.cs
@@ -299,9 +299,21 @@ namespace IdentityProvider.Services
             }
             catch (DbUpdateException ex)
             {
-                // 事前チェックと UpdateAsync の間に race で別ユーザーが同じ external_id を持った場合の保険
-                throw new ExternalIdConflictException(
-                    $"ExternalId '{requestedExternalId}' conflict while syncing for Subject '{user.Subject}'.", ex);
+                // DB 更新失敗の原因を実状態で再確認する。
+                // UNIQUE 制約違反（race で別ユーザーが同じ external_id を取得）なら 409 相当として
+                // ExternalIdConflictException にラップするが、それ以外（タイムアウト、接続断、
+                // 別制約違反など 500 相当 / 再試行対象）の障害までは 409 に吸収せず元例外を再スローする。
+                // SQL エラーコード判定ではなく「現時点で別ユーザーが当該 external_id を保有しているか」で
+                // 判定することで、DB プロバイダー非依存に race condition を検出できる。
+                var owner = await _userService.GetByExternalIdAsync(requestedExternalId, organizationId);
+                if (owner != null
+                    && !string.Equals(owner.Subject, user.Subject, StringComparison.Ordinal))
+                {
+                    throw new ExternalIdConflictException(
+                        "ExternalId is already used by another user in this organization.", ex);
+                }
+
+                throw;
             }
         }
 

--- a/IdentityProvider/Services/B2BPasskeyService.cs
+++ b/IdentityProvider/Services/B2BPasskeyService.cs
@@ -95,6 +95,11 @@ namespace IdentityProvider.Services
 
             if (user != null)
             {
+                // Organization 境界チェック: B2BUser クエリフィルターは TenantName ベースなので、
+                // 同一テナント内の別 Organization の subject がヒットし得る。
+                // これを許すと cross-organization での external_id 上書きや credential 紐付けが可能になるため遮断する。
+                EnsureUserBelongsToClientOrganization(user, client.OrganizationId.Value, b2bSubject);
+
                 // Subject が一致: external_id が変わっていたら自動同期（EC-CUBE login_id 変更への追随）
                 user = await SyncExternalIdIfChangedAsync(user, request.ExternalId, client.OrganizationId.Value);
                 subjectResolution = IB2BPasskeyService.SubjectResolutions.AsRequested;
@@ -149,6 +154,9 @@ namespace IdentityProvider.Services
                         }
                         else
                         {
+                            // race 経由でも別組織の subject が返りうるため、メインフローと同じ境界チェックを適用
+                            EnsureUserBelongsToClientOrganization(user, client.OrganizationId.Value, b2bSubject);
+
                             // 並行リクエストが先に書き込んだ external_id と、今回のリクエストの external_id が
                             // 異なる場合があるため、メインフローと同じく同期ロジックを適用する。
                             user = await SyncExternalIdIfChangedAsync(user, request.ExternalId, client.OrganizationId.Value);
@@ -223,6 +231,26 @@ namespace IdentityProvider.Services
                 ResolvedSubject = resolvedSubject,
                 SubjectResolution = subjectResolution
             };
+        }
+
+        /// <summary>
+        /// subject で解決した B2BUser が、呼び出し元クライアントの Organization に属しているかを検証する。
+        /// B2BUser の QueryFilter は TenantName ベースなので、同一テナント内の別 Organization の
+        /// subject がヒットする可能性があり、それを許すと cross-organization 書き換えに繋がるため遮断する。
+        /// ログ・例外メッセージには requestedSubject の値を含めない（別組織 subject の存在有無を漏らさないため）。
+        /// </summary>
+        private void EnsureUserBelongsToClientOrganization(B2BUser user, int clientOrganizationId, string requestedSubject)
+        {
+            if (user.OrganizationId == clientOrganizationId)
+            {
+                return;
+            }
+
+            _logger.LogWarning(
+                "B2BSubject does not belong to the client's organization. ClientOrganizationId={ClientOrganizationId}, UserOrganizationId={UserOrganizationId}",
+                clientOrganizationId, user.OrganizationId);
+
+            throw new InvalidOperationException("B2BSubject is not associated with this client's organization.");
         }
 
         /// <summary>

--- a/IdentityProvider/Services/B2BPasskeyService.cs
+++ b/IdentityProvider/Services/B2BPasskeyService.cs
@@ -240,7 +240,8 @@ namespace IdentityProvider.Services
 
             // 先行チェック: 同一 Organization 内で他ユーザーが既にその external_id を使っていれば 409
             var conflictingUser = await _userService.GetByExternalIdAsync(requestedExternalId, organizationId);
-            if (conflictingUser != null && conflictingUser.Subject != user.Subject)
+            if (conflictingUser != null
+                && !string.Equals(conflictingUser.Subject, user.Subject, StringComparison.Ordinal))
             {
                 throw new ExternalIdConflictException(
                     $"ExternalId '{requestedExternalId}' is already used by another user in this organization.");
@@ -257,7 +258,10 @@ namespace IdentityProvider.Services
                     Subject = user.Subject,
                     ExternalId = requestedExternalId
                 });
-                return updated ?? user;
+                // 事前に GetBySubjectAsync で取得済みの user の subject で呼んでいるため、
+                // 通常 null は返らない。並行削除等で null になった場合は silent 失敗を避けて例外化。
+                return updated ?? throw new InvalidOperationException(
+                    $"UpdateAsync returned null while syncing ExternalId for Subject '{user.Subject}'.");
             }
             catch (DbUpdateException ex)
             {

--- a/IdentityProvider/Services/B2BPasskeyService.cs
+++ b/IdentityProvider/Services/B2BPasskeyService.cs
@@ -110,9 +110,10 @@ namespace IdentityProvider.Services
                 user = await _userService.GetByExternalIdAsync(request.ExternalId, client.OrganizationId.Value);
                 if (user != null)
                 {
+                    // external_id は login_id 等 PII を含み得るため Information ログには含めない
                     _logger.LogInformation(
-                        "Resolved B2BUser via ExternalId fallback: ExternalId={ExternalId}, RequestedSubject={RequestedSubject}, ResolvedSubject={ResolvedSubject}",
-                        request.ExternalId, b2bSubject, user.Subject);
+                        "Resolved B2BUser via ExternalId fallback: RequestedSubject={RequestedSubject}, ResolvedSubject={ResolvedSubject}, OrganizationId={OrganizationId}",
+                        b2bSubject, user.Subject, user.OrganizationId);
                     subjectResolution = IB2BPasskeyService.SubjectResolutions.FallbackByExternalId;
                 }
                 else
@@ -120,8 +121,8 @@ namespace IdentityProvider.Services
                     try
                     {
                         _logger.LogInformation(
-                            "JIT provisioning B2BUser: Subject={Subject}, ExternalId={ExternalId}, OrganizationId={OrganizationId}",
-                            b2bSubject, request.ExternalId, client.OrganizationId);
+                            "JIT provisioning B2BUser: Subject={Subject}, OrganizationId={OrganizationId}",
+                            b2bSubject, client.OrganizationId);
 
                         var createResult = await _userService.CreateAsync(new IB2BUserService.CreateUserRequest
                         {
@@ -275,8 +276,13 @@ namespace IdentityProvider.Services
                     $"ExternalId '{requestedExternalId}' is already used by another user in this organization.");
             }
 
+            // external_id の具体値は PII を含み得るため Information ログには含めない。
+            // 調査時の Old/New 追跡は Debug ログで opt-in、恒久追跡は DB の updated_at 等に委ねる。
             _logger.LogInformation(
-                "Syncing ExternalId for B2BUser: Subject={Subject}, Old={OldExternalId}, New={NewExternalId}",
+                "Syncing ExternalId for B2BUser: Subject={Subject}, OrganizationId={OrganizationId}",
+                user.Subject, user.OrganizationId);
+            _logger.LogDebug(
+                "ExternalId sync values: Subject={Subject}, Old={OldExternalId}, New={NewExternalId}",
                 user.Subject, user.ExternalId, requestedExternalId);
 
             try

--- a/IdentityProvider/Services/IB2BPasskeyService.cs
+++ b/IdentityProvider/Services/IB2BPasskeyService.cs
@@ -66,6 +66,34 @@ namespace IdentityProvider.Services
             /// JITプロビジョニングでB2BUserが新規作成されたか
             /// </summary>
             public bool IsProvisioned { get; set; }
+
+            /// <summary>
+            /// 解決済み B2B subject。
+            /// external_id フォールバックで resolve された場合、リクエストの b2b_subject と異なる値になる。
+            /// 呼び出し元（プラグイン）は local の subject と不一致なら再同期するべき。
+            /// </summary>
+            public string ResolvedSubject { get; set; } = string.Empty;
+
+            /// <summary>
+            /// subject 解決経路。値は <see cref="SubjectResolutions"/> 参照。
+            /// 文字列型にしているのは将来 Phase 4 で "rejected_by_policy" 等の値を追加できる余地を残すため。
+            /// </summary>
+            public string SubjectResolution { get; set; } = string.Empty;
+        }
+
+        /// <summary>
+        /// <see cref="RegistrationOptionsResult.SubjectResolution"/> が取りうる値の定数定義。
+        /// </summary>
+        public static class SubjectResolutions
+        {
+            /// <summary>リクエストの b2b_subject がそのまま一致した。</summary>
+            public const string AsRequested = "as_requested";
+
+            /// <summary>b2b_subject では見つからず、external_id フォールバックで resolve された。</summary>
+            public const string FallbackByExternalId = "fallback_by_external_id";
+
+            /// <summary>該当ユーザーが存在せず、JIT プロビジョニングで新規作成された。</summary>
+            public const string Provisioned = "provisioned";
         }
 
         /// <summary>


### PR DESCRIPTION
## 概要

Issue #359 の Phase 1 対応。B2B パスキー登録時の subject 解決ギャップ 2 件を EcAuth 側で吸収する。

- **(A)** EC-CUBE の `dtb_member.login_id` 変更が EcAuth 側の `b2b_user.external_id` に追随しない問題
- **(B)** external_id フォールバックで subject 解決がずれた場合、プラグインが `options.user.id` を base64url デコードして自力で reconcile している（API 契約外の挙動に依存）

Issue コメント（[アーキテクチャ観点](https://github.com/EcAuth/EcAuth/issues/359#issuecomment-sequence)）の判断に従い、(1) + (3a) をセットで実装。(2) sync endpoint は Phase 2 以降に後回し。

## 変更内容

### サービス層 (`B2BPasskeyService`)

- subject 一致時に `external_id` の差分があれば `UpdateAsync` で自動同期
- 解決経路を 3 値でトラッキング:
  - `as_requested`: リクエストの b2b_subject がそのまま一致
  - `fallback_by_external_id`: external_id フォールバックで resolve
  - `provisioned`: JIT プロビジョニングで新規作成
- 同一 Organization 内で `external_id` が他ユーザーと衝突した場合は `ExternalIdConflictException` をスロー
  - race condition 対策として事前チェック + `DbUpdateException` catch の二段構え

### DTO (`IB2BPasskeyService.RegistrationOptionsResult`)

- `ResolvedSubject` プロパティ追加
- `SubjectResolution` プロパティ追加（値は `IB2BPasskeyService.SubjectResolutions` 定数で提供）
- 文字列型にしているのは Phase 4 で fallback opt-in 化する際に `"rejected_by_policy"` 等を追加できる余地を残すため

### コントローラー (`B2BPasskeyController`)

- `POST /v1/b2b/passkey/register/options` のレスポンスに `resolved_subject` / `subject_resolution` を追加
- `ExternalIdConflictException` を `409 Conflict` + `error = "external_id_conflict"` に変換
- `is_provisioned` は後方互換のため維持

### 新規ファイル

- `IdentityProvider/Exceptions/ExternalIdConflictException.cs`

### テスト

以下のシナリオをカバー:

**B2BPasskeyServiceTests**:
- subject hit + external_id 一致 → `as_requested`, `UpdateAsync` 呼ばれない
- subject hit + external_id 差分 → `UpdateAsync` 呼ばれ external_id が新値に同期
- subject hit + external_id 衝突 → `ExternalIdConflictException`
- subject miss + external_id hit → `fallback_by_external_id`, `ResolvedSubject` が旧 subject
- subject miss + external_id miss → `provisioned`, `IsProvisioned = true`

**B2BPasskeyControllerTests**:
- 正常系で `resolved_subject` / `subject_resolution` フィールドが JSON に含まれること
- 409 応答で `error = "external_id_conflict"` が返ること

## 互換性

破壊的変更なし。レスポンスフィールド追加のみで `is_provisioned` も維持。DB マイグレーションなし。

プラグイン側（ec-cube4-ecauth）の `reconcileEcauthSubjectFromOptions` を `resolved_subject` 参照に切り替える最適化は任意のフォローアップ扱い（Issue コメント参照）。

## スコープ外（将来対応）

- **Phase 2**: `PUT /v1/b2b/user/{subject}/external-id` sync endpoint（login_id 変更をパスキー操作と独立に同期）
- **Phase 4**: fallback の opt-in 化（#361 対応後）。今回の `SubjectResolution` を string 型にしたのは、`"rejected_by_policy"` 等を追加する余地を残すため
- 孤児 `b2b_user` / credential の管理 UI / API: EcAuthDocs#63 で B2C / SSO と合流

## Test plan

- [x] `dotnet build IdentityProvider/IdentityProvider.csproj` 成功
- [x] `dotnet test IdentityProvider.Test/IdentityProvider.Test.csproj` 522 件全て pass（B2BPasskey 系 80 件 + 既存 442 件、回帰なし）
- [ ] Staging 環境での E2E 回帰（既存 `ec-cube4-ecauth` プラグインは `options.user.id` デコード経由で動作継続）
- [ ] 手動確認:
  - subject 既知 + external_id 変更 → `resolved_subject == 既存 subject`, `subject_resolution == "as_requested"`, DB の external_id が新値に更新
  - subject 新規 + external_id 既存 → `resolved_subject ≠ リクエスト subject`, `subject_resolution == "fallback_by_external_id"`
  - external_id 衝突 → HTTP 409, `error == "external_id_conflict"`

Refs: #359

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * B2B登録時に外部IDの自動同期機能を追加
  * 登録オプションレスポンスに解決済みサブジェクト情報を含めるよう改善
  * 外部ID競合時にHTTP 409エラーを返却

* **テスト**
  * B2Bパスキーコントローラーおよびサービスの包括的なテストケースを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->