### PR TITLE
feat: OIDC Discovery / JWKS エンドポイントを実装（案A サブドメイン型 issuer）

### DIFF
--- a/.github/scripts/verify-federation-auth.sh
+++ b/.github/scripts/verify-federation-auth.sh
@@ -81,6 +81,53 @@ main() {
   write_summary "| ステップ | 結果 |"
   write_summary "|----------|------|"
 
+  # Step 0: OIDC Discovery / JWKS エンドポイント
+  # 以前は当該エンドポイントを 200|404 のいずれでも合格とみなしていたが、
+  # 実装後は 200 を厳格に要求する（EcAuthDocs#83）。
+  log_step "Step 0: OIDC Discovery / JWKS エンドポイント"
+
+  DISCOVERY_URL="${ECAUTH_BASE_URL}/.well-known/openid-configuration"
+  DISCOVERY_STATUS=$(curl -s -o /tmp/discovery.json -w "%{http_code}" "$DISCOVERY_URL" 2>/dev/null || echo "000")
+  if [ "$DISCOVERY_STATUS" != "200" ]; then
+    log_error "Discovery endpoint did not return 200 (got: $DISCOVERY_STATUS)"
+    write_summary "| OIDC Discovery | ❌ HTTP $DISCOVERY_STATUS |"
+    write_output "result" "failure"
+    write_output "failed_step" "discovery_endpoint"
+    exit 1
+  fi
+
+  ISSUER=$(jq -r '.issuer // empty' /tmp/discovery.json)
+  JWKS_URI=$(jq -r '.jwks_uri // empty' /tmp/discovery.json)
+  if [ -z "$ISSUER" ] || [ -z "$JWKS_URI" ]; then
+    log_error "Discovery metadata is missing issuer or jwks_uri"
+    write_summary "| OIDC Discovery | ❌ Missing issuer/jwks_uri |"
+    write_output "result" "failure"
+    write_output "failed_step" "discovery_metadata"
+    exit 1
+  fi
+  log_info "Discovery OK (issuer=$ISSUER)"
+  write_summary "| OIDC Discovery | ✅ |"
+
+  # jwks_uri を辿って JWKS が 200 で公開鍵を返すことを確認
+  JWKS_STATUS=$(curl -s -o /tmp/jwks.json -w "%{http_code}" "$JWKS_URI" 2>/dev/null || echo "000")
+  if [ "$JWKS_STATUS" != "200" ]; then
+    log_error "JWKS endpoint did not return 200 (got: $JWKS_STATUS)"
+    write_summary "| JWKS | ❌ HTTP $JWKS_STATUS |"
+    write_output "result" "failure"
+    write_output "failed_step" "jwks_endpoint"
+    exit 1
+  fi
+  JWKS_KEY_COUNT=$(jq '.keys | length' /tmp/jwks.json 2>/dev/null || echo "0")
+  if [ "$JWKS_KEY_COUNT" -lt 1 ]; then
+    log_error "JWKS returned no keys"
+    write_summary "| JWKS | ❌ No keys |"
+    write_output "result" "failure"
+    write_output "failed_step" "jwks_keys"
+    exit 1
+  fi
+  log_info "JWKS OK ($JWKS_KEY_COUNT key(s))"
+  write_summary "| JWKS | ✅ |"
+
   # Step 1: EcAuth 認可エンドポイント
   log_step "Step 1: EcAuth 認可エンドポイント"
   MOCKIDP_URL=$(curl -s -i "${ECAUTH_BASE_URL}/v1/authorization?client_id=${CLIENT_ID}&redirect_uri=https%3A%2F%2Flocalhost%3A8081%2Fv1%2Fauth%2Fcallback&response_type=code&scope=openid%20profile%20email&provider_name=${MOCK_IDP_PROVIDER_NAME}&state=test123" 2>/dev/null | grep -i "^location:" | sed 's/location: //i' | tr -d '\r')

--- a/E2ETests/tests/specs/oidc_discovery.spec.ts
+++ b/E2ETests/tests/specs/oidc_discovery.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect, request } from '@playwright/test';
+
+/**
+ * OIDC Discovery / JWKS エンドポイントの動作確認。
+ *
+ * 以前は run-e2e-docker.sh が /.well-known/openid-configuration を 200|404 の
+ * いずれでも合格とみなしており、未実装でもチェックが通ってしまっていた。
+ * 実装後はこのテストで 200 を厳格に要求し、Provider Metadata と JWKS の構造を検証する。
+ *
+ * 設計判断（EcAuthDocs#83）:
+ * - issuer は案A サブドメイン型（{scheme}://{host}）。
+ * - authorization_endpoint / response_types_supported / code_challenge_methods_supported は
+ *   意図的に省略しているため「含まれないこと」も明示的に検証する。
+ */
+test.describe('OIDC Discovery / JWKS エンドポイントのテストをします', () => {
+  // ローカル Docker / GitHub Actions では IdP は https://localhost:8081 で待ち受ける。
+  // issuer は Request の {scheme}://{host} 由来のため localhost:8081 はポートを含む。
+  const issuer = process.env.E2E_ISSUER || 'https://localhost:8081';
+  const discoveryEndpoint =
+    process.env.E2E_DISCOVERY_ENDPOINT || `${issuer}/.well-known/openid-configuration`;
+
+  test('Discovery が 200 を返し Provider Metadata を広告すること', async () => {
+    const ctx = await request.newContext({ ignoreHTTPSErrors: true });
+
+    const res = await ctx.get(discoveryEndpoint);
+    expect(res.status()).toBe(200);
+
+    const meta = await res.json();
+
+    // issuer と各エンドポイント URL が issuer を基底にしていること
+    expect(meta.issuer).toBe(issuer);
+    expect(meta.token_endpoint).toBe(`${issuer}/v1/token`);
+    expect(meta.userinfo_endpoint).toBe(`${issuer}/v1/userinfo`);
+    expect(meta.jwks_uri).toBe(`${issuer}/.well-known/jwks.json`);
+
+    // 実装実態に合わせた広告値
+    expect(meta.grant_types_supported).toContain('authorization_code');
+    expect(meta.token_endpoint_auth_methods_supported).toEqual(
+      expect.arrayContaining(['client_secret_post', 'none'])
+    );
+    expect(meta.id_token_signing_alg_values_supported).toContain('RS256');
+    expect(meta.subject_types_supported).toContain('public');
+    expect(meta.scopes_supported).toEqual(
+      expect.arrayContaining(['openid', 'email', 'profile'])
+    );
+    expect(meta.claims_supported).toContain('sub');
+
+    // 意図的に省略しているフィールドが含まれないこと（設計判断の固定）
+    expect(meta).not.toHaveProperty('authorization_endpoint');
+    expect(meta).not.toHaveProperty('response_types_supported');
+    expect(meta).not.toHaveProperty('code_challenge_methods_supported');
+
+    await ctx.dispose();
+  });
+
+  test('jwks_uri が 200 を返し RS256 公開鍵を JWK で配信すること', async () => {
+    const ctx = await request.newContext({ ignoreHTTPSErrors: true });
+
+    // Discovery から jwks_uri を取得し、その URL を辿って検証する（リンク整合性も担保）
+    const discovery = await ctx.get(discoveryEndpoint);
+    expect(discovery.status()).toBe(200);
+    const jwksUri = (await discovery.json()).jwks_uri as string;
+
+    const res = await ctx.get(jwksUri);
+    expect(res.status()).toBe(200);
+
+    const jwks = await res.json();
+    expect(Array.isArray(jwks.keys)).toBe(true);
+    // 既定テナント（example）には active な RsaKeyPair がシードされているため 1 件以上返る
+    expect(jwks.keys.length).toBeGreaterThanOrEqual(1);
+
+    const key = jwks.keys[0];
+    expect(key.kty).toBe('RSA');
+    expect(key.use).toBe('sig');
+    expect(key.alg).toBe('RS256');
+    expect(typeof key.kid).toBe('string');
+    expect(key.kid.length).toBeGreaterThan(0);
+    expect(typeof key.n).toBe('string');
+    expect(key.n.length).toBeGreaterThan(0);
+    expect(typeof key.e).toBe('string');
+    expect(key.e.length).toBeGreaterThan(0);
+
+    await ctx.dispose();
+  });
+});

