### PR TITLE
ci(claude): 公式テンプレ更新を取り込み EcAuth 固有設定を維持

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,30 +2,25 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize, ready_for_review, reopened]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"
     #   - "src/**/*.tsx"
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
-  issue_comment:
-    types: [created]
 
 jobs:
   claude-review:
-    # Run on PR creation, or on comments containing /review or @claude
-    if: |
-      (github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]') ||
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request &&
-       (contains(github.event.comment.body, '/review') || contains(github.event.comment.body, '@claude')))
+    # Skip reviews for dependabot PRs
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: read
       pull-requests: write
-      issues: write
+      issues: read
       id-token: write
 
     steps:
@@ -63,22 +58,13 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
           prompt: |
-            REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
 
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage
-            - 日本語で回答してください
-
-            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
-
-            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
-
+            Use the repository's CLAUDE.md for guidance on style and conventions.
+            日本語で回答してください。
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
+          # or https://code.claude.com/docs/en/cli-reference for available options
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,7 +22,7 @@ jobs:
        )
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       packages: read
       pull-requests: write
       issues: write
@@ -56,6 +56,7 @@ jobs:
         run: dotnet tool restore
       - name: Restore dependencies
         run: dotnet restore ./EcAuth.sln
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
@@ -64,12 +65,12 @@ jobs:
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
-            actions: write
+            actions: read
 
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
 
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
+          # or https://code.claude.com/docs/en/cli-reference for available options
           claude_args: '--allowed-tools Bash'


### PR DESCRIPTION
## Summary

- `/install-github-app` による公式テンプレ最新版の改善点を取り込み
- EcAuth 固有のセキュリティガード／ビルド環境／日本語レビュー指示を再適用
- `@claude` (claude.yml) をレビュー／Q&A 用途のみに限定し `contents: read` に縮小

## 変更内容

### `.github/workflows/claude-code-review.yml`
- 新テンプレ由来の改善を採用:
  - `pull_request` トリガーに `synchronize` / `ready_for_review` / `reopened` を追加し、差分 push に追従
  - `plugin_marketplaces` + `plugins: code-review@claude-code-plugins` によるプラグイン方式へ移行
  - `issue_comment` 手動トリガーは `synchronize` でカバーされるため削除
- EcAuth 固有設定を維持:
  - Dependabot PR を除外 (`user.login != 'dependabot[bot]'`)
  - `EcAuthDocs` checkout／.NET 9 SDK セットアップ／GitHub Packages 認証／`dotnet restore`
  - `gh` コマンド許可リスト (`--allowed-tools`)
  - 日本語回答指示と CLAUDE.md 参照指示
- 権限調整: `issues: write` → `read`（PR コメントは `pull-requests: write` で投稿）

### `.github/workflows/claude.yml`
- `@claude` の運用方針をレビュー／Q&A 専用に確定:
  - `contents: write` → `read`（コード編集不可）
  - `additional_permissions: actions: write` → `read`（CI 結果参照のみ）
  - 返信投稿のため `pull-requests: write` / `issues: write` は維持
- 新テンプレ準拠:
  - doc URL を `code.claude.com/docs/en/cli-reference` に更新
- EcAuth 固有設定を維持:
  - `github.repository_owner == github.actor` による外部ユーザー発火防止ガード
  - `EcAuthDocs` checkout／.NET 9 SDK セットアップ／GitHub Packages 認証／`dotnet restore`

## Test plan

- [ ] この PR をドラフトで作成し、Claude Code Review が自動起動することを確認
- [ ] PR に `synchronize` 発火するコミットを追加し、再レビューが走ることを確認
- [ ] PR コメントで `@claude` を呼び出し、Q&A 応答が投稿されることを確認
- [ ] `@claude` がコード編集・コミット操作を行えないことを確認（read 権限）
- [ ] EcAuthDocs checkout と `dotnet restore` が成功することを workflow ログで確認

## 関連

- `/install-github-app` で生成された `add-claude-github-actions-1776671555103` ブランチの内容をベースに、EcAuth 固有カスタマイズを統合

🤖 Generated with [Claude Code](https://claude.com/claude-code)