### PR TITLE
fix(telemetry): TimingScope のタグ値を文字列化して customDimensions に出力する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ cd E2ETests && pnpm install && pnpm exec playwright test
 
 `/token` `/userinfo` `register/verify` `authenticate/verify` の各エンドポイントは、`IdentityProvider.Telemetry.TimingScope` を使った `using` ブロックで処理ステップ毎の所要時間を `Activity.Current` のタグとして記録している。Azure Monitor が `Activity` タグを自動的に `customDimensions` にマッピングするため、本番テレメトリ上で内訳をクエリできる。
 
-タグキーは `step.{step_name}.elapsed_ms`（値は `double` ms）。
+タグキーは `step.{step_name}.elapsed_ms`。値はミリ秒単位の文字列（`InvariantCulture` の `F3` フォーマット、例: `"12.345"`）。Azure Monitor の OpenTelemetry エクスポーターは数値型の Activity タグを customDimensions に出力しないため、SDK 側で文字列化してから `SetTag` する。クエリ側は `todouble(customDimensions["..."])` で数値として扱う。
 
 #### 計測対象（2026-04 時点）
 

--- a/IdentityProvider.Test/Telemetry/TimingScopeTests.cs
+++ b/IdentityProvider.Test/Telemetry/TimingScopeTests.cs
@@ -1,5 +1,6 @@
 using IdentityProvider.Telemetry;
 using System.Diagnostics;
+using System.Globalization;
 
 namespace IdentityProvider.Test.Telemetry
 {
@@ -34,10 +35,13 @@ namespace IdentityProvider.Test.Telemetry
                 Thread.Sleep(2);
             }
 
+            // Azure Monitor が customDimensions にマッピングできるよう、値は文字列で記録される。
+            // クエリ側は todouble() で数値として扱う想定。
             var tag = activity.GetTagItem("step.sample_step.elapsed_ms");
             Assert.NotNull(tag);
-            Assert.IsType<double>(tag);
-            Assert.True((double)tag! >= 0.0);
+            var tagString = Assert.IsType<string>(tag);
+            Assert.True(double.TryParse(tagString, NumberStyles.Float, CultureInfo.InvariantCulture, out var elapsed));
+            Assert.True(elapsed >= 0.0);
         }
 
         [Fact]

--- a/IdentityProvider/Telemetry/TimingScope.cs
+++ b/IdentityProvider/Telemetry/TimingScope.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Globalization;
 
 namespace IdentityProvider.Telemetry
 {
@@ -38,7 +39,13 @@ namespace IdentityProvider.Telemetry
             }
 
             var elapsedMs = Stopwatch.GetElapsedTime(_startTimestamp).TotalMilliseconds;
-            _activity.SetTag($"step.{_stepName}.elapsed_ms", elapsedMs);
+            // Azure Monitor の OpenTelemetry エクスポーター (Azure.Monitor.OpenTelemetry.AspNetCore)
+            // は Activity タグの数値型 (double) を customDimensions にマッピングしないため、
+            // 明示的に文字列化する。クエリ側は todouble(customDimensions["..."]) で数値として扱う。
+            // フォーマットはロケール非依存にするため InvariantCulture を指定。
+            _activity.SetTag(
+                $"step.{_stepName}.elapsed_ms",
+                elapsedMs.ToString("F3", CultureInfo.InvariantCulture));
         }
     }
 }


### PR DESCRIPTION
## Summary

PR #375 を本番デプロイ後 (`cb30f62`、2026-04-28 13:33)、Application Insights の `customDimensions` に **`step.*.elapsed_ms` タグが一切記録されないことが判明** したため修正します。

## 観測結果（本番）

直近 15 分のリクエスト 38 件で:

| タグ | 値の型 | 記録件数 |
|---|---|---:|
| `tenant.name` | `string` | 37 |
| `client.id` | `string` | 8 |
| `step.*.elapsed_ms` | **`double`** | **0** |

`Activity.SetTag()` 経由の他のタグは正常に出力されており、唯一の差分は **値の型**。

## 原因

`Azure.Monitor.OpenTelemetry.AspNetCore 1.4.0` のエクスポーターは `Activity` タグの数値型 (`double`) を `customDimensions` にマッピングしない実装になっている（`customDimensions` は string 型のみサポート）。SDK 側で明示的に文字列化する必要がある。

## Changes

- `IdentityProvider/Telemetry/TimingScope.cs`: `Dispose` 内で `elapsedMs` を `InvariantCulture` の `F3` フォーマット（例: `"12.345"`）で文字列化してから `SetTag` に渡す
- `IdentityProvider.Test/Telemetry/TimingScopeTests.cs`: `Dispose_WithActivity_AddsElapsedTag` のアサーションを文字列前提に変更（`string` 型確認 + `double.TryParse` で数値検証）
- `CLAUDE.md`: タグ値の説明を「文字列で記録、クエリ側で `todouble()` 変換」に更新

## Test plan

- [x] `dotnet build EcAuth.sln` 通過（0 エラー）
- [x] TimingScope 関連テスト 4/4 pass
- [x] 全件テスト 530/530 pass
- [ ] 本番デプロイ後、`requests | extend keys = bag_keys(customDimensions) | mv-expand key = keys to typeof(string) | where key startswith 'step.'` で step タグが記録されることを確認
- [ ] CLAUDE.md の Kusto クエリで各エンドポイントのステップ毎 p50/p95 を取得し、Issue #69 にコメント

## Backwards compatibility

クエリ側は既に `todouble(customDimensions["step.xxx.elapsed_ms"])` として実装済み（PR #375 の CLAUDE.md）。文字列でも数値でも `todouble()` は正しく動作するため、本番運用クエリの変更は不要。

## Related

- 起点: [EcAuth/EcAuthDocs#69](https://github.com/EcAuth/EcAuthDocs/issues/69)
- 元 PR: #375（プロファイリング基盤を導入したが値が記録されない不具合）