--- a/IdentityProvider.Test/Controllers/B2BPasskeyControllerIntegrationTests.cs
+++ b/IdentityProvider.Test/Controllers/B2BPasskeyControllerIntegrationTests.cs
@@ -68,11 +68,8 @@ namespace IdentityProvider.Test.Controllers
             _authCodeService = new AuthorizationCodeService(_context, authCodeLogger.Object);
 
             var tokenLogger = new Mock<ILogger<TokenService>>();
-            var httpContext = new DefaultHttpContext();
-            httpContext.Request.Scheme = "https";
-            httpContext.Request.Host = new HostString("test.ec-cube.io");
-            var httpContextAccessor = new HttpContextAccessor { HttpContext = httpContext };
-            _tokenService = new TokenService(_context, tokenLogger.Object, httpContextAccessor);
+            var issuerResolver = TestDbContextHelper.CreateIssuerResolver(host: "test.ec-cube.io");
+            _tokenService = new TokenService(_context, tokenLogger.Object, issuerResolver);
 
             _mockControllerLogger = new Mock<ILogger<B2BPasskeyController>>();
             _mockTokenService = new Mock<ITokenService>();

--- a/IdentityProvider.Test/Controllers/IssuerConsistencyTests.cs
+++ b/IdentityProvider.Test/Controllers/IssuerConsistencyTests.cs
@@ -1,0 +1,87 @@
+using System.IdentityModel.Tokens.Jwt;
+using IdentityProvider.Controllers;
+using IdentityProvider.Models;
+using IdentityProvider.Services;
+using IdentityProvider.Test.TestHelpers;
+using IdpUtilities;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace IdentityProvider.Test.Controllers
+{
+    /// <summary>
+    /// 回帰防止: OpenID Connect Discovery が返す issuer と、TokenService が発行する
+    /// ID Token の iss クレームが「完全一致」することを保証する。
+    /// 両者は同一の IIssuerResolver を単一ソースとして参照するため、同じ HttpContext
+    /// （= 同じ scheme/host）を与えれば必ず一致しなければならない。
+    /// この一致が崩れると RP 側の iss 検証が失敗するため、最重要の不変条件として固定する。
+    /// </summary>
+    public class IssuerConsistencyTests
+    {
+        [Theory]
+        [InlineData("https", "tenant.ec-cube.io")]
+        [InlineData("https", "another.example.com:9443")]
+        [InlineData("http", "localhost:8080")]
+        public async Task DiscoveryIssuer_AndIdTokenIssClaim_AreIdentical(string scheme, string host)
+        {
+            // Arrange - Discovery と TokenService に「同一の」IIssuerResolver を注入する
+            var issuerResolver = TestDbContextHelper.CreateIssuerResolver(scheme: scheme, host: host);
+
+            using var context = TestDbContextHelper.CreateInMemoryContext();
+            var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
+            var tokenService = new TokenService(context, loggerFactory.CreateLogger<TokenService>(), issuerResolver);
+
+            var (client, user) = await SetupTestDataAsync(context);
+
+            // Act - Discovery の issuer を取得
+            var discoveryController = new OpenIdConfigurationController(issuerResolver);
+            var jsonResult = Assert.IsType<JsonResult>(discoveryController.Get());
+            var metadata = Assert.IsType<Dictionary<string, object>>(jsonResult.Value);
+            var discoveryIssuer = Assert.IsType<string>(metadata["issuer"]);
+
+            // ID Token を生成し iss クレームを取得
+            var idToken = await tokenService.GenerateIdTokenAsync(new ITokenService.TokenRequest
+            {
+                User = user,
+                Client = client,
+                RequestedScopes = new[] { "openid" }
+            });
+            var jwt = new JwtSecurityTokenHandler().ReadJwtToken(idToken);
+            var issClaim = jwt.Claims.FirstOrDefault(c => c.Type == JwtRegisteredClaimNames.Iss)?.Value;
+
+            // Assert - 完全一致
+            Assert.Equal($"{scheme}://{host}", discoveryIssuer);
+            Assert.Equal(discoveryIssuer, issClaim);
+        }
+
+        private static async Task<(Client client, EcAuthUser user)> SetupTestDataAsync(EcAuthDbContext context)
+        {
+            var organization = new Organization { Id = 1, Code = "TESTORG", Name = "TestOrg", TenantName = "test-tenant" };
+            context.Organizations.Add(organization);
+
+            var client = new Client
+            {
+                Id = 1,
+                ClientId = "test-client",
+                ClientSecret = "test-secret",
+                AppName = "Test App",
+                OrganizationId = 1
+            };
+            context.Clients.Add(client);
+
+            var user = new EcAuthUser
+            {
+                Subject = "test-subject",
+                EmailHash = EmailHashUtil.HashEmail("test@example.com"),
+                OrganizationId = 1
+            };
+            context.EcAuthUsers.Add(user);
+
+            TestDbContextHelper.GenerateAndAddRsaKeyPair(context, organization, 1);
+
+            await context.SaveChangesAsync();
+            return (client, user);
+        }
+    }
+}

