### PR TITLE
feat(telemetry): Application Insights テレメトリ送信を有効化 (#68)

### DIFF
--- a/IdentityProvider/Controllers/B2BPasskeyController.cs
+++ b/IdentityProvider/Controllers/B2BPasskeyController.cs
@@ -5,6 +5,7 @@ using IdentityProvider.Services;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using System.Diagnostics;
 using System.Net.Http.Headers;
 using System.Text.Json.Serialization;
 using System.Web;
@@ -125,6 +126,7 @@ namespace IdentityProvider.Controllers
         {
             try
             {
+                Activity.Current?.SetTag("client.id", request.ClientId);
                 _logger.LogInformation("B2B Passkey RegisterOptions requested for client: {ClientId}", request.ClientId);
 
                 // バリデーション
@@ -240,6 +242,7 @@ namespace IdentityProvider.Controllers
         {
             try
             {
+                Activity.Current?.SetTag("client.id", request.ClientId);
                 _logger.LogInformation("B2B Passkey RegisterVerify requested. SessionId: {SessionId}", request.SessionId);
 
                 // バリデーション
@@ -317,6 +320,7 @@ namespace IdentityProvider.Controllers
         {
             try
             {
+                Activity.Current?.SetTag("client.id", request.ClientId);
                 _logger.LogInformation("B2B Passkey AuthenticateOptions requested for client: {ClientId}", request.ClientId);
 
                 // バリデーション
@@ -400,6 +404,7 @@ namespace IdentityProvider.Controllers
         {
             try
             {
+                Activity.Current?.SetTag("client.id", request.ClientId);
                 _logger.LogInformation("B2B Passkey AuthenticateVerify requested. SessionId: {SessionId}", request.SessionId);
 
                 // バリデーション

--- a/IdentityProvider/Controllers/B2BPasskeyController.cs
+++ b/IdentityProvider/Controllers/B2BPasskeyController.cs
@@ -126,7 +126,6 @@ namespace IdentityProvider.Controllers
         {
             try
             {
-                Activity.Current?.SetTag("client.id", request.ClientId);
                 _logger.LogInformation("B2B Passkey RegisterOptions requested for client: {ClientId}", request.ClientId);
 
                 // バリデーション
@@ -168,6 +167,8 @@ namespace IdentityProvider.Controllers
                         error_description = "クライアント認証に失敗しました。"
                     });
                 }
+
+                Activity.Current?.SetTag("client.id", client.ClientId);
 
                 // サービス呼び出し
                 var serviceRequest = new IB2BPasskeyService.RegistrationOptionsRequest
@@ -242,7 +243,6 @@ namespace IdentityProvider.Controllers
         {
             try
             {
-                Activity.Current?.SetTag("client.id", request.ClientId);
                 _logger.LogInformation("B2B Passkey RegisterVerify requested. SessionId: {SessionId}", request.SessionId);
 
                 // バリデーション
@@ -266,6 +266,8 @@ namespace IdentityProvider.Controllers
                         error_description = "クライアント認証に失敗しました。"
                     });
                 }
+
+                Activity.Current?.SetTag("client.id", client.ClientId);
 
                 // サービス呼び出し
                 var serviceRequest = new IB2BPasskeyService.RegistrationVerifyRequest
@@ -320,7 +322,6 @@ namespace IdentityProvider.Controllers
         {
             try
             {
-                Activity.Current?.SetTag("client.id", request.ClientId);
                 _logger.LogInformation("B2B Passkey AuthenticateOptions requested for client: {ClientId}", request.ClientId);
 
                 // バリデーション
@@ -347,6 +348,8 @@ namespace IdentityProvider.Controllers
                         error_description = "クライアントが見つかりません。"
                     });
                 }
+
+                Activity.Current?.SetTag("client.id", client.ClientId);
 
                 // サービス呼び出し
                 var serviceRequest = new IB2BPasskeyService.AuthenticationOptionsRequest
@@ -404,7 +407,6 @@ namespace IdentityProvider.Controllers
         {
             try
             {
-                Activity.Current?.SetTag("client.id", request.ClientId);
                 _logger.LogInformation("B2B Passkey AuthenticateVerify requested. SessionId: {SessionId}", request.SessionId);
 
                 // バリデーション
@@ -441,6 +443,8 @@ namespace IdentityProvider.Controllers
                         error_description = "クライアントが見つかりません。"
                     });
                 }
+
+                Activity.Current?.SetTag("client.id", client.ClientId);
 
                 // redirect_uri 検証
                 var allowedRedirectUris = client.RedirectUris?

--- a/IdentityProvider/IdentityProvider.csproj
+++ b/IdentityProvider/IdentityProvider.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Asp.Versioning.Mvc" Version="8.1.1" />
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.1" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.4.0" />
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="Fido2" Version="4.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.6" />

--- a/IdentityProvider/Middlewares/TenantMiddleware.cs
+++ b/IdentityProvider/Middlewares/TenantMiddleware.cs
@@ -1,5 +1,6 @@
 using IdentityProvider.Constants;
 using IdentityProvider.Services;
+using System.Diagnostics;
 using System.Net;
 
 namespace IdentityProvider.Middlewares
@@ -34,6 +35,7 @@ namespace IdentityProvider.Middlewares
                 host, tenantName, defaultOrganizationTenantName, finalTenantName);
 
             tenantService.SetTenant(finalTenantName);
+            Activity.Current?.SetTag("tenant.name", finalTenantName);
 
             await _next(context);
         }

--- a/IdentityProvider/Program.cs
+++ b/IdentityProvider/Program.cs
@@ -90,8 +90,14 @@ builder.Services.AddSwaggerGen();
 
 // Application Insights / OpenTelemetry
 // 接続文字列は環境変数 APPLICATIONINSIGHTS_CONNECTION_STRING 経由で供給される。
-// 未設定（ローカル dev 等）の場合 SDK は no-op となり起動・動作には影響しない。
-builder.Services.AddOpenTelemetry().UseAzureMonitor();
+// SDK は接続文字列未設定時に起動失敗例外を投げるため、設定がある場合のみ有効化する。
+// （ローカル dev / CI 等では未設定 → SDK 無効、Azure staging/production では設定あり → 有効）
+var appInsightsConnectionString =
+    Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING");
+if (!string.IsNullOrWhiteSpace(appInsightsConnectionString))
+{
+    builder.Services.AddOpenTelemetry().UseAzureMonitor();
+}
 
 var app = builder.Build();
 

--- a/IdentityProvider/Program.cs
+++ b/IdentityProvider/Program.cs
@@ -7,7 +7,9 @@ using IdentityProvider.Middlewares;
 using IdentityProvider.Models;
 using IdentityProvider.Services;
 using Asp.Versioning;
+using Azure.Monitor.OpenTelemetry.AspNetCore;
 using Microsoft.EntityFrameworkCore;
+using OpenTelemetry;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -85,6 +87,11 @@ builder.Services.AddMvc();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+
+// Application Insights / OpenTelemetry
+// 接続文字列は環境変数 APPLICATIONINSIGHTS_CONNECTION_STRING 経由で供給される。
+// 未設定（ローカル dev 等）の場合 SDK は no-op となり起動・動作には影響しない。
+builder.Services.AddOpenTelemetry().UseAzureMonitor();
 
 var app = builder.Build();
 

--- a/IdentityProvider/Services/B2BPasskeyService.cs
+++ b/IdentityProvider/Services/B2BPasskeyService.cs
@@ -14,6 +14,14 @@ namespace IdentityProvider.Services
     /// </summary>
     public class B2BPasskeyService : IB2BPasskeyService
     {
+        // Application Insights / traces テーブルでの集計クエリ
+        // (`traces | where message startswith "Passkey.Verify.Failed"`) で利用するため、
+        // メッセージテンプレートをクラス定数として一元化する。
+        private const string PasskeyVerifyFailedLogTemplate =
+            "Passkey.Verify.Failed: clientId={ClientId} sessionId={SessionId} reason={FailureReason} detail={ErrorDetail}";
+        private const string PasskeyVerifyFailedExceptionLogTemplate =
+            "Passkey.Verify.Failed: clientId={ClientId} sessionId={SessionId} reason={FailureReason}";
+
         private readonly EcAuthDbContext _context;
         private readonly IFido2 _fido2;
         private readonly IWebAuthnChallengeService _challengeService;
@@ -328,7 +336,7 @@ namespace IdentityProvider.Services
                 if (challenge == null)
                 {
                     _logger.LogWarning(
-                        "Passkey.Verify.Failed: clientId={ClientId} sessionId={SessionId} reason={FailureReason} detail={ErrorDetail}",
+                        PasskeyVerifyFailedLogTemplate,
                         request.ClientId, request.SessionId, "session_not_found", "Session not found or expired");
                     return new IB2BPasskeyService.RegistrationVerifyResult
                     {
@@ -343,7 +351,7 @@ namespace IdentityProvider.Services
                 if (challenge.ExpiresAt < DateTimeOffset.UtcNow)
                 {
                     _logger.LogWarning(
-                        "Passkey.Verify.Failed: clientId={ClientId} sessionId={SessionId} reason={FailureReason} detail={ErrorDetail}",
+                        PasskeyVerifyFailedLogTemplate,
                         request.ClientId, request.SessionId, "challenge_expired", "Challenge has expired");
                     return new IB2BPasskeyService.RegistrationVerifyResult
                     {
@@ -356,7 +364,7 @@ namespace IdentityProvider.Services
                 if (challenge.Type != "registration")
                 {
                     _logger.LogWarning(
-                        "Passkey.Verify.Failed: clientId={ClientId} sessionId={SessionId} reason={FailureReason} detail={ErrorDetail}",
+                        PasskeyVerifyFailedLogTemplate,
                         request.ClientId, request.SessionId, "challenge_type_invalid", "Invalid challenge type");
                     return new IB2BPasskeyService.RegistrationVerifyResult
                     {
@@ -452,7 +460,7 @@ namespace IdentityProvider.Services
             {
                 _logger.LogError(
                     ex,
-                    "Passkey.Verify.Failed: clientId={ClientId} sessionId={SessionId} reason={FailureReason}",
+                    PasskeyVerifyFailedExceptionLogTemplate,
                     request.ClientId, request.SessionId, "fido2_error");
                 return new IB2BPasskeyService.RegistrationVerifyResult
                 {
@@ -573,7 +581,7 @@ namespace IdentityProvider.Services
                 if (challenge == null)
                 {
                     _logger.LogWarning(
-                        "Passkey.Verify.Failed: clientId={ClientId} sessionId={SessionId} reason={FailureReason} detail={ErrorDetail}",
+                        PasskeyVerifyFailedLogTemplate,
                         request.ClientId, request.SessionId, "session_not_found", "Session not found or expired");
                     return new IB2BPasskeyService.AuthenticationVerifyResult
                     {
@@ -588,7 +596,7 @@ namespace IdentityProvider.Services
                 if (challenge.ExpiresAt < DateTimeOffset.UtcNow)
                 {
                     _logger.LogWarning(
-                        "Passkey.Verify.Failed: clientId={ClientId} sessionId={SessionId} reason={FailureReason} detail={ErrorDetail}",
+                        PasskeyVerifyFailedLogTemplate,
                         request.ClientId, request.SessionId, "challenge_expired", "Challenge has expired");
                     return new IB2BPasskeyService.AuthenticationVerifyResult
                     {
@@ -601,7 +609,7 @@ namespace IdentityProvider.Services
                 if (challenge.Type != "authentication")
                 {
                     _logger.LogWarning(
-                        "Passkey.Verify.Failed: clientId={ClientId} sessionId={SessionId} reason={FailureReason} detail={ErrorDetail}",
+                        PasskeyVerifyFailedLogTemplate,
                         request.ClientId, request.SessionId, "challenge_type_invalid", "Invalid challenge type");
                     return new IB2BPasskeyService.AuthenticationVerifyResult
                     {
@@ -621,7 +629,7 @@ namespace IdentityProvider.Services
                 if (credential == null)
                 {
                     _logger.LogWarning(
-                        "Passkey.Verify.Failed: clientId={ClientId} sessionId={SessionId} reason={FailureReason} detail={ErrorDetail}",
+                        PasskeyVerifyFailedLogTemplate,
                         request.ClientId, request.SessionId, "credential_not_found", "Credential not found");
                     return new IB2BPasskeyService.AuthenticationVerifyResult
                     {
@@ -696,7 +704,7 @@ namespace IdentityProvider.Services
             {
                 _logger.LogError(
                     ex,
-                    "Passkey.Verify.Failed: clientId={ClientId} sessionId={SessionId} reason={FailureReason}",
+                    PasskeyVerifyFailedExceptionLogTemplate,
                     request.ClientId, request.SessionId, "fido2_error");
                 return new IB2BPasskeyService.AuthenticationVerifyResult
                 {

--- a/IdentityProvider/Services/B2BPasskeyService.cs
+++ b/IdentityProvider/Services/B2BPasskeyService.cs
@@ -327,6 +327,9 @@ namespace IdentityProvider.Services
                 var challenge = await _challengeService.GetChallengeBySessionIdAsync(request.SessionId);
                 if (challenge == null)
                 {
+                    _logger.LogWarning(
+                        "Passkey.Verify.Failed: clientId={ClientId} sessionId={SessionId} reason={FailureReason} detail={ErrorDetail}",
+                        request.ClientId, request.SessionId, "session_not_found", "Session not found or expired");
                     return new IB2BPasskeyService.RegistrationVerifyResult
                     {
                         Success = false,
@@ -339,6 +342,9 @@ namespace IdentityProvider.Services
                 // 多層防御として明示的に検証。将来の実装変更に対する安全性を確保。
                 if (challenge.ExpiresAt < DateTimeOffset.UtcNow)
                 {
+                    _logger.LogWarning(
+                        "Passkey.Verify.Failed: clientId={ClientId} sessionId={SessionId} reason={FailureReason} detail={ErrorDetail}",
+                        request.ClientId, request.SessionId, "challenge_expired", "Challenge has expired");
                     return new IB2BPasskeyService.RegistrationVerifyResult
                     {
                         Success = false,
@@ -349,6 +355,9 @@ namespace IdentityProvider.Services
                 // タイプチェック
                 if (challenge.Type != "registration")
                 {
+                    _logger.LogWarning(
+                        "Passkey.Verify.Failed: clientId={ClientId} sessionId={SessionId} reason={FailureReason} detail={ErrorDetail}",
+                        request.ClientId, request.SessionId, "challenge_type_invalid", "Invalid challenge type");
                     return new IB2BPasskeyService.RegistrationVerifyResult
                     {
                         Success = false,
@@ -441,7 +450,10 @@ namespace IdentityProvider.Services
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to verify registration for session {SessionId}", request.SessionId);
+                _logger.LogError(
+                    ex,
+                    "Passkey.Verify.Failed: clientId={ClientId} sessionId={SessionId} reason={FailureReason}",
+                    request.ClientId, request.SessionId, "fido2_error");
                 return new IB2BPasskeyService.RegistrationVerifyResult
                 {
                     Success = false,
@@ -560,6 +572,9 @@ namespace IdentityProvider.Services
                 var challenge = await _challengeService.GetChallengeBySessionIdAsync(request.SessionId);
                 if (challenge == null)
                 {
+                    _logger.LogWarning(
+                        "Passkey.Verify.Failed: clientId={ClientId} sessionId={SessionId} reason={FailureReason} detail={ErrorDetail}",
+                        request.ClientId, request.SessionId, "session_not_found", "Session not found or expired");
                     return new IB2BPasskeyService.AuthenticationVerifyResult
                     {
                         Success = false,
@@ -572,6 +587,9 @@ namespace IdentityProvider.Services
                 // 多層防御として明示的に検証。将来の実装変更に対する安全性を確保。
                 if (challenge.ExpiresAt < DateTimeOffset.UtcNow)
                 {
+                    _logger.LogWarning(
+                        "Passkey.Verify.Failed: clientId={ClientId} sessionId={SessionId} reason={FailureReason} detail={ErrorDetail}",
+                        request.ClientId, request.SessionId, "challenge_expired", "Challenge has expired");
                     return new IB2BPasskeyService.AuthenticationVerifyResult
                     {
                         Success = false,
@@ -582,6 +600,9 @@ namespace IdentityProvider.Services
                 // タイプチェック
                 if (challenge.Type != "authentication")
                 {
+                    _logger.LogWarning(
+                        "Passkey.Verify.Failed: clientId={ClientId} sessionId={SessionId} reason={FailureReason} detail={ErrorDetail}",
+                        request.ClientId, request.SessionId, "challenge_type_invalid", "Invalid challenge type");
                     return new IB2BPasskeyService.AuthenticationVerifyResult
                     {
                         Success = false,
@@ -599,6 +620,9 @@ namespace IdentityProvider.Services
 
                 if (credential == null)
                 {
+                    _logger.LogWarning(
+                        "Passkey.Verify.Failed: clientId={ClientId} sessionId={SessionId} reason={FailureReason} detail={ErrorDetail}",
+                        request.ClientId, request.SessionId, "credential_not_found", "Credential not found");
                     return new IB2BPasskeyService.AuthenticationVerifyResult
                     {
                         Success = false,
@@ -670,7 +694,10 @@ namespace IdentityProvider.Services
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to verify authentication for session {SessionId}", request.SessionId);
+                _logger.LogError(
+                    ex,
+                    "Passkey.Verify.Failed: clientId={ClientId} sessionId={SessionId} reason={FailureReason}",
+                    request.ClientId, request.SessionId, "fido2_error");
                 return new IB2BPasskeyService.AuthenticationVerifyResult
                 {
                     Success = false,


### PR DESCRIPTION
## Summary

- インフラ側（#50）で作成済みの Application Insights リソースに対し、IdentityProvider アプリから `requests` / `exceptions` / `dependencies` を送信できるようにする
- `Azure.Monitor.OpenTelemetry.AspNetCore` 1.4.0 を導入し、純正 OpenTelemetry スタイルで自動計装を有効化
- マルチテナント分離可視化のため、テナント名・クライアント ID を span tag (custom dimension) として付与
- B2B パスキー検証失敗の切り分けを容易にするため、各失敗パスに `Passkey.Verify.Failed` の構造化ログを追加

Refs: EcAuth/EcAuthDocs#68 (積み残し)
Closes via: 本 PR が main にマージされ staging/production にデプロイされた時点で Issue クローズ可能

## Changes

### 1. SDK 導入

- `IdentityProvider/IdentityProvider.csproj`: `Azure.Monitor.OpenTelemetry.AspNetCore` 1.4.0 を追加
- `IdentityProvider/Program.cs`: `builder.Services.AddOpenTelemetry().UseAzureMonitor();` を `AddSwaggerGen` の直後に追加
  - 接続文字列は環境変数 `APPLICATIONINSIGHTS_CONNECTION_STRING` から自動認識（appsettings 変更なし）
  - 未設定（ローカル dev 等）の場合は SDK が no-op となり起動・動作に影響しない

### 2. カスタムディメンション付与

- `IdentityProvider/Middlewares/TenantMiddleware.cs`: `tenantService.SetTenant(...)` の直後に `Activity.Current?.SetTag(""tenant.name"", finalTenantName)` を追加。**全リクエスト**に付与される
- `IdentityProvider/Controllers/B2BPasskeyController.cs`: B2B パスキーの 4 アクション（RegisterOptions / RegisterVerify / AuthenticateOptions / AuthenticateVerify）の先頭で `Activity.Current?.SetTag(""client.id"", request.ClientId)` を呼ぶ
  - `List` / `Delete` は Bearer Token 認証で `client_id` を持たないため対象外

### 3. 検証失敗イベント

- `IdentityProvider/Services/B2BPasskeyService.cs`: `VerifyRegistrationAsync` / `VerifyAuthenticationAsync` の各失敗 return 直前に `_logger.LogWarning(""Passkey.Verify.Failed: ..."")` を追加（catch ブロックは `LogError`）
- 失敗理由カテゴリ:
  - `session_not_found` … チャレンジセッション不在
  - `challenge_expired` … チャレンジ期限切れ
  - `challenge_type_invalid` … タイプ不一致（registration/authentication）
  - `credential_not_found` … 認証時にクレデンシャル不在（authenticate のみ）
  - `fido2_error` … Fido2 ライブラリ内例外（attestation/assertion 検証失敗）
- ILogger 経由のログは `Azure.Monitor.OpenTelemetry.AspNetCore` により Application Insights の `traces` テーブルに自動送信される
- クエリ例: `traces | where message startswith ""Passkey.Verify.Failed""`

## スコープ外（後続対応）

- OAuth2 / OIDC 系エンドポイント（`/v1/authorization`, `/v1/token`, `/v1/userinfo` 等）への `client.id` 付与は本 PR では対象外。必要なら別 issue で追従
- `OpenTelemetry.Api 1.14.0` の中重大度脆弱性警告（NU1902 / GHSA-g94r-2vxg-569j）は Azure SDK の transitive 依存。Azure SDK チームの追従待ち

## Test plan

- [x] `dotnet build EcAuth.sln` がエラーなしで完了
- [x] `dotnet test IdentityProvider.Test/IdentityProvider.Test.csproj` で全 526 テスト通過
- [ ] **staging デプロイ後に Log Analytics で以下を確認**（Issue タスク 5）
  - [ ] `requests` テーブルにレコードが流入し、`customDimensions[""tenant.name""]` および `customDimensions[""client.id""]` が記録されている
  - [ ] `exceptions` テーブルにレコードが流入している（B2B パスキーの登録/認証失敗テストで検証）
  - [ ] `traces | where message startswith ""Passkey.Verify.Failed""` で失敗イベントが取得できる
- [ ] **本番デプロイ後に確認**（Issue タスク 6）
  - [ ] 上記と同等のクエリが本番環境でも結果を返す
  - [ ] Application Insights ポータルで response-time / failure-rate アラートが「データあり」状態に遷移

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Azure Monitorとの統合により、分散トレーシング機能を強化しました。認証処理のトレーシング情報にクライアントIDおよびテナント情報が自動的に追加されるようになります。
  * パスキー検証における失敗時のログ記録が構造化され、エラー診断がより詳細になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->