### PR TITLE
feat(telemetry): /token /userinfo /b2b/verify のステップ別プロファイリング追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,74 @@ cd E2ETests && pnpm install && pnpm exec playwright test
 - DbInitializer / シーダーが参照する環境変数は **Azure ランタイム（Terraform `app_settings`）** に設定が必要。CI ワークフローに定義があっても、Terraform に漏れているとアプリ起動時にシーダーがスキップされる
 - B2BPasskeySeeder は DEV 環境では `DEFAULT_*` を、Staging/Production では `STAGING_*` / `PROD_*` プレフィックスの変数を参照する分岐がある。シーダーのコード（`B2BPasskeySeeder.cs`）で実際に参照される全変数名を確認すること
 
+### Application Insights 上のステップ別プロファイリング
+
+`/token` `/userinfo` `register/verify` `authenticate/verify` の各エンドポイントは、`IdentityProvider.Telemetry.TimingScope` を使った `using` ブロックで処理ステップ毎の所要時間を `Activity.Current` のタグとして記録している。Azure Monitor が `Activity` タグを自動的に `customDimensions` にマッピングするため、本番テレメトリ上で内訳をクエリできる。
+
+タグキーは `step.{step_name}.elapsed_ms`（値は `double` ms）。
+
+#### 計測対象（2026-04 時点）
+
+| エンドポイント | ステップ |
+|---|---|
+| `/token` | `client_lookup` / `auth_code_lookup` / `auth_code_mark_used` / `user_lookup` / `token_generate` |
+| `/userinfo` | `auth_header_parse` / `access_token_validate` / `user_lookup` |
+| `/api/external-userinfo` | `auth_header_parse` / `access_token_validate` / `external_userinfo_fetch` |
+| `register/verify` | `client_authenticate` / `service_call`（内訳: `challenge_lookup` / `fido2_make_credential` / `credential_persist` / `challenge_consume`） |
+| `authenticate/verify` | `client_authenticate` / `service_call`（内訳: `challenge_lookup` / `credential_lookup` / `fido2_make_assertion` / `signcount_persist` / `challenge_consume`） |
+
+#### Application Insights クエリ例
+
+`/token` の各ステップの p50 / p95 を分解:
+
+```kusto
+requests
+| where url has "/v1/token" and timestamp > ago(7d)
+| extend
+    step_client_lookup = todouble(customDimensions["step.client_lookup.elapsed_ms"]),
+    step_auth_code_lookup = todouble(customDimensions["step.auth_code_lookup.elapsed_ms"]),
+    step_auth_code_mark_used = todouble(customDimensions["step.auth_code_mark_used.elapsed_ms"]),
+    step_user_lookup = todouble(customDimensions["step.user_lookup.elapsed_ms"]),
+    step_token_generate = todouble(customDimensions["step.token_generate.elapsed_ms"])
+| summarize
+    p50_total = percentile(duration, 50),
+    p95_total = percentile(duration, 95),
+    p50_client = percentile(step_client_lookup, 50),
+    p50_auth_code = percentile(step_auth_code_lookup, 50),
+    p50_user = percentile(step_user_lookup, 50),
+    p50_token = percentile(step_token_generate, 50)
+```
+
+`authenticate/verify` の Fido2 検証本体（`fido2_make_assertion`）が主因かを確認:
+
+```kusto
+requests
+| where url has "authenticate/verify" and timestamp > ago(7d)
+| extend
+    step_fido2 = todouble(customDimensions["step.fido2_make_assertion.elapsed_ms"]),
+    step_lookup = todouble(customDimensions["step.credential_lookup.elapsed_ms"])
+| summarize
+    p50_total = percentile(duration, 50),
+    p50_fido2 = percentile(step_fido2, 50),
+    p50_lookup = percentile(step_lookup, 50)
+| extend
+    fido2_share = round(p50_fido2 / p50_total * 100, 1)
+```
+
+#### 計測ポイントの追加方法
+
+```csharp
+using IdentityProvider.Telemetry;
+
+using (TimingScope.Begin("my_step"))
+{
+    await SomeAsyncWork();
+}
+```
+
+- `Activity.Current` が null（ローカル開発で Application Insights 未設定など）の場合は no-op
+- ネスト可、各スコープが独立して `step.{name}.elapsed_ms` タグを付与
+
 ### マイグレーション設計ルール
 
 - `migrationBuilder.Sql()` でカラムを参照する UPDATE/INSERT 文を書く場合、`EXEC()` 動的 SQL でラップすること

--- a/IdentityProvider.Test/Telemetry/TimingScopeTests.cs
+++ b/IdentityProvider.Test/Telemetry/TimingScopeTests.cs
@@ -64,5 +64,33 @@ namespace IdentityProvider.Test.Telemetry
             Assert.NotNull(activity.GetTagItem("step.outer.elapsed_ms"));
             Assert.NotNull(activity.GetTagItem("step.inner.elapsed_ms"));
         }