--- a/IdentityProvider.Test/Controllers/JwksControllerTests.cs
+++ b/IdentityProvider.Test/Controllers/JwksControllerTests.cs
@@ -1,0 +1,194 @@
+using System.Security.Cryptography;
+using IdentityProvider.Controllers;
+using IdentityProvider.Models;
+using IdentityProvider.Services;
+using IdentityProvider.Test.TestHelpers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace IdentityProvider.Test.Controllers
+{
+    public class JwksControllerTests
+    {
+        private readonly ILogger<JwksController> _logger;
+
+        public JwksControllerTests()
+        {
+            var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
+            _logger = loggerFactory.CreateLogger<JwksController>();
+        }
+
+        /// <summary>
+        /// 匿名オブジェクトのプロパティ値をリフレクションで取得する。
+        /// JwksController は匿名型で JWK を構築するため、テスト側もリフレクションで検証する。
+        /// </summary>
+        private static object? GetProp(object obj, string name)
+            => obj.GetType().GetProperty(name)?.GetValue(obj);
+
+        /// <summary>
+        /// Ok(new { keys }) の keys を List&lt;object&gt; として取り出す。
+        /// </summary>
+        private static List<object> GetKeys(IActionResult result)
+        {
+            var ok = Assert.IsType<OkObjectResult>(result);
+            Assert.NotNull(ok.Value);
+            var keysObj = GetProp(ok.Value!, "keys");
+            Assert.NotNull(keysObj);
+            var keys = Assert.IsAssignableFrom<System.Collections.IEnumerable>(keysObj!);
+            return keys.Cast<object>().ToList();
+        }
+
+        [Fact]
+        public async Task Get_ActiveRsaKeyPair_ReturnsJwkWithCorrectFields()
+        {
+            // Arrange - MockTenantService の TenantName "test-tenant" に合わせた Organization を用意
+            using var context = TestDbContextHelper.CreateInMemoryContext();
+            var organization = new Organization { Id = 1, Code = "TESTORG", Name = "TestOrg", TenantName = "test-tenant" };
+            context.Organizations.Add(organization);
+
+            // 公開鍵パラメータ（n/e）の期待値を保持するため、ここで鍵を生成する
+            RSAParameters expected;
+            string publicKeyDer, kid;
+            using (var rsa = RSA.Create(2048))
+            {
+                expected = rsa.ExportParameters(false);
+                publicKeyDer = Convert.ToBase64String(rsa.ExportRSAPublicKey());
+            }
+            kid = Guid.NewGuid().ToString();
+
+            context.RsaKeyPairs.Add(new RsaKeyPair
+            {
+                Id = 1,
+                Kid = kid,
+                OrganizationId = organization.Id,
+                PublicKey = publicKeyDer,
+                PrivateKey = "unused-in-jwks",
+                IsActive = true,
+                Organization = organization
+            });
+            await context.SaveChangesAsync();
+
+            var controller = new JwksController(context, new MockTenantService(), _logger);
+
+            // Act
+            var keys = GetKeys(await controller.Get());
+
+            // Assert - active 鍵 1 件が JWK として返ること
+            var jwk = Assert.Single(keys);
+            Assert.Equal("RSA", GetProp(jwk, "kty"));
+            Assert.Equal("sig", GetProp(jwk, "use"));
+            Assert.Equal("RS256", GetProp(jwk, "alg"));
+            Assert.Equal(kid, GetProp(jwk, "kid"));
+
+            // n/e が元の公開鍵パラメータと一致すること（Base64Url エンコードして比較）
+            var expectedN = Base64UrlEncoder.Encode(expected.Modulus);
+            var expectedE = Base64UrlEncoder.Encode(expected.Exponent);
+            Assert.Equal(expectedN, GetProp(jwk, "n"));
+            Assert.Equal(expectedE, GetProp(jwk, "e"));
+
+            // 逆方向検証: n/e から復元した公開鍵が元の鍵と一致すること
+            using var restored = RSA.Create();
+            restored.ImportParameters(new RSAParameters
+            {
+                Modulus = Base64UrlEncoder.DecodeBytes((string)GetProp(jwk, "n")!),
+                Exponent = Base64UrlEncoder.DecodeBytes((string)GetProp(jwk, "e")!)
+            });
+            var restoredParams = restored.ExportParameters(false);
+            Assert.Equal(expected.Modulus, restoredParams.Modulus);
+            Assert.Equal(expected.Exponent, restoredParams.Exponent);
+        }
+
+        [Fact]
+        public async Task Get_NoActiveKey_ReturnsEmptyKeys()
+        {
+            // Arrange - Organization はあるが active 鍵が無い（IsActive=false のみ）
+            using var context = TestDbContextHelper.CreateInMemoryContext();
+            var organization = new Organization { Id = 1, Code = "TESTORG", Name = "TestOrg", TenantName = "test-tenant" };
+            context.Organizations.Add(organization);
+
+            string publicKeyDer;
+            using (var rsa = RSA.Create(2048))
+            {
+                publicKeyDer = Convert.ToBase64String(rsa.ExportRSAPublicKey());
+            }
+
+            context.RsaKeyPairs.Add(new RsaKeyPair
+            {
+                Id = 1,
+                Kid = Guid.NewGuid().ToString(),
+                OrganizationId = organization.Id,
+                PublicKey = publicKeyDer,
+                PrivateKey = "unused",
+                IsActive = false, // 無効化済み
+                Organization = organization
+            });
+            await context.SaveChangesAsync();
+
+            var controller = new JwksController(context, new MockTenantService(), _logger);
+
+            // Act
+            var keys = GetKeys(await controller.Get());
+
+            // Assert - 空配列（500 にしない）
+            Assert.Empty(keys);
+        }
+
+        [Fact]
+        public async Task Get_OrganizationNotFound_ReturnsEmptyKeys()
+        {
+            // Arrange - Organization を一切登録しない
+            using var context = TestDbContextHelper.CreateInMemoryContext();
+            var controller = new JwksController(context, new MockTenantService(), _logger);
+
+            // Act
+            var keys = GetKeys(await controller.Get());
+
+            // Assert - 空配列を返し例外にしない
+            Assert.Empty(keys);
+        }
+
+        [Fact]
+        public async Task Get_MultipleActiveKeys_ReturnsAllAsJwk()
+        {
+            // Arrange - active 鍵を 2 件用意
+            using var context = TestDbContextHelper.CreateInMemoryContext();
+            var organization = new Organization { Id = 1, Code = "TESTORG", Name = "TestOrg", TenantName = "test-tenant" };
+            context.Organizations.Add(organization);
+
+            var kids = new List<string>();
+            for (var i = 1; i <= 2; i++)
+            {
+                string publicKeyDer;
+                using (var rsa = RSA.Create(2048))
+                {
+                    publicKeyDer = Convert.ToBase64String(rsa.ExportRSAPublicKey());
+                }
+                var kid = Guid.NewGuid().ToString();
+                kids.Add(kid);
+                context.RsaKeyPairs.Add(new RsaKeyPair
+                {
+                    Id = i,
+                    Kid = kid,
+                    OrganizationId = organization.Id,
+                    PublicKey = publicKeyDer,
+                    PrivateKey = "unused",
+                    IsActive = true,
+                    Organization = organization
+                });
+            }
+            await context.SaveChangesAsync();
+
+            var controller = new JwksController(context, new MockTenantService(), _logger);
+
+            // Act
+            var keys = GetKeys(await controller.Get());
+
+            // Assert - 2 件とも返り、kid が一致すること
+            Assert.Equal(2, keys.Count);
+            var returnedKids = keys.Select(k => (string)GetProp(k, "kid")!).ToList();
+            Assert.All(kids, kid => Assert.Contains(kid, returnedKids));
+        }
+    }
+}

