### PR TITLE
fix(ci): ヘルスチェックで Discovery エンドポイントの稼働も待機する

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -256,19 +256,28 @@ jobs:
       - name: Health check
         env:
           HEALTH_CHECK_URL: https://production.ec-auth.io/healthz
+          # /healthz は新旧両方のコードに存在するため、デプロイ伝播中は旧リビジョンでも 200 を返す。
+          # 新コードが live になったことを保証するため、新設エンドポイント Discovery の 200 も合わせて待つ。
+          DISCOVERY_URL: https://production.ec-auth.io/.well-known/openid-configuration
+          # /healthz は CanConnectAsync の軽量チェックのみで実 DB クエリ経路を温めない。
+          # JWKS は実際に DB を引くため、ここで 200 を待つことで verify 実行前に DB を
+          # ウォームアップし、コールド DB によるオリジンタイムアウト(Cloudflare 524)を防ぐ。
+          JWKS_URL: https://production.ec-auth.io/.well-known/jwks.json
         run: |
           echo "Waiting for deployment to complete..."
           sleep 30
           for i in {1..10}; do
-            response=$(curl -s -o /dev/null -w "%{http_code}" "$HEALTH_CHECK_URL" || echo "000")
-            if [ "$response" = "200" ]; then
-              echo "Health check passed!"
+            health=$(curl -s -m 30 -o /dev/null -w "%{http_code}" "$HEALTH_CHECK_URL" || echo "000")
+            discovery=$(curl -s -m 30 -o /dev/null -w "%{http_code}" "$DISCOVERY_URL" || echo "000")
+            jwks=$(curl -s -m 30 -o /dev/null -w "%{http_code}" "$JWKS_URL" || echo "000")
+            if [ "$health" = "200" ] && [ "$discovery" = "200" ] && [ "$jwks" = "200" ]; then
+              echo "Health check passed! (healthz=200, discovery=200, jwks=200)"
               exit 0
             fi
-            echo "Attempt $i: Health check returned $response, retrying in 30 seconds..."
+            echo "Attempt $i: healthz=$health discovery=$discovery jwks=$jwks, retrying in 30 seconds..."
             sleep 30
           done
-          echo "Health check failed after 10 attempts"
+          echo "Health check failed after 10 attempts (last: healthz=$health discovery=$discovery jwks=$jwks)"
           exit 1
 
   verify:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -247,19 +247,28 @@ jobs:
       - name: Health check
         env:
           HEALTH_CHECK_URL: https://ecauth-staging-${{ env.WEB_APP_SUFFIX }}.azurewebsites.net/healthz
+          # /healthz は新旧両方のコードに存在するため、デプロイ伝播中は旧リビジョンでも 200 を返す。
+          # 新コードが live になったことを保証するため、新設エンドポイント Discovery の 200 も合わせて待つ。
+          DISCOVERY_URL: https://ecauth-staging-${{ env.WEB_APP_SUFFIX }}.azurewebsites.net/.well-known/openid-configuration
+          # /healthz は CanConnectAsync の軽量チェックのみで実 DB クエリ経路を温めない。
+          # JWKS は実際に DB を引くため、ここで 200 を待つことで verify 実行前に DB を
+          # ウォームアップし、コールド DB によるオリジンタイムアウト(Cloudflare 524)を防ぐ。
+          JWKS_URL: https://ecauth-staging-${{ env.WEB_APP_SUFFIX }}.azurewebsites.net/.well-known/jwks.json
         run: |
           echo "Waiting for deployment to complete..."
           sleep 30
           for i in {1..10}; do
-            response=$(curl -s -o /dev/null -w "%{http_code}" "$HEALTH_CHECK_URL" || echo "000")
-            if [ "$response" = "200" ]; then
-              echo "Health check passed!"
+            health=$(curl -s -m 30 -o /dev/null -w "%{http_code}" "$HEALTH_CHECK_URL" || echo "000")
+            discovery=$(curl -s -m 30 -o /dev/null -w "%{http_code}" "$DISCOVERY_URL" || echo "000")
+            jwks=$(curl -s -m 30 -o /dev/null -w "%{http_code}" "$JWKS_URL" || echo "000")
+            if [ "$health" = "200" ] && [ "$discovery" = "200" ] && [ "$jwks" = "200" ]; then
+              echo "Health check passed! (healthz=200, discovery=200, jwks=200)"
               exit 0
             fi
-            echo "Attempt $i: Health check returned $response, retrying in 30 seconds..."
+            echo "Attempt $i: healthz=$health discovery=$discovery jwks=$jwks, retrying in 30 seconds..."
             sleep 30
           done
-          echo "Health check failed after 10 attempts"
+          echo "Health check failed after 10 attempts (last: healthz=$health discovery=$discovery jwks=$jwks)"
           exit 1
 
   verify:


### PR DESCRIPTION
## Summary

PR #393 でマージした OIDC Discovery 検証（`verify-federation-auth.sh` の Step 0）が、production デプロイ直後に失敗し再実行で成功する事象が複数発生しました（[run 26676801095](https://github.com/EcAuth/EcAuth/actions/runs/26676801095)）。いずれもデプロイ直後の準備未完了が原因のため、デプロイ後ヘルスゲートを強化します。

## 観測した 2 つの失敗と原因

**① Discovery が 404**
`/healthz` は新旧両方のコードに存在する既存エンドポイントのため、Azure App Service のリビジョン切替中は**旧コンテナでも `/healthz` が 200 を返してヘルスゲートを通過**します。しかし新設の `/.well-known/openid-configuration` は旧コードに無いため **404**。新リビジョンが live になる前に verify が走り失敗していました。

**② JWKS が 524（Cloudflare オリジンタイムアウト）**
`/healthz` は `Database.CanConnectAsync()` の軽量チェックのみで、実 DB クエリ経路・コネクションプールを温めません。そのため**ゲート通過後の最初の実 DB クエリ（JWKS）がコールド DB でハング**し、Cloudflare 配下の production で約 130 秒後に 524 になっていました。JWKS 自体は軽量 2 クエリでコードバグではなく、デプロイ直後のコールドスタートが要因です。

## Changes

`staging.yml` / `production.yml` のヘルスチェックループを拡張:

- `/healthz` に加えて **Discovery** と **JWKS** の `200` も待機条件に追加。
- JWKS は実 DB クエリ経路を通るため、ゲートで JWKS 200 を待つことが「新コード稼働の確認」と「DB ウォームアップ」を兼ね、verify 実行前の準備完了を保証する。
- 各 curl に `-m 30` を付与し 1 試行を上限付きに（コールド時のハングで Cloudflare 524 を待たずに次試行へ）。待機上限（10×30s）は維持。
- 上限を超えれば従来どおり失敗する（問題を握り潰さない）。

## Test plan

- [x] 両ワークフローの YAML 構文（`yaml.safe_load`）・行末空白・LF を確認
- [x] 次回 staging / production デプロイで Step 0 が初回から通過することを確認

## Related

Refs: EcAuth/EcAuthDocs#83