+
+        [Fact]
+        public void Dispose_AfterActivityCurrentChanged_TagsTheCapturedActivity()
+        {
+            // スコープ開始時にアクティブだった Activity に対してタグが付与され、
+            // ブロック内で Activity.Current が変化（子 Activity の Start 等）しても
+            // 子 Activity 側にタグが漏れないことを保証する（PR #375 レビュー対応）。
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = _ => true,
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            using var source = new ActivitySource(nameof(TimingScopeTests));
+            using var outer = source.StartActivity("outer_capture")!;
+
+            using (TimingScope.Begin("captured_step"))
+            {
+                // スコープ内で子 Activity を Start/Stop し、Activity.Current を一時的に差し替える
+                using (var inner = source.StartActivity("inner_should_not_get_tag"))
+                {
+                    Thread.Sleep(1);
+                }
+            }
+
+            Assert.NotNull(outer.GetTagItem("step.captured_step.elapsed_ms"));
+        }
     }
 }

--- a/IdentityProvider.Test/Telemetry/TimingScopeTests.cs
+++ b/IdentityProvider.Test/Telemetry/TimingScopeTests.cs
@@ -1,0 +1,68 @@
+using IdentityProvider.Telemetry;
+using System.Diagnostics;
+
+namespace IdentityProvider.Test.Telemetry
+{
+    public class TimingScopeTests
+    {
+        [Fact]
+        public void Dispose_WithoutActivity_DoesNotThrow()
+        {
+            // Activity.Current が null の状況（ActivitySource が未設定 / sampling=false 等）でも
+            // 例外が発生しないことを保証する。本番では SDK 未初期化のローカル環境でも no-op で動く必要がある。
+            Activity.Current = null;
+
+            var scope = TimingScope.Begin("noop_step");
+            scope.Dispose();
+        }
+
+        [Fact]
+        public void Dispose_WithActivity_AddsElapsedTag()
+        {
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = _ => true,
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            using var source = new ActivitySource(nameof(TimingScopeTests));
+            using var activity = source.StartActivity("test")!;
+
+            using (TimingScope.Begin("sample_step"))
+            {
+                Thread.Sleep(2);
+            }
+
+            var tag = activity.GetTagItem("step.sample_step.elapsed_ms");
+            Assert.NotNull(tag);
+            Assert.IsType<double>(tag);
+            Assert.True((double)tag! >= 0.0);
+        }
+
+        [Fact]
+        public void Nested_Scopes_AddIndependentTags()
+        {
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = _ => true,
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            using var source = new ActivitySource(nameof(TimingScopeTests));
+            using var activity = source.StartActivity("test_nested")!;
+
+            using (TimingScope.Begin("outer"))
+            {
+                using (TimingScope.Begin("inner"))
+                {
+                    Thread.Sleep(1);
+                }
+            }
+
+            Assert.NotNull(activity.GetTagItem("step.outer.elapsed_ms"));
+            Assert.NotNull(activity.GetTagItem("step.inner.elapsed_ms"));
+        }
+    }
+}

--- a/IdentityProvider/Controllers/B2BPasskeyController.cs
+++ b/IdentityProvider/Controllers/B2BPasskeyController.cs
@@ -2,6 +2,7 @@ using Fido2NetLib;
 using IdentityProvider.Exceptions;
 using IdentityProvider.Models;
 using IdentityProvider.Services;
+using IdentityProvider.Telemetry;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -256,7 +257,11 @@ namespace IdentityProvider.Controllers
                 }
 
                 // クライアント認証
-                var client = await AuthenticateClientAsync(request.ClientId, request.ClientSecret);
+                Client? client;
+                using (TimingScope.Begin("client_authenticate"))
+                {
+                    client = await AuthenticateClientAsync(request.ClientId, request.ClientSecret);
+                }
                 if (client == null)
                 {
                     _logger.LogWarning("Client authentication failed for: {ClientId}", request.ClientId);
@@ -278,7 +283,11 @@ namespace IdentityProvider.Controllers
                     DeviceName = request.DeviceName
                 };
 
-                var result = await _passkeyService.VerifyRegistrationAsync(serviceRequest);
+                IB2BPasskeyService.RegistrationVerifyResult result;
+                using (TimingScope.Begin("service_call"))
+                {
+                    result = await _passkeyService.VerifyRegistrationAsync(serviceRequest);
+                }
 
                 if (!result.Success)
                 {
@@ -429,10 +438,14 @@ namespace IdentityProvider.Controllers
                 }
 
                 // クライアント存在確認・redirect_uri検証
-                var client = await _context.Clients
-                    .IgnoreQueryFilters()
-                    .Include(c => c.RedirectUris)
-                    .FirstOrDefaultAsync(c => c.ClientId == request.ClientId);
+                Client? client;
+                using (TimingScope.Begin("client_authenticate"))
+                {
+                    client = await _context.Clients
+                        .IgnoreQueryFilters()
+                        .Include(c => c.RedirectUris)
+                        .FirstOrDefaultAsync(c => c.ClientId == request.ClientId);
+                }
 
                 if (client == null)
                 {
@@ -469,7 +482,11 @@ namespace IdentityProvider.Controllers
                     AssertionResponse = request.Response
                 };
 