--- a/IdentityProvider.Test/Controllers/OpenIdConfigurationControllerTests.cs
+++ b/IdentityProvider.Test/Controllers/OpenIdConfigurationControllerTests.cs
@@ -1,0 +1,116 @@
+using IdentityProvider.Controllers;
+using IdentityProvider.Services;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace IdentityProvider.Test.Controllers
+{
+    public class OpenIdConfigurationControllerTests
+    {
+        private readonly Mock<IIssuerResolver> _mockIssuerResolver;
+        private readonly OpenIdConfigurationController _controller;
+
+        private const string TestIssuer = "https://tenant.ec-cube.io";
+
+        public OpenIdConfigurationControllerTests()
+        {
+            _mockIssuerResolver = new Mock<IIssuerResolver>();
+            _mockIssuerResolver.Setup(x => x.GetIssuer()).Returns(TestIssuer);
+            _controller = new OpenIdConfigurationController(_mockIssuerResolver.Object);
+        }
+
+        private static Dictionary<string, object> GetMetadata(IActionResult result)
+        {
+            var jsonResult = Assert.IsType<JsonResult>(result);
+            var metadata = Assert.IsType<Dictionary<string, object>>(jsonResult.Value);
+            return metadata;
+        }
+
+        [Fact]
+        public void Get_ReturnsRequiredDiscoveryFields()
+        {
+            // Act
+            var metadata = GetMetadata(_controller.Get());
+
+            // Assert - 確定フィールドが全て含まれること
+            Assert.Equal(TestIssuer, metadata["issuer"]);
+            Assert.Equal($"{TestIssuer}/v1/token", metadata["token_endpoint"]);
+            Assert.Equal($"{TestIssuer}/v1/userinfo", metadata["userinfo_endpoint"]);
+            Assert.Equal($"{TestIssuer}/.well-known/jwks.json", metadata["jwks_uri"]);
+
+            Assert.Equal(new[] { "authorization_code" }, Assert.IsType<string[]>(metadata["grant_types_supported"]));
+            Assert.Equal(new[] { "client_secret_post", "none" }, Assert.IsType<string[]>(metadata["token_endpoint_auth_methods_supported"]));
+            Assert.Equal(new[] { "RS256" }, Assert.IsType<string[]>(metadata["id_token_signing_alg_values_supported"]));
+            Assert.Equal(new[] { "public" }, Assert.IsType<string[]>(metadata["subject_types_supported"]));
+            Assert.Equal(new[] { "openid", "email", "profile" }, Assert.IsType<string[]>(metadata["scopes_supported"]));
+            Assert.Equal(new[] { "sub" }, Assert.IsType<string[]>(metadata["claims_supported"]));
+        }
+
+        [Fact]
+        public void Get_IssuerReflectsRequestHost()
+        {
+            // Arrange - 別ホストを返す resolver に差し替え
+            var otherIssuer = "https://another-tenant.example.com";
+            _mockIssuerResolver.Setup(x => x.GetIssuer()).Returns(otherIssuer);
+
+            // Act
+            var metadata = GetMetadata(_controller.Get());
+
+            // Assert - issuer がリクエスト Host を反映すること
+            Assert.Equal(otherIssuer, metadata["issuer"]);
+            // 各 endpoint URL が issuer を基底に組み立てられること
+            Assert.Equal($"{otherIssuer}/v1/token", metadata["token_endpoint"]);
+            Assert.Equal($"{otherIssuer}/v1/userinfo", metadata["userinfo_endpoint"]);
+            Assert.Equal($"{otherIssuer}/.well-known/jwks.json", metadata["jwks_uri"]);
+        }
+
+        [Fact]
+        public void Get_AllEndpointUrlsAreRootedAtIssuer()
+        {
+            // Act
+            var metadata = GetMetadata(_controller.Get());
+
+            // Assert - URL を含む全フィールドが issuer を前置していること
+            foreach (var key in new[] { "token_endpoint", "userinfo_endpoint", "jwks_uri" })
+            {
+                var url = Assert.IsType<string>(metadata[key]);
+                Assert.StartsWith(TestIssuer + "/", url);
+            }
+        }
+
+        [Fact]
+        public void Get_DoesNotExposeAuthorizationEndpoint()
+        {
+            // Act
+            var metadata = GetMetadata(_controller.Get());
+
+            // Assert - /v1/authorization は非標準のフェデレーション proxy のため
+            // authorization_endpoint は意図的に省略される（設計判断）。
+            Assert.False(metadata.ContainsKey("authorization_endpoint"),
+                "authorization_endpoint は意図的に省略されるべき（非標準フェデレーション proxy のため）");
+        }
+
+        [Fact]
+        public void Get_DoesNotExposeResponseTypesSupported()
+        {
+            // Act
+            var metadata = GetMetadata(_controller.Get());
+
+            // Assert - authorization_endpoint 非公開に伴い response_types_supported も省略される。
+            Assert.False(metadata.ContainsKey("response_types_supported"),
+                "response_types_supported は意図的に省略されるべき（authorization_endpoint 非公開に伴う）");
+        }
+
+        [Fact]
+        public void Get_DoesNotExposeCodeChallengeMethodsSupported()
+        {
+            // Act
+            var metadata = GetMetadata(_controller.Get());
+
+            // Assert - PKCE 未実装のため code_challenge_methods_supported も省略される。
+            Assert.False(metadata.ContainsKey("code_challenge_methods_supported"),
+                "code_challenge_methods_supported は意図的に省略されるべき（PKCE 未実装のため）");
+        }
+    }
+}

--- a/IdentityProvider.Test/Controllers/UserinfoControllerIntegrationTests.cs
+++ b/IdentityProvider.Test/Controllers/UserinfoControllerIntegrationTests.cs
@@ -34,12 +34,9 @@ namespace IdentityProvider.Test.Controllers
             var mockLogger = new Mock<ILogger<TokenService>>();
             var mockUserLogger = new Mock<ILogger<UserService>>();
 
-            var httpContext = new DefaultHttpContext();
-            httpContext.Request.Scheme = "https";
-            httpContext.Request.Host = new HostString("test.ec-cube.io");
-            var httpContextAccessor = new HttpContextAccessor { HttpContext = httpContext };
+            var issuerResolver = TestDbContextHelper.CreateIssuerResolver(host: "test.ec-cube.io");
 
-            _tokenService = new TokenService(_context, mockLogger.Object, httpContextAccessor);
+            _tokenService = new TokenService(_context, mockLogger.Object, issuerResolver);
             _userService = new UserService(_context, mockUserLogger.Object);
             _mockB2BUserService = new Mock<IB2BUserService>();
 

