### PR TITLE
test(e2e): Selenium ブラウザ smoke テストと setup-chromedriver CI を追加

### DIFF
--- a/.github/workflows/selenium.yml
+++ b/.github/workflows/selenium.yml
@@ -174,7 +174,7 @@ jobs:
       # PATH に通す。E2ETests.Selenium の ChromeDriverFixture は PATH 上の chromedriver を
       # 明示的に解決して使う（Selenium Manager の自動 DL には頼らない）。
       - name: Setup ChromeDriver
-        uses: nanasess/setup-chromedriver@v3
+        uses: nanasess/setup-chromedriver@e913548694400f275b4070efcd90f47dbbc8914c # v3.0.0
 
       - name: Show Chrome / ChromeDriver versions
         run: |

--- a/.github/workflows/selenium.yml
+++ b/.github/workflows/selenium.yml
@@ -1,0 +1,202 @@
+name: Selenium Smoke Tests - IdentityProvider
+
+# Playwright E2E（playwright.yml）とは別に、実ブラウザ（Chrome + ChromeDriver）で
+# 動かす軽量な smoke テストを実行する。ChromeDriver のセットアップには自作の
+# nanasess/setup-chromedriver@v3 を使用し、テスト本体は C#（Selenium.WebDriver /
+# xUnit）の E2ETests.Selenium プロジェクトで管理する。
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  selenium:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: read
+
+    env:
+      DB_PASSWORD: <YourStrong@Passw0rd>
+      MOCK_IDP_BASE_URL: ${{ secrets.MOCK_IDP_BASE_URL }}
+      MOCK_IDP_ORG: dev
+
+    services:
+      sqlserver:
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        env:
+          SA_PASSWORD: ${{ env.DB_PASSWORD }}
+          ACCEPT_EULA: "Y"
+        ports:
+          - 1433:1433
+        options: >-
+          --health-cmd "exit 0"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Load base environment variables
+        run: |
+          # E2E 用の非機密ローカル/ダミー設定値（旧 .env.dist 相当）。クレデンシャルは含まない。
+          cat <<'EOF' >> $GITHUB_ENV
+          DB_HOST=db
+          MIGRATION_DB_HOST=localhost
+          DB_NAME=EcAuthDb
+          DB_USER=SA
+          DB_PASSWORD='<YourStrong@Passw0rd>'
+          STATE_PASSWORD='<strong_password_string_of_at_least_32_characters>'
+          MOCK_IDP_DB_NAME=MockIdp
+          MOCK_IDP_DEFAULT_USER_PASSWORD=password
+          MOCK_IDP_DEFAULT_CLIENT_ID=mockclientid
+          MOCK_IDP_DEFAULT_CLIENT_SECRET=mock-client-secret
+          MOCK_IDP_DEFAULT_CLIENT_NAME=MockClient
+          MOCK_IDP_DEFAULT_USER_EMAIL=defaultuser@example.com
+          MOCK_IDP_FEDERATE_CLIENT_ID=federateclientid
+          MOCK_IDP_FEDERATE_CLIENT_SECRET=federate-client-secret
+          MOCK_IDP_FEDERATE_CLIENT_NAME=FederateClient
+          MOCK_IDP_FEDERATE_USER_EMAIL=federate@example.jp
+          MOCK_IDP_BASE_URL=https://localhost:9091
+          FEDERATE_OAUTH2_APP_NAME=federate-oauth2
+          DEFAULT_ORGANIZATION_CODE=example
+          DEFAULT_ORGANIZATION_NAME=example
+          DEFAULT_ORGANIZATION_TENANT_NAME=example
+          DEFAULT_ORGANIZATION_REDIRECT_URI=https://localhost:8081/v1/auth/callback
+          DEFAULT_CLIENT_ID=client_id
+          DEFAULT_CLIENT_SECRET=client_secret
+          DEFAULT_APP_NAME=app_name
+          GOOGLE_OAUTH2_APP_NAME=google-oauth2
+          GOOGLE_OAUTH2_CLIENT_ID=<Google OAuth2 client_id>
+          GOOGLE_OAUTH2_CLIENT_SECRET=<Google OAuth2 client_secret>
+          GOOGLE_OAUTH2_DISCOVERY_URL=https://accounts.google.com/.well-known/openid-configuration
+          AMAZON_OAUTH2_APP_NAME=amazon-oauth2
+          AMAZON_OAUTH2_CLIENT_ID=<Amazon OAuth2 client_id>
+          AMAZON_OAUTH2_CLIENT_SECRET=<Amazon OAuth2 client_secret>
+          AMAZON_OAUTH2_AUTHORIZATION_ENDPOINT=https://www.amazon.com/ap/oa
+          AMAZON_OAUTH2_TOKEN_ENDPOINT=https://api.amazon.co.jp/auth/o2/token
+          AMAZON_OAUTH2_USERINFO_ENDPOINT=https://api.amazon.com/user/profile
+          DEV_B2B_USER_SUBJECT=3f7c0ab4-b004-4102-b6ed-a730369dd237
+          DEV_B2B_USER_EXTERNAL_ID=test-admin
+          DEV_B2B_REDIRECT_URI=https://localhost:8081/admin/ecauth/callback
+          DEV_B2B_ALLOWED_RP_IDS=localhost
+          EOF
+
+      - name: Set up environment variables
+        run: |
+          echo "DB_HOST=localhost" >> $GITHUB_ENV
+          echo "ConnectionStrings__EcAuthDbContext=Server=localhost;Database=${DB_NAME};User Id=${DB_USER};Password=${DB_PASSWORD};TrustServerCertificate=true;MultipleActiveResultSets=true" >> $GITHUB_ENV
+          # フェデレーション設定（smoke テストでは未使用だが、IdP 起動時の構成読み込みのため設定）
+          echo "FEDERATE_OAUTH2_CLIENT_ID=${MOCK_IDP_FEDERATE_CLIENT_ID}" >> $GITHUB_ENV
+          echo "FEDERATE_OAUTH2_CLIENT_SECRET=${MOCK_IDP_FEDERATE_CLIENT_SECRET}" >> $GITHUB_ENV
+          echo "FEDERATE_OAUTH2_AUTHORIZATION_ENDPOINT=${MOCK_IDP_BASE_URL}/authorization?org=${MOCK_IDP_ORG}" >> $GITHUB_ENV
+          echo "FEDERATE_OAUTH2_TOKEN_ENDPOINT=${MOCK_IDP_BASE_URL}/token?org=${MOCK_IDP_ORG}" >> $GITHUB_ENV
+          echo "FEDERATE_OAUTH2_USERINFO_ENDPOINT=${MOCK_IDP_BASE_URL}/userinfo?org=${MOCK_IDP_ORG}" >> $GITHUB_ENV
+          # Selenium テスト用のベース URL
+          echo "E2E_BASE_URL=https://localhost:8081" >> $GITHUB_ENV
+        env:
+          DB_NAME: ${{ env.DB_NAME }}
+          DB_USER: ${{ env.DB_USER }}
+          DB_PASSWORD: ${{ env.DB_PASSWORD }}
+          MOCK_IDP_FEDERATE_CLIENT_ID: ${{ env.MOCK_IDP_FEDERATE_CLIENT_ID }}
+          MOCK_IDP_FEDERATE_CLIENT_SECRET: ${{ env.MOCK_IDP_FEDERATE_CLIENT_SECRET }}
+          MOCK_IDP_BASE_URL: ${{ secrets.MOCK_IDP_BASE_URL }}
+          MOCK_IDP_ORG: ${{ env.MOCK_IDP_ORG }}
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Add GitHub Packages source with credentials
+        run: |
+          dotnet nuget remove source github || true
+          dotnet nuget add source https://nuget.pkg.github.com/EcAuth/index.json \
+            --name github \
+            --username ${{ github.actor }} \
+            --password ${{ secrets.ORG_PAT || secrets.PACKAGES_READ_TOKEN }} \
+            --store-password-in-clear-text
+
+      - name: Restore .NET tools
+        run: dotnet tool restore
+
+      - name: Install dependencies
+        run: dotnet restore ./EcAuth.sln
+
+      - name: Build IdentityProvider
+        run: dotnet build --no-restore --configuration Release IdentityProvider
+
+      - name: Migrate IdentityProvider DB
+        working-directory: IdentityProvider
+        run: |
+          dotnet ef database update
+          echo "Waiting for database to be fully online..."
+          sleep 10
+
+      - name: Start IdentityProvider
+        run: |
+          export ASPNETCORE_HTTPS_PORT=8081
+          export ASPNETCORE_URLS="https://0.0.0.0:8081"
+          dotnet run --project IdentityProvider --configuration Release --urls "https://0.0.0.0:8081" > /tmp/identityprovider.log 2>&1 &
+          echo $! > /tmp/identityprovider.pid
+          echo "IdentityProvider started with PID: $(cat /tmp/identityprovider.pid)"
+        env:
+          ASPNETCORE_ENVIRONMENT: Development
+
+      - name: Wait for IdentityProvider to start
+        run: |
+          echo "Waiting for IdentityProvider to start..."
+          for i in {1..60}; do
+            if curl -sk https://localhost:8081/healthz > /dev/null 2>&1; then
+              echo "IdentityProvider is ready"
+              sleep 5
+              break
+            fi
+            if [ $i -eq 30 ]; then
+              echo "=== IdentityProvider logs (intermediate check) ==="
+              cat /tmp/identityprovider.log || echo "No logs available"
+            fi
+            echo "Waiting... ($i/60)"
+            sleep 2
+          done
+          if ! curl -sk https://localhost:8081/healthz > /dev/null 2>&1; then
+            echo "ERROR: IdentityProvider failed to start"
+            echo "=== IdentityProvider logs ==="
+            cat /tmp/identityprovider.log || echo "No logs available"
+            exit 1
+          fi
+
+      # ここからが setup-chromedriver の本題。ubuntu ランナーには Google Chrome が
+      # プリインストールされているため、その Chrome に一致する ChromeDriver を導入し
+      # PATH に通す。E2ETests.Selenium の ChromeDriverFixture は PATH 上の chromedriver を
+      # 明示的に解決して使う（Selenium Manager の自動 DL には頼らない）。
+      - name: Setup ChromeDriver
+        uses: nanasess/setup-chromedriver@v3
+
+      - name: Show Chrome / ChromeDriver versions
+        run: |
+          google-chrome --version || true
+          chromedriver --version
+          echo "chromedriver path: $(command -v chromedriver)"
+
+      - name: Run Selenium smoke tests
+        working-directory: E2ETests.Selenium
+        run: dotnet test --configuration Release --logger "trx;LogFileName=selenium.trx" --results-directory TestResults
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: selenium-test-results
+          path: 'E2ETests.Selenium/TestResults/'
+
+      - name: Display IdentityProvider logs
+        if: always()
+        run: |
+          echo "=== IdentityProvider logs ==="
+          cat /tmp/identityprovider.log || echo "No logs available"
+          echo "=== .NET exception logs ==="
+          cat IdentityProvider/logs/*.log 2>/dev/null || echo "No exception logs found"

--- a/E2ETests.Selenium/B2bPasskeyPageSmokeTests.cs
+++ b/E2ETests.Selenium/B2bPasskeyPageSmokeTests.cs
@@ -1,0 +1,39 @@
+using OpenQA.Selenium;
+using OpenQA.Selenium.Support.UI;
+
+namespace E2ETests.Selenium;
+
+/// <summary>
+/// B2B パスキーテストページ（wwwroot/b2b-passkey-test.html）の描画 smoke テスト。
+///
+/// 実ブラウザ（Chrome + ChromeDriver）で静的ページを開き、タイトル・見出し・主要な
+/// フォーム要素がレンダリングされることを確認する。WebAuthn の署名検証そのものは
+/// CDP Virtual Authenticator を使う Playwright 側 E2E に委ね、ここでは「ページが
+/// 正しく配信され DOM が組み上がる」ことだけを軽量に検証する。
+/// </summary>
+public sealed class B2bPasskeyPageSmokeTests : IClassFixture<ChromeDriverFixture>
+{
+    private readonly ChromeDriverFixture _fixture;
+    private IWebDriver Driver => _fixture.Driver;
+
+    public B2bPasskeyPageSmokeTests(ChromeDriverFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public void パスキーテストページが配信され主要要素が描画されること()
+    {
+        Driver.Navigate().GoToUrl($"{_fixture.BaseUrl}/b2b-passkey-test.html");
+
+        var wait = new WebDriverWait(Driver, TimeSpan.FromSeconds(15));
+        var heading = wait.Until(d => d.FindElement(By.TagName("h1")));
+
+        Assert.Equal("B2B Passkey Test - EcAuth", Driver.Title);
+        Assert.Contains("B2B Passkey Test Page", heading.Text);
+
+        // 登録フォームの既定値が DOM に反映されていること（静的配信＋スクリプト初期化の最低限の確認）。
+        Assert.Equal("client_id", Driver.FindElement(By.Id("clientId")).GetAttribute("value"));
+        Assert.Equal("localhost", Driver.FindElement(By.Id("rpId")).GetAttribute("value"));
+
+        // デバッグログ用の <pre id="debugLog"> が存在し、ページの土台が組み上がっていること。
+        Assert.True(Driver.FindElement(By.Id("debugLog")).Displayed);
+    }
+}

--- a/E2ETests.Selenium/ChromeDriverFixture.cs
+++ b/E2ETests.Selenium/ChromeDriverFixture.cs
@@ -1,0 +1,91 @@
+using System.Runtime.InteropServices;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Chrome;
+
+namespace E2ETests.Selenium;
+
+/// <summary>
+/// Selenium WebDriver（Chrome）を 1 テストクラスにつき 1 つ起動・破棄する xUnit フィクスチャ。
+///
+/// このプロジェクトは nanasess/setup-chromedriver@v3 で導入された ChromeDriver を
+/// 「そのまま使う」ことを意図している。そのため Selenium Manager による
+/// ドライバ自動ダウンロードには頼らず、PATH（または CHROMEWEBDRIVER）上の
+/// chromedriver を明示的に解決して使用する。CI ではこの解決経路が action 由来の
+/// バイナリを指す。ローカル開発で chromedriver が見つからない場合のみ、Selenium
+/// Manager にフォールバックする。
+/// </summary>
+public sealed class ChromeDriverFixture : IDisposable
+{
+    /// <summary>テスト対象 IdP のベース URL。CI / ローカル Docker いずれも https://localhost:8081。</summary>
+    public string BaseUrl { get; } =
+        Environment.GetEnvironmentVariable("E2E_BASE_URL")?.TrimEnd('/') ?? "https://localhost:8081";
+
+    public IWebDriver Driver { get; }
+
+    public ChromeDriverFixture()
+    {
+        var options = new ChromeOptions();
+        // CI ランナー / コンテナでの定番フラグ。--headless=new は Chrome 109+ の新ヘッドレス。
+        options.AddArgument("--headless=new");
+        options.AddArgument("--no-sandbox");
+        options.AddArgument("--disable-dev-shm-usage");
+        options.AddArgument("--disable-gpu");
+        options.AddArgument("--window-size=1280,1024");
+        // IdP はローカル/CI とも自己署名証明書の HTTPS で待ち受けるため証明書エラーを無視する。
+        options.AcceptInsecureCertificates = true;
+
+        var driverDirectory = ResolveChromeDriverDirectory();
+
+        ChromeDriverService service = driverDirectory is null
+            ? ChromeDriverService.CreateDefaultService()        // ローカル: Selenium Manager に委譲
+            : ChromeDriverService.CreateDefaultService(driverDirectory); // CI: action 導入の chromedriver
+
+        service.SuppressInitialDiagnosticInformation = true;
+        service.HideCommandPromptWindow = true;
+
+        Driver = new ChromeDriver(service, options, TimeSpan.FromSeconds(60));
+    }
+
+    /// <summary>
+    /// setup-chromedriver が配置した chromedriver の「ディレクトリ」を解決する。
+    /// 優先順位: CHROMEWEBDRIVER 環境変数 → PATH 上の探索。見つからなければ null。
+    /// </summary>
+    private static string? ResolveChromeDriverDirectory()
+    {
+        var explicitDir = Environment.GetEnvironmentVariable("CHROMEWEBDRIVER");
+        if (!string.IsNullOrEmpty(explicitDir) && File.Exists(Path.Combine(explicitDir, ExecutableName)))
+        {
+            return explicitDir;
+        }
+
+        var pathValue = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrEmpty(pathValue))
+        {
+            return null;
+        }
+
+        foreach (var dir in pathValue.Split(Path.PathSeparator))
+        {
+            if (string.IsNullOrEmpty(dir))
+            {
+                continue;
+            }
+
+            if (File.Exists(Path.Combine(dir, ExecutableName)))
+            {
+                return dir;
+            }
+        }
+
+        return null;
+    }
+
+    private static string ExecutableName =>
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "chromedriver.exe" : "chromedriver";
+
+    public void Dispose()
+    {
+        Driver.Quit();
+        Driver.Dispose();
+    }
+}

--- a/E2ETests.Selenium/E2ETests.Selenium.csproj
+++ b/E2ETests.Selenium/E2ETests.Selenium.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.44.0" />
+    <PackageReference Include="Selenium.Support" Version="4.44.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/E2ETests.Selenium/OidcDiscoverySmokeTests.cs
+++ b/E2ETests.Selenium/OidcDiscoverySmokeTests.cs
@@ -1,0 +1,57 @@
+using OpenQA.Selenium;
+using OpenQA.Selenium.Support.UI;
+
+namespace E2ETests.Selenium;
+
+/// <summary>
+/// OIDC Discovery / JWKS エンドポイントのブラウザ smoke テスト。
+///
+/// 厳密な Provider Metadata 検証（省略フィールドの不在チェック等）は Playwright 側の
+/// oidc_discovery.spec.ts が担う。ここでは実ブラウザで JSON エンドポイントを開き、
+/// 主要キーがレスポンス本文に現れることだけを軽量に確認する（配信経路の生存確認）。
+/// Chrome は application/json をビルトインの JSON ビューアで描画するため、
+/// document.body.innerText に整形済み JSON テキストが含まれる。
+/// </summary>
+public sealed class OidcDiscoverySmokeTests : IClassFixture<ChromeDriverFixture>
+{
+    private readonly ChromeDriverFixture _fixture;
+    private IWebDriver Driver => _fixture.Driver;
+
+    public OidcDiscoverySmokeTests(ChromeDriverFixture fixture) => _fixture = fixture;
+
+    private string BodyText()
+    {
+        var wait = new WebDriverWait(Driver, TimeSpan.FromSeconds(15));
+        return wait.Until(d =>
+        {
+            var text = ((IJavaScriptExecutor)d).ExecuteScript("return document.body.innerText;") as string;
+            return string.IsNullOrWhiteSpace(text) ? null : text;
+        })!;
+    }
+
+    [Fact]
+    public void Discovery_が_Provider_Metadata_を返すこと()
+    {
+        Driver.Navigate().GoToUrl($"{_fixture.BaseUrl}/.well-known/openid-configuration");
+
+        var body = BodyText();
+
+        Assert.Contains("\"issuer\"", body);
+        Assert.Contains(_fixture.BaseUrl, body);
+        Assert.Contains("\"token_endpoint\"", body);
+        Assert.Contains("\"userinfo_endpoint\"", body);
+        Assert.Contains("\"jwks_uri\"", body);
+    }
+
+    [Fact]
+    public void JWKS_が_RS256_公開鍵を配信すること()
+    {
+        Driver.Navigate().GoToUrl($"{_fixture.BaseUrl}/.well-known/jwks.json");
+
+        var body = BodyText();
+
+        Assert.Contains("\"keys\"", body);
+        Assert.Contains("\"RSA\"", body);
+        Assert.Contains("\"RS256\"", body);
+    }
+}

--- a/E2ETests.Selenium/README.md
+++ b/E2ETests.Selenium/README.md
@@ -1,0 +1,49 @@
+# E2ETests.Selenium
+
+実ブラウザ（Chrome + ChromeDriver）で動かす **軽量な smoke テスト** を集めた C#（xUnit /
+Selenium.WebDriver）プロジェクトです。フル機能の E2E（WebAuthn 署名検証やフェデレーション
+認可コードフロー）は引き続き Playwright 版 [`../E2ETests`](../E2ETests) が担当し、ここはその
+補完として「ページ/エンドポイントがブラウザから正しく配信される」ことだけを素早く確認します。
+
+## テスト一覧
+
+| テスト | 確認内容 |
+|--------|----------|
+| `OidcDiscoverySmokeTests` | `/.well-known/openid-configuration` と `/.well-known/jwks.json` をブラウザで開き、主要キー（`issuer` / `token_endpoint` / `jwks_uri`、RS256 公開鍵）が本文に現れること |
+| `B2bPasskeyPageSmokeTests` | `/b2b-passkey-test.html` が配信され、タイトル・見出し・登録フォームの主要要素が描画されること |
+
+## 前提
+
+テストは起動済みの IdentityProvider（既定 `https://localhost:8081`）に接続します。先に
+ローカル Docker 環境を起動してください。
+
+```bash
+docker compose -p ec-auth up -d --build
+```
+
+## ChromeDriver の解決方針
+
+`ChromeDriverFixture` は **PATH（または `CHROMEWEBDRIVER`）上の `chromedriver` を明示的に解決**
+して使用します。これは CI で [`nanasess/setup-chromedriver`](https://github.com/nanasess/setup-chromedriver)
+が導入したドライバをそのまま使うことを意図したものです。ローカルで `chromedriver` が見つからない
+場合のみ、Selenium Manager による自動ダウンロードにフォールバックします。
+
+## ローカル実行
+
+```bash
+# IdP 起動後に実行
+dotnet test E2ETests.Selenium/E2ETests.Selenium.csproj
+
+# ベース URL を上書きする場合
+E2E_BASE_URL=https://localhost:8081 dotnet test E2ETests.Selenium/E2ETests.Selenium.csproj
+```
+
+テストはヘッドレス Chrome（`--headless=new`）で動作し、自己署名証明書を許可
+（`AcceptInsecureCertificates`）します。
+
+## CI
+
+[`.github/workflows/selenium.yml`](../.github/workflows/selenium.yml) が、SQL Server 起動 →
+.NET ビルド → DB マイグレーション → IdP 起動 → `nanasess/setup-chromedriver@v3` で ChromeDriver
+導入 → `dotnet test` の順で実行します。Playwright ワークフロー（`playwright.yml`）とは独立した
+ジョブです。

--- a/E2ETests.Selenium/README.md
+++ b/E2ETests.Selenium/README.md
@@ -44,6 +44,7 @@ E2E_BASE_URL=https://localhost:8081 dotnet test E2ETests.Selenium/E2ETests.Selen
 ## CI
 
 [`.github/workflows/selenium.yml`](../.github/workflows/selenium.yml) が、SQL Server 起動 →
-.NET ビルド → DB マイグレーション → IdP 起動 → `nanasess/setup-chromedriver@v3` で ChromeDriver
+.NET ビルド → DB マイグレーション → IdP 起動 → `nanasess/setup-chromedriver` で ChromeDriver
 導入 → `dotnet test` の順で実行します。Playwright ワークフロー（`playwright.yml`）とは独立した
-ジョブです。
+ジョブです。サプライチェーン強化のため action は full commit SHA でピン留めし、末尾コメントに
+バージョン（`# v3.0.0`）を残しています。

--- a/EcAuth.sln
+++ b/EcAuth.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EcAuthConsoleApp", "Console
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IdentityProvider.Test", "IdentityProvider.Test\IdentityProvider.Test.csproj", "{DC886767-8777-E1AD-B4C4-09FCB2A4E4B1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "E2ETests.Selenium", "E2ETests.Selenium\E2ETests.Selenium.csproj", "{E879AE86-3F3D-4103-97CE-550F402FCC7A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -55,6 +57,18 @@ Global
 		{DC886767-8777-E1AD-B4C4-09FCB2A4E4B1}.Release|x64.Build.0 = Release|Any CPU
 		{DC886767-8777-E1AD-B4C4-09FCB2A4E4B1}.Release|x86.ActiveCfg = Release|Any CPU
 		{DC886767-8777-E1AD-B4C4-09FCB2A4E4B1}.Release|x86.Build.0 = Release|Any CPU
+		{E879AE86-3F3D-4103-97CE-550F402FCC7A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E879AE86-3F3D-4103-97CE-550F402FCC7A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E879AE86-3F3D-4103-97CE-550F402FCC7A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E879AE86-3F3D-4103-97CE-550F402FCC7A}.Debug|x64.Build.0 = Debug|Any CPU
+		{E879AE86-3F3D-4103-97CE-550F402FCC7A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E879AE86-3F3D-4103-97CE-550F402FCC7A}.Debug|x86.Build.0 = Debug|Any CPU
+		{E879AE86-3F3D-4103-97CE-550F402FCC7A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E879AE86-3F3D-4103-97CE-550F402FCC7A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E879AE86-3F3D-4103-97CE-550F402FCC7A}.Release|x64.ActiveCfg = Release|Any CPU
+		{E879AE86-3F3D-4103-97CE-550F402FCC7A}.Release|x64.Build.0 = Release|Any CPU
+		{E879AE86-3F3D-4103-97CE-550F402FCC7A}.Release|x86.ActiveCfg = Release|Any CPU
+		{E879AE86-3F3D-4103-97CE-550F402FCC7A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## 概要

Playwright E2E（`E2ETests/`）とは別に、実ブラウザ（Chrome + ChromeDriver）で動かす **軽量な smoke テスト** を C#（xUnit / Selenium.WebDriver）の新規プロジェクト `E2ETests.Selenium` として追加します。ChromeDriver のセットアップには拙作の [`nanasess/setup-chromedriver@v3`](https://github.com/nanasess/setup-chromedriver) を使用します。

フル機能の E2E（WebAuthn 署名検証 / フェデレーション認可コードフロー）は引き続き Playwright 版が担当し、本 PR はその補完です。

## 変更点

- **`E2ETests.Selenium/`**（新規 C# テストプロジェクト、`EcAuth.sln` に追加）
  - `OidcDiscoverySmokeTests` — `/.well-known/openid-configuration` と `/.well-known/jwks.json` をブラウザで開き、主要キー（`issuer` / `token_endpoint` / `jwks_uri`、RS256 公開鍵）の配信を確認
  - `B2bPasskeyPageSmokeTests` — `/b2b-passkey-test.html` が配信され、タイトル・見出し・登録フォームの主要要素が描画されることを確認
  - `ChromeDriverFixture` — PATH（または `CHROMEWEBDRIVER`）上の `chromedriver` を **明示解決** して使用。CI で setup-chromedriver が導入したドライバをそのまま使い、Selenium Manager の自動 DL には依存しない。ローカルで未検出時のみ Manager にフォールバック
  - ヘッドレス Chrome（`--headless=new`）+ 自己署名証明書許可（`AcceptInsecureCertificates`）
- **`.github/workflows/selenium.yml`**（新規ワークフロー）
  - `playwright.yml` のサーバ起動手順（SQL Server → .NET ビルド → DB マイグレーション → IdP 起動 → `/healthz` 待機）を踏襲
  - `nanasess/setup-chromedriver@v3` で ChromeDriver を導入 → `dotnet test E2ETests.Selenium` を実行
  - Playwright ワークフローとは独立したジョブ

## 検証

- [x] `dotnet build` / `dotnet test --list-tests`（Release）で 3 テストの検出・コンパイルを確認（ローカル）
- [x] CI（`selenium.yml`）でブラウザ smoke テストが通過（本 PR の CI で検証）

> 補足: サプライチェーン強化として `setup-chromedriver` を full commit SHA でピン留めする選択肢もあります（README 推奨）。本 PR では作者リクエストにより `@v3` を使用しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * 実ブラウザ（Chrome）を用いたエンドツーエンドスモークテストを追加しました。OIDC Discovery、JWKS、B2B パスキーページなどの主要機能について、自動化されたテストが CI パイプラインで実行されます。

* **Chores**
  * CI/CD ワークフローに自動スモークテスト実行環境を構築し、本番リリース前の品質検証を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->