-                var result = await _passkeyService.VerifyAuthenticationAsync(serviceRequest);
+                IB2BPasskeyService.AuthenticationVerifyResult result;
+                using (TimingScope.Begin("service_call"))
+                {
+                    result = await _passkeyService.VerifyAuthenticationAsync(serviceRequest);
+                }
 
                 if (!result.Success)
                 {

--- a/IdentityProvider/Controllers/ExternalUserInfoController.cs
+++ b/IdentityProvider/Controllers/ExternalUserInfoController.cs
@@ -1,4 +1,5 @@
 using IdentityProvider.Services;
+using IdentityProvider.Telemetry;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Mvc;
 using System.Net.Http.Headers;
@@ -49,58 +50,66 @@ namespace IdentityProvider.Controllers
                     });
                 }
 
-                // 2. Authorization ヘッダーの取得
-                var authorizationHeader = HttpContext.Request.Headers["Authorization"].FirstOrDefault();
-                if (string.IsNullOrEmpty(authorizationHeader))
+                // 2. Authorization ヘッダーの取得 + Bearer Token 解析
+                string accessToken;
+                using (TimingScope.Begin("auth_header_parse"))
                 {
-                    _logger.LogWarning("Authorization header is missing");
-                    return Unauthorized(new
+                    var authorizationHeader = HttpContext.Request.Headers["Authorization"].FirstOrDefault();
+                    if (string.IsNullOrEmpty(authorizationHeader))
                     {
-                        error = "invalid_token",
-                        error_description = "アクセストークンが提供されていません。"
-                    });
+                        _logger.LogWarning("Authorization header is missing");
+                        return Unauthorized(new
+                        {
+                            error = "invalid_token",
+                            error_description = "アクセストークンが提供されていません。"
+                        });
+                    }
+
+                    AuthenticationHeaderValue authHeaderValue;
+                    try
+                    {
+                        authHeaderValue = AuthenticationHeaderValue.Parse(authorizationHeader);
+                    }
+                    catch (FormatException)
+                    {
+                        _logger.LogWarning("Invalid Authorization header format: {Header}", authorizationHeader);
+                        return Unauthorized(new
+                        {
+                            error = "invalid_token",
+                            error_description = "Authorizationヘッダーの形式が正しくありません。"
+                        });
+                    }
+
+                    if (authHeaderValue.Scheme != "Bearer")
+                    {
+                        _logger.LogWarning("Unsupported authentication scheme: {Scheme}", authHeaderValue.Scheme);
+                        return Unauthorized(new
+                        {
+                            error = "invalid_token",
+                            error_description = "Bearer認証のみサポートされています。"
+                        });
+                    }
+
+                    var token = authHeaderValue.Parameter;
+                    if (string.IsNullOrEmpty(token))
+                    {
+                        _logger.LogWarning("Access token is empty");
+                        return Unauthorized(new
+                        {
+                            error = "invalid_token",
+                            error_description = "アクセストークンが空です。"
+                        });
+                    }
+                    accessToken = token;
                 }
 
-                // 3. Bearer Token の解析
-                AuthenticationHeaderValue authHeaderValue;
-                try
-                {
-                    authHeaderValue = AuthenticationHeaderValue.Parse(authorizationHeader);
-                }
-                catch (FormatException)
-                {
-                    _logger.LogWarning("Invalid Authorization header format: {Header}", authorizationHeader);
-                    return Unauthorized(new
-                    {
-                        error = "invalid_token",
-                        error_description = "Authorizationヘッダーの形式が正しくありません。"
-                    });
-                }
-
-                if (authHeaderValue.Scheme != "Bearer")
-                {
-                    _logger.LogWarning("Unsupported authentication scheme: {Scheme}", authHeaderValue.Scheme);
-                    return Unauthorized(new
-                    {
-                        error = "invalid_token",
-                        error_description = "Bearer認証のみサポートされています。"
-                    });
-                }
-
-                var accessToken = authHeaderValue.Parameter;
-                if (string.IsNullOrEmpty(accessToken))
-                {
-                    _logger.LogWarning("Access token is empty");
-                    return Unauthorized(new
-                    {
-                        error = "invalid_token",
-                        error_description = "アクセストークンが空です。"
-                    });
-                }
-
-                // 4. アクセストークンの検証
+                // 3. アクセストークンの検証
                 _logger.LogInformation("Validating access token");
-                var subject = await _tokenService.ValidateAccessTokenAsync(accessToken);
+                string? subject;
+                using (TimingScope.Begin("access_token_validate"))
+                {
+                    subject = await _tokenService.ValidateAccessTokenAsync(accessToken);
+                }
 
                 if (subject == null)
                 {
@@ -112,16 +121,20 @@ namespace IdentityProvider.Controllers
                     });
                 }
 
-                // 5. 外部IdPユーザー情報の取得
+                // 4. 外部IdPユーザー情報の取得
                 _logger.LogInformation("Fetching external user info for subject {Subject} and provider {Provider}",
                     subject, provider);
 