--- a/IdentityProvider.Test/Services/IssuerResolverTests.cs
+++ b/IdentityProvider.Test/Services/IssuerResolverTests.cs
@@ -1,0 +1,57 @@
+using IdentityProvider.Services;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace IdentityProvider.Test.Services
+{
+    public class IssuerResolverTests
+    {
+        [Fact]
+        public void GetIssuer_WithHttpContext_ReturnsSchemeAndHost()
+        {
+            // Arrange
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Scheme = "https";
+            httpContext.Request.Host = new HostString("acme.ec-cube.io");
+            var accessor = new HttpContextAccessor { HttpContext = httpContext };
+            var resolver = new IssuerResolver(accessor);
+
+            // Act
+            var issuer = resolver.GetIssuer();
+
+            // Assert
+            Assert.Equal("https://acme.ec-cube.io", issuer);
+        }
+
+        [Theory]
+        [InlineData("https", "example.com", "https://example.com")]
+        [InlineData("http", "localhost:8080", "http://localhost:8080")]
+        [InlineData("https", "tenant.example.co.jp:9443", "https://tenant.example.co.jp:9443")]
+        public void GetIssuer_VariousSchemeAndHost_ReturnsExpected(string scheme, string host, string expected)
+        {
+            // Arrange
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Scheme = scheme;
+            httpContext.Request.Host = new HostString(host);
+            var accessor = new HttpContextAccessor { HttpContext = httpContext };
+            var resolver = new IssuerResolver(accessor);
+
+            // Act
+            var issuer = resolver.GetIssuer();
+
+            // Assert
+            Assert.Equal(expected, issuer);
+        }
+
+        [Fact]
+        public void GetIssuer_NullHttpContext_ThrowsInvalidOperationException()
+        {
+            // Arrange - HttpContext を持たない accessor（バックグラウンド処理等を想定）
+            var accessor = new HttpContextAccessor { HttpContext = null };
+            var resolver = new IssuerResolver(accessor);
+
+            // Act & Assert
+            Assert.Throws<InvalidOperationException>(() => resolver.GetIssuer());
+        }
+    }
+}

--- a/IdentityProvider.Test/Services/TokenServiceTests.cs
+++ b/IdentityProvider.Test/Services/TokenServiceTests.cs
@@ -15,7 +15,7 @@ namespace IdentityProvider.Test.Services
     public class TokenServiceTests
     {
         private readonly ILogger<TokenService> _logger;
-        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IIssuerResolver _issuerResolver;
 
         public const string TestIssuer = "https://test.ec-cube.io";
 
@@ -24,17 +24,16 @@ namespace IdentityProvider.Test.Services
             var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
             _logger = loggerFactory.CreateLogger<TokenService>();
 
-            var httpContext = new DefaultHttpContext();
-            httpContext.Request.Scheme = "https";
-            httpContext.Request.Host = new HostString("test.ec-cube.io");
-            _httpContextAccessor = new HttpContextAccessor { HttpContext = httpContext };
+            // TokenService は IIssuerResolver 経由で issuer を取得する。
+            // host を "test.ec-cube.io" にすることで TestIssuer ("https://test.ec-cube.io") と一致させる。
+            _issuerResolver = TestDbContextHelper.CreateIssuerResolver(host: "test.ec-cube.io");
         }
 
         [Fact]
         public async Task GenerateIdTokenAsync_ValidRequest_ShouldGenerateValidJwtToken()
         {
             using var context = TestDbContextHelper.CreateInMemoryContext();
-            var service = new TokenService(context, _logger, _httpContextAccessor);
+            var service = new TokenService(context, _logger, _issuerResolver);
 
             // Arrange
             var (client, user, rsaKeyPair) = await SetupTestDataAsync(context);
@@ -70,7 +69,7 @@ namespace IdentityProvider.Test.Services
         public async Task GenerateIdTokenAsync_WithoutNonce_ShouldGenerateTokenWithoutNonceClaim()
         {
             using var context = TestDbContextHelper.CreateInMemoryContext();
-            var service = new TokenService(context, _logger, _httpContextAccessor);
+            var service = new TokenService(context, _logger, _issuerResolver);
 
             // Arrange
             var (client, user, rsaKeyPair) = await SetupTestDataAsync(context);
@@ -96,7 +95,7 @@ namespace IdentityProvider.Test.Services
         public async Task GenerateIdTokenAsync_WithoutEmailScope_ShouldNotIncludeEmailClaims()
         {
             using var context = TestDbContextHelper.CreateInMemoryContext();
-            var service = new TokenService(context, _logger, _httpContextAccessor);
+            var service = new TokenService(context, _logger, _issuerResolver);
 
             // Arrange
             var (client, user, rsaKeyPair) = await SetupTestDataAsync(context);
@@ -122,7 +121,7 @@ namespace IdentityProvider.Test.Services
         public async Task GenerateIdTokenAsync_NullUser_ShouldThrowArgumentException()
         {
             using var context = TestDbContextHelper.CreateInMemoryContext();
-            var service = new TokenService(context, _logger, _httpContextAccessor);
+            var service = new TokenService(context, _logger, _issuerResolver);
 
             // Arrange
             var (client, _, _) = await SetupTestDataAsync(context);
@@ -141,7 +140,7 @@ namespace IdentityProvider.Test.Services
         public async Task GenerateIdTokenAsync_NullClient_ShouldThrowArgumentException()
         {
             using var context = TestDbContextHelper.CreateInMemoryContext();
-            var service = new TokenService(context, _logger, _httpContextAccessor);
+            var service = new TokenService(context, _logger, _issuerResolver);
 
             // Arrange
             var (_, user, _) = await SetupTestDataAsync(context);
@@ -160,7 +159,7 @@ namespace IdentityProvider.Test.Services
         public async Task GenerateIdTokenAsync_NoRsaKeyPair_ShouldThrowInvalidOperationException()
         {
             using var context = TestDbContextHelper.CreateInMemoryContext();
-            var service = new TokenService(context, _logger, _httpContextAccessor);
+            var service = new TokenService(context, _logger, _issuerResolver);
 
             // Arrange - Create client and user without RSA key pair
             var organization = new Organization { Id = 1, Code = "TESTORG", Name = "TestOrg", TenantName = "test-tenant" };
@@ -199,7 +198,7 @@ namespace IdentityProvider.Test.Services
         public async Task GenerateAccessTokenAsync_ValidRequest_ShouldGenerateAccessToken()
         {
             using var context = TestDbContextHelper.CreateInMemoryContext();
-            var service = new TokenService(context, _logger, _httpContextAccessor);
+            var service = new TokenService(context, _logger, _issuerResolver);
 
             // Arrange
             var (client, user, _) = await SetupTestDataAsync(context);
@@ -231,7 +230,7 @@ namespace IdentityProvider.Test.Services
         public async Task GenerateAccessTokenAsync_ShouldContainCorrectJwtClaims()
         {
             using var context = TestDbContextHelper.CreateInMemoryContext();
-            var service = new TokenService(context, _logger, _httpContextAccessor);
+            var service = new TokenService(context, _logger, _issuerResolver);
 
             // Arrange
             var (client, user, _) = await SetupTestDataAsync(context);
@@ -264,7 +263,7 @@ namespace IdentityProvider.Test.Services
         public async Task GenerateTokensAsync_ValidRequest_ShouldGenerateBothTokens()
         {
             using var context = TestDbContextHelper.CreateInMemoryContext();
-            var service = new TokenService(context, _logger, _httpContextAccessor);
+            var service = new TokenService(context, _logger, _issuerResolver);
 
             // Arrange
             var (client, user, _) = await SetupTestDataAsync(context);
@@ -301,7 +300,7 @@ namespace IdentityProvider.Test.Services
         public async Task ValidateTokenAsync_ValidToken_ShouldReturnSubject()
         {
             using var context = TestDbContextHelper.CreateInMemoryContext();
-            var service = new TokenService(context, _logger, _httpContextAccessor);
+            var service = new TokenService(context, _logger, _issuerResolver);
 
             // Arrange
             var (client, user, _) = await SetupTestDataAsync(context);
@@ -325,7 +324,7 @@ namespace IdentityProvider.Test.Services
         public async Task ValidateTokenAsync_InvalidToken_ShouldReturnNull()
         {
             using var context = TestDbContextHelper.CreateInMemoryContext();
-            var service = new TokenService(context, _logger, _httpContextAccessor);
+            var service = new TokenService(context, _logger, _issuerResolver);
 
             // Arrange
             var (client, _, _) = await SetupTestDataAsync(context);
@@ -341,7 +340,7 @@ namespace IdentityProvider.Test.Services
         public async Task ValidateTokenAsync_NoRsaKeyPair_ShouldReturnNull()
         {
             using var context = TestDbContextHelper.CreateInMemoryContext();
-            var service = new TokenService(context, _logger, _httpContextAccessor);
+            var service = new TokenService(context, _logger, _issuerResolver);
 
             // Arrange - Create client without RSA key pair
             var organization = new Organization { Id = 1, Code = "TESTORG", Name = "TestOrg", TenantName = "test-tenant" };
@@ -399,7 +398,7 @@ namespace IdentityProvider.Test.Services
         public async Task ValidateAccessTokenAsync_ValidToken_ShouldReturnSubject()
         {
             using var context = TestDbContextHelper.CreateInMemoryContext();
-            var service = new TokenService(context, _logger, _httpContextAccessor);
+            var service = new TokenService(context, _logger, _issuerResolver);
 
             // Arrange
             var (client, user, _) = await SetupTestDataAsync(context);
@@ -424,7 +423,7 @@ namespace IdentityProvider.Test.Services
         public async Task ValidateAccessTokenAsync_InvalidToken_ShouldReturnNull()
         {
             using var context = TestDbContextHelper.CreateInMemoryContext();
-            var service = new TokenService(context, _logger, _httpContextAccessor);
+            var service = new TokenService(context, _logger, _issuerResolver);
 
             // Act
             var subject = await service.ValidateAccessTokenAsync("invalid-token");
@@ -437,7 +436,7 @@ namespace IdentityProvider.Test.Services
         public async Task ValidateAccessTokenAsync_ExpiredToken_ShouldReturnNull()
         {
             using var context = TestDbContextHelper.CreateInMemoryContext();
-            var service = new TokenService(context, _logger, _httpContextAccessor);
+            var service = new TokenService(context, _logger, _issuerResolver);
 
             // Arrange
             var (client, user, rsaKeyPair) = await SetupTestDataAsync(context);
@@ -503,7 +502,7 @@ namespace IdentityProvider.Test.Services
         public async Task ValidateAccessTokenAsync_RevokedJwt_ShouldReturnNull()
         {
             using var context = TestDbContextHelper.CreateInMemoryContext();
-            var service = new TokenService(context, _logger, _httpContextAccessor);
+            var service = new TokenService(context, _logger, _issuerResolver);
 
             // Arrange
             var (client, user, _) = await SetupTestDataAsync(context);
@@ -532,7 +531,7 @@ namespace IdentityProvider.Test.Services
         public async Task RevokeAccessTokenAsync_ValidToken_ShouldRevokeSuccessfully()
         {
             using var context = TestDbContextHelper.CreateInMemoryContext();
-            var service = new TokenService(context, _logger, _httpContextAccessor);
+            var service = new TokenService(context, _logger, _issuerResolver);
 
             // Arrange
             var (client, user, _) = await SetupTestDataAsync(context);
@@ -567,7 +566,7 @@ namespace IdentityProvider.Test.Services
         public async Task RevokeAccessTokenAsync_InvalidToken_ShouldReturnFalse()
         {
             using var context = TestDbContextHelper.CreateInMemoryContext();
-            var service = new TokenService(context, _logger, _httpContextAccessor);
+            var service = new TokenService(context, _logger, _issuerResolver);
 
             // Act
             var result = await service.RevokeAccessTokenAsync("invalid-token");
@@ -580,7 +579,7 @@ namespace IdentityProvider.Test.Services
         public async Task ValidateAccessTokenAsync_DifferentClientKey_ShouldReturnInvalid()
         {
             using var context = TestDbContextHelper.CreateInMemoryContext();
-            var service = new TokenService(context, _logger, _httpContextAccessor);
+            var service = new TokenService(context, _logger, _issuerResolver);
 
             // Arrange - Client A のデータを作成
             var (clientA, user, rsaKeyPairA) = await SetupTestDataAsync(context);
@@ -651,7 +650,7 @@ namespace IdentityProvider.Test.Services
         public async Task ValidateAccessTokenAsync_WrongIssuer_ShouldReturnInvalid()
         {
             using var context = TestDbContextHelper.CreateInMemoryContext();
-            var service = new TokenService(context, _logger, _httpContextAccessor);
+            var service = new TokenService(context, _logger, _issuerResolver);
 
             // Arrange
             var (client, user, rsaKeyPair) = await SetupTestDataAsync(context);
@@ -716,7 +715,7 @@ namespace IdentityProvider.Test.Services
         public async Task ValidateAccessTokenAsync_MissingJtiClaim_ShouldReturnInvalid()
         {
             using var context = TestDbContextHelper.CreateInMemoryContext();
-            var service = new TokenService(context, _logger, _httpContextAccessor);
+            var service = new TokenService(context, _logger, _issuerResolver);
 
             // Arrange
             var (client, user, rsaKeyPair) = await SetupTestDataAsync(context);
@@ -770,7 +769,7 @@ namespace IdentityProvider.Test.Services
         public async Task GenerateAccessTokenAsync_ShouldSaveTokenToDatabase()
         {
             using var context = TestDbContextHelper.CreateInMemoryContext();
-            var service = new TokenService(context, _logger, _httpContextAccessor);
+            var service = new TokenService(context, _logger, _issuerResolver);
 
             // Arrange
             var (client, user, _) = await SetupTestDataAsync(context);

--- a/IdentityProvider.Test/TestHelpers/TestDbContextHelper.cs
+++ b/IdentityProvider.Test/TestHelpers/TestDbContextHelper.cs
@@ -1,5 +1,6 @@
 using IdentityProvider.Models;
 using IdentityProvider.Services;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using System.Security.Cryptography;
 
@@ -7,6 +8,20 @@ namespace IdentityProvider.Test.TestHelpers
 {
     public static class TestDbContextHelper
     {
+        /// <summary>
+        /// 指定した scheme / host を返す IIssuerResolver を生成するテストヘルパー。
+        /// TokenService は IIssuerResolver 経由で issuer（"{scheme}://{host}"）を取得するため、
+        /// 既存テストの "https://test.ec-cube.io" 期待値を維持したまま注入できるようにする。
+        /// </summary>
+        public static IIssuerResolver CreateIssuerResolver(string scheme = "https", string host = "test.ec-cube.io")
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Scheme = scheme;
+            httpContext.Request.Host = new HostString(host);
+            var httpContextAccessor = new HttpContextAccessor { HttpContext = httpContext };
+            return new IssuerResolver(httpContextAccessor);
+        }
+
         public static EcAuthDbContext CreateInMemoryContext(string? databaseName = null, ITenantService? tenantService = null)
         {
             var dbName = databaseName ?? Guid.NewGuid().ToString();

--- a/IdentityProvider/Controllers/JwksController.cs
+++ b/IdentityProvider/Controllers/JwksController.cs
@@ -1,0 +1,91 @@
+using System.Security.Cryptography;
+using IdentityProvider.Models;
+using IdentityProvider.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
+
+namespace IdentityProvider.Controllers
+{
+    /// <summary>
+    /// JWKS (JSON Web Key Set) endpoint。
+    /// OpenID Connect Discovery の jwks_uri から参照される公開鍵セットを返します。
+    /// host ルート直下の固定パス（.well-known/jwks.json）で公開し、/v1/ 配下には置きません。
+    /// </summary>
+    [ApiController]
+    [AllowAnonymous]
+    public class JwksController : ControllerBase
+    {
+        private readonly EcAuthDbContext _context;
+        private readonly ITenantService _tenantService;
+        private readonly ILogger<JwksController> _logger;
+
+        public JwksController(
+            EcAuthDbContext context,
+            ITenantService tenantService,
+            ILogger<JwksController> logger)
+        {
+            _context = context;
+            _tenantService = tenantService;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// 現在の Organization の有効な RSA 公開鍵を JWKS 形式で返します。
+        /// </summary>
+        /// <returns>{ "keys": [ ... ] } 形式の JSON Web Key Set</returns>
+        [HttpGet(".well-known/jwks.json")]
+        public async Task<IActionResult> Get()
+        {
+            // Organization の特定は Organizations への global query filter
+            // （o.TenantName == _tenantService.TenantName、TenantMiddleware が設定）に委ねる。
+            var organization = await _context.Organizations.FirstOrDefaultAsync();
+            if (organization == null)
+            {
+                _logger.LogWarning("JWKS: Organization not found for tenant {TenantName}", _tenantService.TenantName);
+                // 該当 Organization が無い場合も 500 にせず空の keys を返す。
+                return Ok(new { keys = Array.Empty<object>() });
+            }
+
+            // RsaKeyPair には query filter が無いため明示的に OrganizationId で絞り込む
+            // （TokenService の鍵取得と同じパターン）。当面は IsActive==true の鍵のみ返す。
+            var rsaKeyPairs = await _context.RsaKeyPairs
+                .IgnoreQueryFilters()
+                .Where(k => k.OrganizationId == organization.Id && k.IsActive)
+                .ToListAsync();
+
+            var keys = new List<object>();
+            foreach (var rsaKeyPair in rsaKeyPairs)
+            {
+                try
+                {
+                    using var rsa = RSA.Create();
+                    // PublicKey は Base64 エンコードされた DER(PKCS#1) 形式で格納されている
+                    // （生成箇所: OrganizationClientSeeder の rsa.ExportRSAPublicKey()。
+                    //  TokenService の検証時も ImportRSAPublicKey を使用）。
+                    rsa.ImportRSAPublicKey(Convert.FromBase64String(rsaKeyPair.PublicKey), out _);
+
+                    var parameters = rsa.ExportParameters(false);
+
+                    keys.Add(new
+                    {
+                        kty = "RSA",
+                        use = "sig",
+                        alg = "RS256",
+                        kid = rsaKeyPair.Kid,
+                        n = Base64UrlEncoder.Encode(parameters.Modulus),
+                        e = Base64UrlEncoder.Encode(parameters.Exponent),
+                    });
+                }
+                catch (Exception ex)
+                {
+                    // 1 鍵の変換失敗で endpoint 全体を落とさず、当該鍵のみスキップする。
+                    _logger.LogWarning(ex, "JWKS: Failed to convert RSA public key (Kid={Kid})", rsaKeyPair.Kid);
+                }
+            }
+
+            return Ok(new { keys });
+        }
+    }
+}

--- a/IdentityProvider/Controllers/OpenIdConfigurationController.cs
+++ b/IdentityProvider/Controllers/OpenIdConfigurationController.cs
@@ -1,0 +1,61 @@
+using IdentityProvider.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace IdentityProvider.Controllers
+{
+    /// <summary>
+    /// OpenID Connect Discovery (RFC 8414 / OpenID Connect Discovery 1.0) エンドポイント。
+    /// host ルート直下の ".well-known/openid-configuration" を GET で公開する（/v1/ 配下にしない）。
+    /// issuer は IIssuerResolver 経由で HttpContext から動的取得（案A サブドメイン型）し、
+    /// 各エンドポイント URL は issuer を基底に組み立てる。
+    /// </summary>
+    [ApiController]
+    [AllowAnonymous]
+    public class OpenIdConfigurationController : ControllerBase
+    {
+        private readonly IIssuerResolver _issuerResolver;
+
+        public OpenIdConfigurationController(IIssuerResolver issuerResolver)
+        {
+            _issuerResolver = issuerResolver;
+        }
+
+        /// <summary>
+        /// OpenID Provider Metadata を返す。
+        /// </summary>
+        [HttpGet(".well-known/openid-configuration")]
+        public IActionResult Get()
+        {
+            var issuer = _issuerResolver.GetIssuer();
+
+            // JSON のキー順・スネークケースを確実に保つため、プロパティ名は
+            // リテラルのスネークケース文字列で構築する（C# プロパティ名の自動変換に依存しない）。
+            //
+            // 意図的に省略しているフィールド（仕様上 RECOMMENDED だが本 IdP の設計判断で出さない）:
+            // - authorization_endpoint:
+            //     /v1/authorization は標準の OAuth2 認可エンドポイントではなく、
+            //     外部 IdP へリダイレクトする非標準のフェデレーション proxy のため公開しない。
+            //     これに伴い response_types_supported も省略する。
+            // - response_types_supported:
+            //     上記 authorization_endpoint 非公開に伴い省略。
+            // - code_challenge_methods_supported:
+            //     PKCE 未実装のため省略。
+            var metadata = new Dictionary<string, object>
+            {
+                ["issuer"] = issuer,
+                ["token_endpoint"] = $"{issuer}/v1/token",
+                ["userinfo_endpoint"] = $"{issuer}/v1/userinfo",
+                ["jwks_uri"] = $"{issuer}/.well-known/jwks.json",
+                ["grant_types_supported"] = new[] { "authorization_code" },
+                ["token_endpoint_auth_methods_supported"] = new[] { "client_secret_post", "none" },
+                ["id_token_signing_alg_values_supported"] = new[] { "RS256" },
+                ["subject_types_supported"] = new[] { "public" },
+                ["scopes_supported"] = new[] { "openid", "email", "profile" },
+                ["claims_supported"] = new[] { "sub" }
+            };
+
+            return new JsonResult(metadata);
+        }
+    }
+}

--- a/IdentityProvider/Program.cs
+++ b/IdentityProvider/Program.cs
@@ -14,6 +14,7 @@ using OpenTelemetry;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddHttpContextAccessor();
+builder.Services.AddScoped<IIssuerResolver, IssuerResolver>();
 builder.Services.AddScoped<ITenantService, TenantService>();
 builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddScoped<ITokenService, TokenService>();

--- a/IdentityProvider/Services/IssuerResolver.cs
+++ b/IdentityProvider/Services/IssuerResolver.cs
@@ -1,0 +1,36 @@
+namespace IdentityProvider.Services
+{
+    /// <summary>
+    /// issuer 値（iss クレーム / Discovery の issuer）の単一ソース。
+    /// 案A サブドメイン型に基づき、設定値ではなく HttpContext から動的に取得する。
+    /// </summary>
+    public interface IIssuerResolver
+    {
+        /// <summary>
+        /// 現在のリクエストから issuer 値を「{Scheme}://{Host}」形式で返す。
+        /// HttpContext が利用できない場合は InvalidOperationException を投げる。
+        /// </summary>
+        string GetIssuer();
+    }
+
+    public class IssuerResolver : IIssuerResolver
+    {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public IssuerResolver(IHttpContextAccessor httpContextAccessor)
+        {
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        public string GetIssuer()
+        {
+            var request = _httpContextAccessor.HttpContext?.Request;
+            if (request != null)
+            {
+                return $"{request.Scheme}://{request.Host}";
+            }
+
+            throw new InvalidOperationException("HttpContext is not available. Cannot determine issuer.");
+        }
+    }
+}

--- a/IdentityProvider/Services/TokenService.cs
+++ b/IdentityProvider/Services/TokenService.cs
@@ -12,13 +12,13 @@ namespace IdentityProvider.Services
     {
         private readonly EcAuthDbContext _context;
         private readonly ILogger<TokenService> _logger;
-        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IIssuerResolver _issuerResolver;
 
-        public TokenService(EcAuthDbContext context, ILogger<TokenService> logger, IHttpContextAccessor httpContextAccessor)
+        public TokenService(EcAuthDbContext context, ILogger<TokenService> logger, IIssuerResolver issuerResolver)
         {
             _context = context;
             _logger = logger;
-            _httpContextAccessor = httpContextAccessor;
+            _issuerResolver = issuerResolver;
         }
 
         public async Task<ITokenService.TokenResponse> GenerateTokensAsync(ITokenService.TokenRequest request)
@@ -297,16 +297,9 @@ namespace IdentityProvider.Services
             }
         }
 
-        private string GetIssuer()
-        {
-            var request = _httpContextAccessor.HttpContext?.Request;
-            if (request != null)
-            {
-                return $"{request.Scheme}://{request.Host}";
-            }
-
-            throw new InvalidOperationException("HttpContext is not available. Cannot determine issuer.");
-        }
+        // issuer 値は IIssuerResolver に単一ソース化した。
+        // 既存トークンとの後方互換のため出力（{Scheme}://{Host}）は不変。
+        private string GetIssuer() => _issuerResolver.GetIssuer();
 
         public async Task<string?> ValidateAccessTokenAsync(string token)
         {


### PR DESCRIPTION
## Summary

OpenID Connect Discovery 1.0 の Provider Metadata エンドポイント `/.well-known/openid-configuration` と、署名公開鍵を配信する JWKS エンドポイント `/.well-known/jwks.json` を新設します。これまで未実装だったため、RP がエンドポイント URL や署名鍵を自動発見できませんでした（EcAuth/EcAuthDocs#83）。

issuer 体系は **案A サブドメイン型**（`{scheme}://{host}`）を採用し、現行の `TokenService.GetIssuer()`・テナント別 `RsaKeyPair`・サブドメインによるテナント解決と完全整合させています。

## Changes

### 実装（`182ad5d`）
- `IIssuerResolver` / `IssuerResolver` を新設し、issuer 値の出所を単一ソース化（`Program.cs` に DI 登録）。
- `TokenService.GetIssuer()` を `IIssuerResolver` への委譲に変更。**iss クレームの値は不変**で既存トークンと後方互換。
- `OpenIdConfigurationController`（`/.well-known/openid-configuration`）を新設。広告値は既存 `TokenController` / `AuthorizationController` / `UserinfoController` の実装実態に合わせて確定。
- `JwksController`（`/.well-known/jwks.json`）を新設。現在テナントの `IsActive` な `RsaKeyPair` のみを JWK 化（`PublicKey` は Base64 DER(PKCS#1) を `ImportRSAPublicKey` で取り込み）。鍵不在時は空 `keys` を返し 500 にしない。

### E2E（`33b3f65`）
- Playwright spec `oidc_discovery.spec.ts` を新設。Discovery / JWKS の **200 を厳格に検証**。
- `verify-federation-auth.sh` に Step 0 を追加し、staging / production スモークで Discovery / JWKS をプリフライト確認。

## 設計判断（詳細は EcAuthDocs#83 / technical-qa Q8）

- **issuer は案A サブドメイン型**。`IIssuerResolver` 単一ソース化で Discovery の `issuer` と ID Token の `iss` が完全一致（回帰テストで固定）。
- **`authorization_endpoint` / `response_types_supported` は意図的に省略**。`/v1/authorization` は標準の認可エンドポイントではなく外部 IdP へリダイレクトする非標準のフェデレーション proxy のため。`code_challenge_methods_supported` も PKCE 未実装のため省略。省略理由はコントローラのコメントに明記。
- **キーローテーション（複数 `kid` 併存配信）は別タスク**として切り出し。現状は active 鍵のみ返却。

## Test plan

- [x] `dotnet build EcAuth.sln`: 0 エラー（自分で実行して確認）
- [x] `dotnet test IdentityProvider.Test`: 548 合格 / 0 失敗（自分で実行して確認）
- [x] 新規単体テスト 18 件 pass（IssuerResolver / Discovery / JWKS / **issuer 一致回帰**）
- [ ] ローカル Docker での Playwright E2E 実走（`oidc_discovery.spec.ts`）※本 PR では未実走

## Related

Refs: EcAuth/EcAuthDocs#83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * OpenID Connect Discovery エンドポイント（`.well-known/openid-configuration`）を追加しました。動的な発行者情報とメタデータを提供します。
  * JWKS（JSON Web Key Set）エンドポイント（`.well-known/jwks.json`）を追加しました。署名鍵情報を公開します。

* **改善**
  * Discovery とJWKS エンドポイントの検証をより厳格にしました。HTTP 200 応答を要求し、必須フィールドの存在を確認します。
  * 発行者情報の解決をリクエストベースで動的に行うようになりました。

* **テスト**
  * E2E テストと単体テストを追加し、OIDC Discovery と JWKS の機能を検証するようにしました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EcAuth/EcAuth/pull/393?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->