-                var externalUserInfo = await _externalUserInfoService.GetExternalUserInfoAsync(
-                    new IExternalUserInfoService.GetExternalUserInfoRequest
-                    {
-                        EcAuthSubject = subject,
-                        ExternalProvider = provider
-                    });
+                IExternalUserInfoService.ExternalUserInfo? externalUserInfo;
+                using (TimingScope.Begin("external_userinfo_fetch"))
+                {
+                    externalUserInfo = await _externalUserInfoService.GetExternalUserInfoAsync(
+                        new IExternalUserInfoService.GetExternalUserInfoRequest
+                        {
+                            EcAuthSubject = subject,
+                            ExternalProvider = provider
+                        });
+                }
 
                 if (externalUserInfo == null)
                 {

--- a/IdentityProvider/Controllers/ExternalUserInfoController.cs
+++ b/IdentityProvider/Controllers/ExternalUserInfoController.cs
@@ -72,7 +72,8 @@ namespace IdentityProvider.Controllers
                     }
                     catch (FormatException)
                     {
-                        _logger.LogWarning("Invalid Authorization header format: {Header}", authorizationHeader);
+                        // Authorization ヘッダーの生値はアクセストークンを含み得るためログに出力しない
+                        _logger.LogWarning("Invalid Authorization header format");
                         return Unauthorized(new
                         {
                             error = "invalid_token",

--- a/IdentityProvider/Controllers/TokenController.cs
+++ b/IdentityProvider/Controllers/TokenController.cs
@@ -1,5 +1,6 @@
 using IdentityProvider.Models;
 using IdentityProvider.Services;
+using IdentityProvider.Telemetry;
 using IdpUtilities;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Mvc;
@@ -124,8 +125,12 @@ namespace IdentityProvider.Controllers
                 }
 
                 // 2. クライアントの存在確認
-                var client = await _context.Clients
-                    .FirstOrDefaultAsync(c => c.ClientId == client_id);
+                Client? client;
+                using (TimingScope.Begin("client_lookup"))
+                {
+                    client = await _context.Clients
+                        .FirstOrDefaultAsync(c => c.ClientId == client_id);
+                }
 
                 if (client == null)
                 {
@@ -152,8 +157,12 @@ namespace IdentityProvider.Controllers
                 }
 
                 // 5. 認可コードの取得・検証
-                var authorizationCode = await _context.AuthorizationCodes
-                    .FirstOrDefaultAsync(ac => ac.Code == code);
+                AuthorizationCode? authorizationCode;
+                using (TimingScope.Begin("auth_code_lookup"))
+                {
+                    authorizationCode = await _context.AuthorizationCodes
+                        .FirstOrDefaultAsync(ac => ac.Code == code);
+                }
 
                 if (authorizationCode == null)
                 {
@@ -214,7 +223,10 @@ namespace IdentityProvider.Controllers
                 // 10. 認可コードを使用済みにマーキング
                 authorizationCode.IsUsed = true;
                 authorizationCode.UsedAt = DateTimeOffset.UtcNow;
-                await _context.SaveChangesAsync();
+                using (TimingScope.Begin("auth_code_mark_used"))
+                {
+                    await _context.SaveChangesAsync();
+                }
 
                 // 11. SubjectType に応じたユーザー情報の取得
                 var subjectType = authorizationCode.SubjectType;
@@ -242,7 +254,11 @@ namespace IdentityProvider.Controllers
                 if (subjectType == SubjectType.B2B)
                 {
                     // B2B認証の場合: B2BUserを取得
-                    var b2bUser = await _b2bUserService.GetBySubjectAsync(subject);
+                    B2BUser? b2bUser;
+                    using (TimingScope.Begin("user_lookup"))
+                    {
+                        b2bUser = await _b2bUserService.GetBySubjectAsync(subject);
+                    }
                     if (b2bUser == null)
                     {
                         _logger.LogError("B2B user not found for subject: {Subject}", subject);
@@ -267,7 +283,11 @@ namespace IdentityProvider.Controllers
                 else if (subjectType == SubjectType.B2C)
                 {
                     // B2C認証の場合: EcAuthUserを取得（従来の処理）
-                    var user = await _userService.GetUserBySubjectAsync(subject);
+                    EcAuthUser? user;
+                    using (TimingScope.Begin("user_lookup"))
+                    {
+                        user = await _userService.GetUserBySubjectAsync(subject);
+                    }
                     if (user == null)
                     {
                         _logger.LogError("User not found for subject: {Subject}", subject);
@@ -304,7 +324,10 @@ namespace IdentityProvider.Controllers
                 ITokenService.TokenResponse tokenResponse;
                 try
                 {
-                    tokenResponse = await _tokenService.GenerateTokensAsync(tokenRequest);
+                    using (TimingScope.Begin("token_generate"))
+                    {
+                        tokenResponse = await _tokenService.GenerateTokensAsync(tokenRequest);
+                    }
                     _logger.LogInformation("Tokens generated successfully for subject: {Subject}, SubjectType: {SubjectType}, client: {ClientId}",
                         subject, subjectType, client_id);
                 }

--- a/IdentityProvider/Controllers/UserinfoController.cs
+++ b/IdentityProvider/Controllers/UserinfoController.cs
@@ -1,5 +1,6 @@
 using IdentityProvider.Models;
 using IdentityProvider.Services;
+using IdentityProvider.Telemetry;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Mvc;
 using System.Net.Http.Headers;
@@ -61,58 +62,66 @@ namespace IdentityProvider.Controllers
             {
                 _logger.LogInformation("UserInfo endpoint accessed");
 
-                // 1. Authorization ヘッダーの取得
-                var authorizationHeader = HttpContext.Request.Headers["Authorization"].FirstOrDefault();
-                if (string.IsNullOrEmpty(authorizationHeader))
+                // 1. Authorization ヘッダーの取得 + Bearer Token 解析
+                string accessToken;
+                using (TimingScope.Begin("auth_header_parse"))
                 {
-                    _logger.LogWarning("Authorization header is missing");
-                    return Unauthorized(new
+                    var authorizationHeader = HttpContext.Request.Headers["Authorization"].FirstOrDefault();
+                    if (string.IsNullOrEmpty(authorizationHeader))
                     {
-                        error = "invalid_token",
-                        error_description = "アクセストークンが提供されていません。"
-                    });
+                        _logger.LogWarning("Authorization header is missing");
+                        return Unauthorized(new
+                        {
+                            error = "invalid_token",
+                            error_description = "アクセストークンが提供されていません。"
+                        });
+                    }
+
+                    AuthenticationHeaderValue authHeaderValue;
+                    try
+                    {
+                        authHeaderValue = AuthenticationHeaderValue.Parse(authorizationHeader);
+                    }
+                    catch (FormatException)
+                    {
+                        _logger.LogWarning("Invalid Authorization header format: {Header}", authorizationHeader);
+                        return Unauthorized(new
+                        {
+                            error = "invalid_token",
+                            error_description = "Authorizationヘッダーの形式が正しくありません。"
+                        });
+                    }
+
+                    if (authHeaderValue.Scheme != "Bearer")
+                    {
+                        _logger.LogWarning("Unsupported authentication scheme: {Scheme}", authHeaderValue.Scheme);
+                        return Unauthorized(new
+                        {
+                            error = "invalid_token",
+                            error_description = "Bearer認証のみサポートされています。"
+                        });
+                    }
+
+                    var token = authHeaderValue.Parameter;
+                    if (string.IsNullOrEmpty(token))
+                    {
+                        _logger.LogWarning("Access token is empty");
+                        return Unauthorized(new
+                        {
+                            error = "invalid_token",
+                            error_description = "アクセストークンが空です。"
+                        });
+                    }
+                    accessToken = token;
                 }
 
-                // 2. Bearer Token の解析
-                AuthenticationHeaderValue authHeaderValue;
-                try
-                {
-                    authHeaderValue = AuthenticationHeaderValue.Parse(authorizationHeader);
-                }
-                catch (FormatException)
-                {
-                    _logger.LogWarning("Invalid Authorization header format: {Header}", authorizationHeader);
-                    return Unauthorized(new
-                    {
-                        error = "invalid_token",
-                        error_description = "Authorizationヘッダーの形式が正しくありません。"
-                    });
-                }
-
-                if (authHeaderValue.Scheme != "Bearer")
-                {
-                    _logger.LogWarning("Unsupported authentication scheme: {Scheme}", authHeaderValue.Scheme);
-                    return Unauthorized(new
-                    {
-                        error = "invalid_token",
-                        error_description = "Bearer認証のみサポートされています。"
-                    });
-                }
-
-                var accessToken = authHeaderValue.Parameter;
-                if (string.IsNullOrEmpty(accessToken))
-                {
-                    _logger.LogWarning("Access token is empty");
-                    return Unauthorized(new
-                    {
-                        error = "invalid_token",
-                        error_description = "アクセストークンが空です。"
-                    });
-                }
-
-                // 3. アクセストークンの検証（SubjectType を含む詳細な結果を取得）
+                // 2. アクセストークンの検証（SubjectType を含む詳細な結果を取得）
                 _logger.LogInformation("Validating access token");
-                var validationResult = await _tokenService.ValidateAccessTokenWithTypeAsync(accessToken);
+                ITokenService.AccessTokenValidationResult validationResult;
+                using (TimingScope.Begin("access_token_validate"))
+                {
+                    validationResult = await _tokenService.ValidateAccessTokenWithTypeAsync(accessToken);
+                }
 
                 if (!validationResult.IsValid || validationResult.Subject == null)
                 {
@@ -127,28 +136,31 @@ namespace IdentityProvider.Controllers
                 var subject = validationResult.Subject;
                 var subjectType = validationResult.SubjectType ?? SubjectType.B2C;
 
-                // 4. SubjectType に応じたユーザー情報の取得
+                // 3. SubjectType に応じたユーザー情報の取得
                 _logger.LogInformation("Fetching user info for subject: {Subject}, SubjectType: {SubjectType}", subject, subjectType);
 
                 string? userSubject = null;
-                switch (subjectType)
+                using (TimingScope.Begin("user_lookup"))
                 {
-                    case SubjectType.B2B:
-                        var b2bUser = await _b2bUserService.GetBySubjectAsync(subject);
-                        if (b2bUser != null)
-                        {
-                            userSubject = b2bUser.Subject;
-                        }
-                        break;
+                    switch (subjectType)
+                    {
+                        case SubjectType.B2B:
+                            var b2bUser = await _b2bUserService.GetBySubjectAsync(subject);
+                            if (b2bUser != null)
+                            {
+                                userSubject = b2bUser.Subject;
+                            }
+                            break;
 
-                    case SubjectType.B2C:
-                    default:
-                        var ecAuthUser = await _userService.GetUserBySubjectAsync(subject);
-                        if (ecAuthUser != null)
-                        {
-                            userSubject = ecAuthUser.Subject;
-                        }
-                        break;
+                        case SubjectType.B2C:
+                        default:
+                            var ecAuthUser = await _userService.GetUserBySubjectAsync(subject);
+                            if (ecAuthUser != null)
+                            {
+                                userSubject = ecAuthUser.Subject;
+                            }
+                            break;
+                    }
                 }
 
                 if (userSubject == null)

--- a/IdentityProvider/Controllers/UserinfoController.cs
+++ b/IdentityProvider/Controllers/UserinfoController.cs
@@ -84,7 +84,8 @@ namespace IdentityProvider.Controllers
                     }
                     catch (FormatException)
                     {
-                        _logger.LogWarning("Invalid Authorization header format: {Header}", authorizationHeader);
+                        // Authorization ヘッダーの生値はアクセストークンを含み得るためログに出力しない
+                        _logger.LogWarning("Invalid Authorization header format");
                         return Unauthorized(new
                         {
                             error = "invalid_token",

--- a/IdentityProvider/Services/B2BPasskeyService.cs
+++ b/IdentityProvider/Services/B2BPasskeyService.cs
@@ -2,6 +2,7 @@ using Fido2NetLib;
 using Fido2NetLib.Objects;
 using IdentityProvider.Exceptions;
 using IdentityProvider.Models;
+using IdentityProvider.Telemetry;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -332,7 +333,11 @@ namespace IdentityProvider.Services
             try
             {
                 // チャレンジ取得
-                var challenge = await _challengeService.GetChallengeBySessionIdAsync(request.SessionId);
+                WebAuthnChallenge? challenge;
+                using (TimingScope.Begin("challenge_lookup"))
+                {
+                    challenge = await _challengeService.GetChallengeBySessionIdAsync(request.SessionId);
+                }
                 if (challenge == null)
                 {
                     _logger.LogWarning(
@@ -418,12 +423,16 @@ namespace IdentityProvider.Services
                 var dynamicFido2 = _fido2Factory(dynamicConfig);
 
                 // 登録検証（Fido2.NetLib 4.0.0 API）
-                var result = await dynamicFido2.MakeNewCredentialAsync(new MakeNewCredentialParams
+                RegisteredPublicKeyCredential result;
+                using (TimingScope.Begin("fido2_make_credential"))
                 {
-                    AttestationResponse = request.AttestationResponse,
-                    OriginalOptions = options,
-                    IsCredentialIdUniqueToUserCallback = isCredentialIdUnique
-                });
+                    result = await dynamicFido2.MakeNewCredentialAsync(new MakeNewCredentialParams
+                    {
+                        AttestationResponse = request.AttestationResponse,
+                        OriginalOptions = options,
+                        IsCredentialIdUniqueToUserCallback = isCredentialIdUnique
+                    });
+                }
 
                 // クレデンシャル保存
                 var credential = new B2BPasskeyCredential
@@ -440,10 +449,16 @@ namespace IdentityProvider.Services
                 };
 
                 _context.B2BPasskeyCredentials.Add(credential);
-                await _context.SaveChangesAsync();
+                using (TimingScope.Begin("credential_persist"))
+                {
+                    await _context.SaveChangesAsync();
+                }
 
                 // チャレンジ消費
-                await _challengeService.ConsumeChallengeAsync(request.SessionId);
+                using (TimingScope.Begin("challenge_consume"))
+                {
+                    await _challengeService.ConsumeChallengeAsync(request.SessionId);
+                }
 
                 _logger.LogInformation(
                     "Registered passkey for B2BUser {Subject}, CredentialId: {CredentialId}",
@@ -577,7 +592,11 @@ namespace IdentityProvider.Services
             try
             {
                 // チャレンジ取得
-                var challenge = await _challengeService.GetChallengeBySessionIdAsync(request.SessionId);
+                WebAuthnChallenge? challenge;
+                using (TimingScope.Begin("challenge_lookup"))
+                {
+                    challenge = await _challengeService.GetChallengeBySessionIdAsync(request.SessionId);
+                }
                 if (challenge == null)
                 {
                     _logger.LogWarning(
@@ -622,9 +641,13 @@ namespace IdentityProvider.Services
                 // Fido2.NetLib 4.0.0では Id は Base64URL文字列なのでデコードが必要
                 var assertionCredentialIdBytes = WebEncoders.Base64UrlDecode(request.AssertionResponse.Id);
                 // EF Coreは byte[] の == 演算子をSQLに変換可能（SequenceEqualは不可）
-                var credential = await _context.B2BPasskeyCredentials
-                    .IgnoreQueryFilters()
-                    .FirstOrDefaultAsync(c => c.CredentialId == assertionCredentialIdBytes);
+                B2BPasskeyCredential? credential;
+                using (TimingScope.Begin("credential_lookup"))
+                {
+                    credential = await _context.B2BPasskeyCredentials
+                        .IgnoreQueryFilters()
+                        .FirstOrDefaultAsync(c => c.CredentialId == assertionCredentialIdBytes);
+                }
 
                 if (credential == null)
                 {
@@ -671,22 +694,32 @@ namespace IdentityProvider.Services
                 var dynamicFido2 = _fido2Factory(dynamicConfig);
 
                 // 認証検証（Fido2.NetLib 4.0.0 API）
-                var result = await dynamicFido2.MakeAssertionAsync(new MakeAssertionParams
+                VerifyAssertionResult result;
+                using (TimingScope.Begin("fido2_make_assertion"))
                 {
-                    AssertionResponse = request.AssertionResponse,
-                    OriginalOptions = options,
-                    StoredPublicKey = credential.PublicKey,
-                    StoredSignatureCounter = credential.SignCount,
-                    IsUserHandleOwnerOfCredentialIdCallback = isUserHandleOwner
-                });
+                    result = await dynamicFido2.MakeAssertionAsync(new MakeAssertionParams
+                    {
+                        AssertionResponse = request.AssertionResponse,
+                        OriginalOptions = options,
+                        StoredPublicKey = credential.PublicKey,
+                        StoredSignatureCounter = credential.SignCount,
+                        IsUserHandleOwnerOfCredentialIdCallback = isUserHandleOwner
+                    });
+                }
 
                 // SignCount更新
                 credential.SignCount = result.SignCount;
                 credential.LastUsedAt = DateTimeOffset.UtcNow;
-                await _context.SaveChangesAsync();
+                using (TimingScope.Begin("signcount_persist"))
+                {
+                    await _context.SaveChangesAsync();
+                }
 
                 // チャレンジ消費
-                await _challengeService.ConsumeChallengeAsync(request.SessionId);
+                using (TimingScope.Begin("challenge_consume"))
+                {
+                    await _challengeService.ConsumeChallengeAsync(request.SessionId);
+                }
 
                 _logger.LogInformation(
                     "Authenticated B2BUser {Subject} with credential {CredentialId}",

--- a/IdentityProvider/Telemetry/TimingScope.cs
+++ b/IdentityProvider/Telemetry/TimingScope.cs
@@ -1,0 +1,40 @@
+using System.Diagnostics;
+
+namespace IdentityProvider.Telemetry
+{
+    /// <summary>
+    /// 各処理ステップの所要時間を Activity.Current のタグとして記録するスコープヘルパー。
+    /// using ブロックの開始時に Stopwatch を起動し、Dispose 時に経過時間を
+    /// step.{name}.elapsed_ms タグとして付与する。
+    /// Application Insights / Azure Monitor は Activity タグを customDimensions に
+    /// 自動マッピングするため、本番テレメトリ上でステップ単位の所要時間を
+    /// クエリ可能になる（EcAuth/EcAuthDocs#69 のボトルネック特定用）。
+    /// Activity.Current が null の場合（ローカル開発で Application Insights 未設定など）は
+    /// no-op として動作する。
+    /// </summary>
+    public readonly struct TimingScope : IDisposable
+    {
+        private readonly string _stepName;
+        private readonly long _startTimestamp;
+
+        private TimingScope(string stepName)
+        {
+            _stepName = stepName;
+            _startTimestamp = Stopwatch.GetTimestamp();
+        }
+
+        public static TimingScope Begin(string stepName) => new(stepName);
+
+        public void Dispose()
+        {
+            var activity = Activity.Current;
+            if (activity == null)
+            {
+                return;
+            }
+
+            var elapsedMs = Stopwatch.GetElapsedTime(_startTimestamp).TotalMilliseconds;
+            activity.SetTag($"step.{_stepName}.elapsed_ms", elapsedMs);
+        }
+    }
+}

--- a/IdentityProvider/Telemetry/TimingScope.cs
+++ b/IdentityProvider/Telemetry/TimingScope.cs
@@ -16,25 +16,29 @@ namespace IdentityProvider.Telemetry
     {
         private readonly string _stepName;
         private readonly long _startTimestamp;
+        private readonly Activity? _activity;
 
         private TimingScope(string stepName)
         {
             _stepName = stepName;
-            _startTimestamp = Stopwatch.GetTimestamp();
+            // 開始時点の Activity.Current を捕捉する。AsyncLocal ベースの Activity.Current は
+            // using ブロック内の await や子 Activity の Start/Stop で変化し得るため、
+            // Dispose 時に取得すると意図と異なる Activity（または子 Activity）にタグが付く可能性がある。
+            _activity = Activity.Current;
+            _startTimestamp = _activity != null ? Stopwatch.GetTimestamp() : 0;
         }
 
         public static TimingScope Begin(string stepName) => new(stepName);
 
         public void Dispose()
         {
-            var activity = Activity.Current;
-            if (activity == null)
+            if (_activity == null)
             {
                 return;
             }
 
             var elapsedMs = Stopwatch.GetElapsedTime(_startTimestamp).TotalMilliseconds;
-            activity.SetTag($"step.{_stepName}.elapsed_ms", elapsedMs);
+            _activity.SetTag($"step.{_stepName}.elapsed_ms", elapsedMs);
         }
     }
 }


### PR DESCRIPTION
## Summary

[EcAuth/EcAuthDocs#69](https://github.com/EcAuth/EcAuthDocs/issues/69) の追加調査で、本番テレメトリ上の `/token` (1899ms) `/userinfo` (1284ms) の主因が `TokenService` の処理ではない可能性が高いと判明（ローカル `GenerateTokensAsync` 実測 **4.02ms/call** で本番との 460 倍以上の乖離）。

真の主因（ASP.NET Core ミドルウェア / EF Core 初回コンパイル / Fido2 検証本体 / テレメトリ送信 等）を本番 Application Insights 上で特定可能にするため、**各エンドポイントの処理ステップ毎の所要時間を `customDimensions` に出力する** プロファイリング基盤を追加する。

詳細な経緯は [Issue #69 のコメント](https://github.com/EcAuth/EcAuthDocs/issues/69#issuecomment-4335504045) を参照。

## Changes

### 新規ファイル

- `IdentityProvider/Telemetry/TimingScope.cs` — `using` ブロックで `Activity.Current` に `step.{name}.elapsed_ms` タグを付与する `IDisposable` 構造体ヘルパー。`Activity.Current == null` の場合は no-op
- `IdentityProvider.Test/Telemetry/TimingScopeTests.cs` — Activity null 時の no-op、タグ付与、ネスト独立性の 3 ケース

### 計測ポイント追加

| エンドポイント | ステップ |
|---|---|
| `/token` | `client_lookup` / `auth_code_lookup` / `auth_code_mark_used` / `user_lookup` / `token_generate` |
| `/userinfo` | `auth_header_parse` / `access_token_validate` / `user_lookup` |
| `/api/external-userinfo` | `auth_header_parse` / `access_token_validate` / `external_userinfo_fetch` |
| `register/verify` | `client_authenticate` / `service_call`（内訳: `challenge_lookup` / `fido2_make_credential` / `credential_persist` / `challenge_consume`） |
| `authenticate/verify` | `client_authenticate` / `service_call`（内訳: `challenge_lookup` / `credential_lookup` / `fido2_make_assertion` / `signcount_persist` / `challenge_consume`） |

### ドキュメント

- `CLAUDE.md` にプロファイリング用 Kusto クエリ例と計測ポイント追加方法を追記

## 設計のポイント

- **既存の `Activity.SetTag()` パターン**（PR #374 で導入された `tenant.name` / `client.id`）と統一。新規ミドルウェアや DI Scoped サービスを増やさない
- **DB 単独計測は割愛**（Azure Monitor の自動 dependency 計測で取得済み）
- **計測オーバーヘッド <1μs/呼び出し**：本番ボトルネック調査用として常時有効でも問題なし
- ネストされた `service_call`（Controller 層）と内部ステップ（`fido2_make_assertion` 等）の **両層から同時に分解可能**
- ローカル開発環境では `Application Insights` 接続文字列が未設定 → `Activity.Current == null` のため計測は no-op、エラーは出ない

## Test plan

- [x] `dotnet build EcAuth.sln` 通過（0 エラー）
- [x] `dotnet test IdentityProvider.Test/IdentityProvider.Test.csproj` 全件 pass（**529/529**、TimingScope 3 ケース含む）
- [ ] staging デプロイ後、Application Insights で `customDimensions["step.*.elapsed_ms"]` が記録されていることを確認
- [ ] Kusto クエリで各エンドポイントのステップ毎 p50/p95 を取得し、Issue #69 にコメント
- [ ] 主因が確定したら別 PR で個別最適化

## Related issues

- [EcAuth/EcAuthDocs#69](https://github.com/EcAuth/EcAuthDocs/issues/69)（起点 issue）
- 前段 PR: #374（Application Insights 有効化、本 PR のテレメトリ起点）

## スコープ外（別 PR）

- TokenService の `CryptoProviderFactory { CacheSignatureProviders = false }` 削除（実装上、RSA インスタンスの singleton 化が同時に必要）
- RSA 鍵の `IMemoryCache` キャッシュ
- 主因確定後の個別最適化

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * テレメトリ計測ガイドの追加：各エンドポイントにおける段階的な計測方法とAzure Application Insightsクエリの説明を含むドキュメントを追加しました。

* **Tests**
  * 計測機能の新規テストスイートを追加しました。複数のシナリオを検証します。

* **Chores**
  * 複数のエンドポイント及びサービスに計測スコープを実装し、システムの可視化を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->