### PR TITLE
feat(account): Phase B - Seeder と環境変数配線

### DIFF
--- a/.env.dev.tpl
+++ b/.env.dev.tpl
@@ -96,6 +96,25 @@ STAGING_MOCK_IDP_TOKEN_ENDPOINT=https://localhost:9091/token
 STAGING_MOCK_IDP_USERINFO_ENDPOINT=https://localhost:9091/userinfo
 
 # =============================================================================
+# Account Management Settings (ローカル開発用ダミー値)
+# =============================================================================
+# AccountsOrganizationSeeder が accounts / stg-accounts Org と管理コンソール Client を
+# 投入するために参照する。本番では Terraform app_settings (Phase E) から注入される。
+# Organization の code / tenant_name はサブドメイン解決と一致させるため Seeder 側で固定。
+ACCOUNTS_CLIENT_ID=ecauth-admin-console
+ACCOUNTS_CLIENT_SECRET=accounts_client_secret
+ACCOUNTS_ALLOWED_RP_IDS=localhost
+ACCOUNTS_REDIRECT_URI=https://localhost:8081/auth/callback
+
+STG_ACCOUNTS_CLIENT_ID=ecauth-admin-console-stg
+STG_ACCOUNTS_CLIENT_SECRET=stg_accounts_client_secret
+STG_ACCOUNTS_ALLOWED_RP_IDS=localhost
+STG_ACCOUNTS_REDIRECT_URI=https://localhost:8081/auth/callback
+
+# 申込・マジックリンクのメール送信 (Phase D で使用)。ローカルはダミー値。
+SENDGRID_API_KEY=dummy_sendgrid_api_key
+
+# =============================================================================
 # EC-CUBE 2系プラグイン Settings (ローカル開発用ダミー値)
 # =============================================================================
 ECCUBE2_CLIENT_ID=eccube2_client_id

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -71,6 +71,18 @@ jobs:
           PROD_B2B_USER_EXTERNAL_ID: op://EcAuth/ecauth-prod-app/b2b_user_external_id
           PROD_B2B_REDIRECT_URI: op://EcAuth/ecauth-prod-app/b2b_redirect_uri
           PROD_B2B_ALLOWED_RP_IDS: op://EcAuth/ecauth-prod-app/b2b_allowed_rp_ids
+          # Account management settings (accounts / stg-accounts Org)
+          # 実際のランタイム注入は Terraform app_settings (Phase E)。ここは CI 配線。
+          ACCOUNTS_CLIENT_ID: op://EcAuth/ecauth-prod-app/accounts_client_id
+          ACCOUNTS_CLIENT_SECRET: op://EcAuth/ecauth-prod-app/accounts_client_secret
+          ACCOUNTS_ALLOWED_RP_IDS: op://EcAuth/ecauth-prod-app/accounts_allowed_rp_ids
+          ACCOUNTS_REDIRECT_URI: op://EcAuth/ecauth-prod-app/accounts_redirect_uri
+          STG_ACCOUNTS_CLIENT_ID: op://EcAuth/ecauth-prod-app/stg_accounts_client_id
+          STG_ACCOUNTS_CLIENT_SECRET: op://EcAuth/ecauth-prod-app/stg_accounts_client_secret
+          STG_ACCOUNTS_ALLOWED_RP_IDS: op://EcAuth/ecauth-prod-app/stg_accounts_allowed_rp_ids
+          STG_ACCOUNTS_REDIRECT_URI: op://EcAuth/ecauth-prod-app/stg_accounts_redirect_uri
+          # Email delivery (signup / magic-link, Phase D)
+          SENDGRID_API_KEY: op://EcAuth/ecauth-prod-app/sendgrid_api_key
           # Staging variables (required for idempotent script generation of staging migration)
           STAGING_ORGANIZATION_CODE: op://EcAuth/ecauth-staging-app/organization_code
           STAGING_ORGANIZATION_NAME: op://EcAuth/ecauth-staging-app/organization_name

--- a/IdentityProvider.Test/Data/Seeders/AccountsOrganizationSeederTests.cs
+++ b/IdentityProvider.Test/Data/Seeders/AccountsOrganizationSeederTests.cs
@@ -1,0 +1,258 @@
+using IdentityProvider.Data.Seeders;
+using IdentityProvider.Models;
+using IdentityProvider.Test.TestHelpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace IdentityProvider.Test.Data.Seeders
+{
+    public class AccountsOrganizationSeederTests : IDisposable
+    {
+        #region Test Constants
+
+        private const string AccountsClientId = "ecauth-admin-console";
+        private const string AccountsClientSecret = "accounts-secret";
+        private const string AccountsAllowedRpIds = "accounts.ec-auth.io";
+        private const string AccountsRedirectUri = "https://accounts.ec-auth.io/auth/callback";
+
+        private const string StgAccountsClientId = "ecauth-admin-console-stg";
+        private const string StgAccountsClientSecret = "stg-accounts-secret";
+        private const string StgAccountsAllowedRpIds = "stg-accounts.ec-auth.io";
+        private const string StgAccountsRedirectUri = "https://stg-accounts.ec-auth.io/auth/callback";
+
+        #endregion
+
+        private readonly EcAuthDbContext _context;
+        private readonly AccountsOrganizationSeeder _seeder;
+        private readonly Mock<ILogger> _mockLogger;
+
+        public AccountsOrganizationSeederTests()
+        {
+            _context = TestDbContextHelper.CreateInMemoryContext();
+            _seeder = new AccountsOrganizationSeeder();
+            _mockLogger = new Mock<ILogger>();
+        }
+
+        #region Metadata Tests
+
+        [Fact]
+        public void RequiredMigration_ShouldBeAccountManagementSchema()
+        {
+            Assert.Equal("20260514085625_AddAccountManagementSchema", _seeder.RequiredMigration);
+        }
+
+        [Fact]
+        public void Order_ShouldBe20()
+        {
+            Assert.Equal(20, _seeder.Order);
+        }
+
+        #endregion
+
+        #region Organization Tests
+
+        [Fact]
+        public async Task SeedAsync_ShouldCreateBothOrganizations()
+        {
+            // Arrange
+            var configuration = CreateFullConfiguration();
+
+            // Act
+            await _seeder.SeedAsync(_context, configuration, _mockLogger.Object);
+
+            // Assert
+            var accounts = await _context.Organizations
+                .IgnoreQueryFilters()
+                .FirstOrDefaultAsync(o => o.Code == "accounts");
+            Assert.NotNull(accounts);
+            Assert.Equal("accounts", accounts.TenantName);
+
+            var stgAccounts = await _context.Organizations
+                .IgnoreQueryFilters()
+                .FirstOrDefaultAsync(o => o.Code == "stg-accounts");
+            Assert.NotNull(stgAccounts);
+            Assert.Equal("stg-accounts", stgAccounts.TenantName);
+        }
+
+        #endregion
+
+        #region Client Tests
+
+        [Fact]
+        public async Task SeedAsync_ShouldCreateClientsWithSubjectTypeAccount()
+        {
+            // Arrange
+            var configuration = CreateFullConfiguration();
+
+            // Act
+            await _seeder.SeedAsync(_context, configuration, _mockLogger.Object);
+
+            // Assert
+            var accountsClient = await _context.Clients
+                .IgnoreQueryFilters()
+                .FirstOrDefaultAsync(c => c.ClientId == AccountsClientId);
+            Assert.NotNull(accountsClient);
+            Assert.Equal(SubjectType.Account, accountsClient.SubjectType);
+            Assert.Equal(AccountsClientSecret, accountsClient.ClientSecret);
+            Assert.Contains(AccountsAllowedRpIds, accountsClient.AllowedRpIds);
+
+            var stgClient = await _context.Clients
+                .IgnoreQueryFilters()
+                .FirstOrDefaultAsync(c => c.ClientId == StgAccountsClientId);
+            Assert.NotNull(stgClient);
+            Assert.Equal(SubjectType.Account, stgClient.SubjectType);
+            Assert.Contains(StgAccountsAllowedRpIds, stgClient.AllowedRpIds);
+        }
+
+        [Fact]
+        public async Task SeedAsync_WithoutClientSecret_ShouldCreateOrganizationButSkipClient()
+        {
+            // Arrange - accounts のみ、CLIENT_SECRET 未設定
+            var configuration = CreateConfiguration(new Dictionary<string, string?>
+            {
+                ["ACCOUNTS_CLIENT_ID"] = AccountsClientId
+            });
+
+            // Act
+            await _seeder.SeedAsync(_context, configuration, _mockLogger.Object);
+
+            // Assert
+            var orgExists = await _context.Organizations
+                .IgnoreQueryFilters()
+                .AnyAsync(o => o.Code == "accounts");
+            Assert.True(orgExists);
+
+            var clientCount = await _context.Clients.IgnoreQueryFilters().CountAsync();
+            Assert.Equal(0, clientCount);
+        }
+
+        #endregion
+
+        #region RedirectUri / RsaKeyPair Tests
+
+        [Fact]
+        public async Task SeedAsync_ShouldCreateRedirectUriAndRsaKeyPairPerOrganization()
+        {
+            // Arrange
+            var configuration = CreateFullConfiguration();
+
+            // Act
+            await _seeder.SeedAsync(_context, configuration, _mockLogger.Object);
+
+            // Assert - RedirectUri
+            var accountsClient = await _context.Clients
+                .IgnoreQueryFilters()
+                .FirstAsync(c => c.ClientId == AccountsClientId);
+            var redirectExists = await _context.RedirectUris
+                .IgnoreQueryFilters()
+                .AnyAsync(r => r.Uri == AccountsRedirectUri && r.ClientId == accountsClient.Id);
+            Assert.True(redirectExists);
+
+            // Assert - RsaKeyPair が各 Org に 1 件ずつ
+            var accounts = await _context.Organizations
+                .IgnoreQueryFilters().FirstAsync(o => o.Code == "accounts");
+            var stgAccounts = await _context.Organizations
+                .IgnoreQueryFilters().FirstAsync(o => o.Code == "stg-accounts");
+
+            Assert.Equal(1, await _context.RsaKeyPairs
+                .IgnoreQueryFilters().CountAsync(r => r.OrganizationId == accounts.Id));
+            Assert.Equal(1, await _context.RsaKeyPairs
+                .IgnoreQueryFilters().CountAsync(r => r.OrganizationId == stgAccounts.Id));
+        }
+
+        #endregion
+
+        #region Skip Conditions Tests
+
+        [Fact]
+        public async Task SeedAsync_WithNoConfiguration_ShouldSeedNothing()
+        {
+            // Arrange - staging 等、ACCOUNTS_* / STG_ACCOUNTS_* 未設定の環境
+            var configuration = CreateConfiguration(new Dictionary<string, string?>());
+
+            // Act
+            await _seeder.SeedAsync(_context, configuration, _mockLogger.Object);
+
+            // Assert
+            Assert.Equal(0, await _context.Organizations.IgnoreQueryFilters().CountAsync());
+            Assert.Equal(0, await _context.Clients.IgnoreQueryFilters().CountAsync());
+        }
+
+        [Fact]
+        public async Task SeedAsync_WithOnlyAccountsConfigured_ShouldSkipStgAccounts()
+        {
+            // Arrange - accounts のみ設定（dev で片方だけ検証するケース）
+            var configuration = CreateConfiguration(new Dictionary<string, string?>
+            {
+                ["ACCOUNTS_CLIENT_ID"] = AccountsClientId,
+                ["ACCOUNTS_CLIENT_SECRET"] = AccountsClientSecret
+            });
+
+            // Act
+            await _seeder.SeedAsync(_context, configuration, _mockLogger.Object);
+
+            // Assert
+            Assert.True(await _context.Organizations
+                .IgnoreQueryFilters().AnyAsync(o => o.Code == "accounts"));
+            Assert.False(await _context.Organizations
+                .IgnoreQueryFilters().AnyAsync(o => o.Code == "stg-accounts"));
+        }
+
+        #endregion
+
+        #region Idempotency Tests
+
+        [Fact]
+        public async Task SeedAsync_CalledMultipleTimes_ShouldBeIdempotent()
+        {
+            // Arrange
+            var configuration = CreateFullConfiguration();
+
+            // Act - 3 回実行
+            await _seeder.SeedAsync(_context, configuration, _mockLogger.Object);
+            await _seeder.SeedAsync(_context, configuration, _mockLogger.Object);
+            await _seeder.SeedAsync(_context, configuration, _mockLogger.Object);
+
+            // Assert
+            Assert.Equal(2, await _context.Organizations.IgnoreQueryFilters().CountAsync());
+            Assert.Equal(2, await _context.Clients.IgnoreQueryFilters().CountAsync());
+            Assert.Equal(2, await _context.RsaKeyPairs.IgnoreQueryFilters().CountAsync());
+            Assert.Equal(2, await _context.RedirectUris.IgnoreQueryFilters().CountAsync());
+        }
+
+        #endregion
+
+        public void Dispose()
+        {
+            _context.Dispose();
+        }
+
+        #region Helper Methods
+
+        private static IConfiguration CreateFullConfiguration()
+        {
+            return CreateConfiguration(new Dictionary<string, string?>
+            {
+                ["ACCOUNTS_CLIENT_ID"] = AccountsClientId,
+                ["ACCOUNTS_CLIENT_SECRET"] = AccountsClientSecret,
+                ["ACCOUNTS_ALLOWED_RP_IDS"] = AccountsAllowedRpIds,
+                ["ACCOUNTS_REDIRECT_URI"] = AccountsRedirectUri,
+                ["STG_ACCOUNTS_CLIENT_ID"] = StgAccountsClientId,
+                ["STG_ACCOUNTS_CLIENT_SECRET"] = StgAccountsClientSecret,
+                ["STG_ACCOUNTS_ALLOWED_RP_IDS"] = StgAccountsAllowedRpIds,
+                ["STG_ACCOUNTS_REDIRECT_URI"] = StgAccountsRedirectUri
+            });
+        }
+
+        private static IConfiguration CreateConfiguration(Dictionary<string, string?> values)
+        {
+            return new ConfigurationBuilder()
+                .AddInMemoryCollection(values)
+                .Build();
+        }
+
+        #endregion
+    }
+}

--- a/IdentityProvider.Test/Data/Seeders/OrganizationClientSeederTests.cs
+++ b/IdentityProvider.Test/Data/Seeders/OrganizationClientSeederTests.cs
@@ -129,6 +129,8 @@ namespace IdentityProvider.Test.Data.Seeders
             Assert.Equal(TestClientSecret, client.ClientSecret);
             Assert.Equal(TestAppName, client.AppName);
             Assert.NotNull(client.OrganizationId);
+            // EC-CUBE 管理画面用 Client は SubjectType.B2B を明示セットする
+            Assert.Equal(SubjectType.B2B, client.SubjectType);
         }
 
         [Fact]

--- a/IdentityProvider/Data/Seeders/AccountsOrganizationSeeder.cs
+++ b/IdentityProvider/Data/Seeders/AccountsOrganizationSeeder.cs
@@ -82,7 +82,8 @@ public class AccountsOrganizationSeeder : IDbSeeder
         var redirectUri = configuration[$"{definition.ConfigPrefix}_REDIRECT_URI"];
 
         // Client ID が未設定の環境（staging 等）ではこの Org を投入しない
-        if (string.IsNullOrEmpty(clientId))
+        // 空白のみの値も未設定とみなす（誤設定による不正な Client ID 投入を防ぐ）
+        if (string.IsNullOrWhiteSpace(clientId))
         {
             logger.LogInformation(
                 "Skipped {Code} - {Prefix}_CLIENT_ID not configured",
@@ -165,7 +166,7 @@ public class AccountsOrganizationSeeder : IDbSeeder
             return (existing, false);
         }
 
-        if (string.IsNullOrEmpty(clientSecret))
+        if (string.IsNullOrWhiteSpace(clientSecret))
         {
             logger.LogWarning(
                 "Client creation skipped for {Code} - {Prefix}_CLIENT_SECRET not configured",
@@ -182,10 +183,11 @@ public class AccountsOrganizationSeeder : IDbSeeder
             SubjectType = SubjectType.Account
         };
 
-        if (!string.IsNullOrEmpty(allowedRpIds))
+        if (!string.IsNullOrWhiteSpace(allowedRpIds))
         {
             client.AllowedRpIds = allowedRpIds
                 .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Distinct()
                 .ToList();
         }
 
@@ -203,7 +205,7 @@ public class AccountsOrganizationSeeder : IDbSeeder
         string? redirectUri,
         ILogger logger)
     {
-        if (string.IsNullOrEmpty(redirectUri))
+        if (string.IsNullOrWhiteSpace(redirectUri))
         {
             return false;
         }

--- a/IdentityProvider/Data/Seeders/AccountsOrganizationSeeder.cs
+++ b/IdentityProvider/Data/Seeders/AccountsOrganizationSeeder.cs
@@ -1,0 +1,270 @@
+using System.Security.Cryptography;
+using IdentityProvider.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace IdentityProvider.Data.Seeders;
+
+/// <summary>
+/// EcAuth Account 管理用の <c>accounts</c> / <c>stg-accounts</c> Organization と
+/// それぞれの管理コンソール Client（<see cref="SubjectType.Account"/>）を投入するシーダー。
+/// <para>
+/// 既存の <see cref="OrganizationClientSeeder"/> が ASPNETCORE_ENVIRONMENT に応じた
+/// DEV/STAGING/PROD プレフィックスで分岐するのに対し、本シーダーは環境に依存せず
+/// 固定の <c>ACCOUNTS_*</c> / <c>STG_ACCOUNTS_*</c> 環境変数の有無で投入可否を判定する。
+/// 本番 App Service では Terraform app_settings から両プレフィックスが注入され 2 Org が投入される。
+/// ローカル開発では <c>.env.dev.tpl</c> のダミー値で動作確認できる。
+/// staging では設定しないため何も投入されずスキップされる（Account 機能は本番のみ）。
+/// </para>
+/// </summary>
+public class AccountsOrganizationSeeder : IDbSeeder
+{
+    /// <inheritdoc />
+    /// <remarks>
+    /// Phase A で 4 マイグレーションが統合されたため、<c>AddSubjectTypeToClient</c> を含む
+    /// 統合マイグレーション名を指定する。
+    /// </remarks>
+    public string RequiredMigration => "20260514085625_AddAccountManagementSchema";
+
+    /// <inheritdoc />
+    public int Order => 20;
+
+    /// <summary>
+    /// 投入対象の Organization 定義。Organization の <c>code</c> / <c>tenant_name</c> は
+    /// サブドメインからのテナント解決と一致させる必要があるため固定値とする。
+    /// </summary>
+    private static readonly AccountOrgDefinition[] Definitions =
+    {
+        new(
+            ConfigPrefix: "ACCOUNTS",
+            Code: "accounts",
+            Name: "EcAuth Accounts",
+            TenantName: "accounts"),
+        new(
+            ConfigPrefix: "STG_ACCOUNTS",
+            Code: "stg-accounts",
+            Name: "EcAuth Accounts (Staging)",
+            TenantName: "stg-accounts"),
+    };
+
+    /// <inheritdoc />
+    public async Task SeedAsync(
+        EcAuthDbContext context,
+        IConfiguration configuration,
+        ILogger logger)
+    {
+        var hasChanges = false;
+
+        foreach (var definition in Definitions)
+        {
+            hasChanges |= await SeedDefinitionAsync(context, configuration, definition, logger);
+        }
+
+        if (hasChanges)
+        {
+            await context.SaveChangesAsync();
+            logger.LogInformation("Account organization seed data saved successfully");
+        }
+        else
+        {
+            logger.LogInformation("No changes needed for account organizations");
+        }
+    }
+
+    private static async Task<bool> SeedDefinitionAsync(
+        EcAuthDbContext context,
+        IConfiguration configuration,
+        AccountOrgDefinition definition,
+        ILogger logger)
+    {
+        var clientId = configuration[$"{definition.ConfigPrefix}_CLIENT_ID"];
+        var clientSecret = configuration[$"{definition.ConfigPrefix}_CLIENT_SECRET"];
+        var allowedRpIds = configuration[$"{definition.ConfigPrefix}_ALLOWED_RP_IDS"];
+        var redirectUri = configuration[$"{definition.ConfigPrefix}_REDIRECT_URI"];
+
+        // Client ID が未設定の環境（staging 等）ではこの Org を投入しない
+        if (string.IsNullOrEmpty(clientId))
+        {
+            logger.LogInformation(
+                "Skipped {Code} - {Prefix}_CLIENT_ID not configured",
+                definition.Code, definition.ConfigPrefix);
+            return false;
+        }
+
+        var hasChanges = false;
+
+        // 1. Organization 作成
+        var organization = await SeedOrganizationAsync(context, definition, logger);
+
+        // 2. Client 作成（SubjectType.Account）
+        var client = await SeedClientAsync(
+            context, definition, clientId, clientSecret, allowedRpIds, organization, logger);
+        hasChanges |= client.created;
+
+        if (client.entity == null)
+        {
+            logger.LogWarning(
+                "Skipped remaining seeds for {Code} - Client could not be created or found",
+                definition.Code);
+            return hasChanges;
+        }
+
+        // 3. RedirectUri 作成
+        hasChanges |= await SeedRedirectUriAsync(context, client.entity, redirectUri, logger);
+
+        // 4. RsaKeyPair 生成・保存（Organization 単位）
+        hasChanges |= await SeedRsaKeyPairAsync(context, organization, logger);
+
+        return hasChanges;
+    }
+
+    private static async Task<Organization> SeedOrganizationAsync(
+        EcAuthDbContext context,
+        AccountOrgDefinition definition,
+        ILogger logger)
+    {
+        var existing = await context.Organizations
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(o => o.Code == definition.Code);
+
+        if (existing != null)
+        {
+            logger.LogInformation("Organization {Code} already exists, skipping", definition.Code);
+            return existing;
+        }
+
+        var organization = new Organization
+        {
+            Code = definition.Code,
+            Name = definition.Name,
+            TenantName = definition.TenantName
+        };
+
+        context.Organizations.Add(organization);
+        await context.SaveChangesAsync();
+
+        logger.LogInformation("Created Organization {Code}", definition.Code);
+        return organization;
+    }
+
+    private static async Task<(Client? entity, bool created)> SeedClientAsync(
+        EcAuthDbContext context,
+        AccountOrgDefinition definition,
+        string clientId,
+        string? clientSecret,
+        string? allowedRpIds,
+        Organization organization,
+        ILogger logger)
+    {
+        var existing = await context.Clients
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(c => c.ClientId == clientId);
+
+        if (existing != null)
+        {
+            logger.LogInformation("Client {ClientId} already exists, skipping", clientId);
+            return (existing, false);
+        }
+
+        if (string.IsNullOrEmpty(clientSecret))
+        {
+            logger.LogWarning(
+                "Client creation skipped for {Code} - {Prefix}_CLIENT_SECRET not configured",
+                definition.Code, definition.ConfigPrefix);
+            return (null, false);
+        }
+
+        var client = new Client
+        {
+            ClientId = clientId,
+            ClientSecret = clientSecret,
+            AppName = definition.Name,
+            OrganizationId = organization.Id,
+            SubjectType = SubjectType.Account
+        };
+
+        if (!string.IsNullOrEmpty(allowedRpIds))
+        {
+            client.AllowedRpIds = allowedRpIds
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .ToList();
+        }
+
+        context.Clients.Add(client);
+        await context.SaveChangesAsync();
+
+        logger.LogInformation("Created Account Client {ClientId} for Organization {OrgCode}",
+            clientId, organization.Code);
+        return (client, true);
+    }
+
+    private static async Task<bool> SeedRedirectUriAsync(
+        EcAuthDbContext context,
+        Client client,
+        string? redirectUri,
+        ILogger logger)
+    {
+        if (string.IsNullOrEmpty(redirectUri))
+        {
+            return false;
+        }
+
+        var exists = await context.RedirectUris
+            .IgnoreQueryFilters()
+            .AnyAsync(r => r.Uri == redirectUri && r.ClientId == client.Id);
+
+        if (exists)
+        {
+            return false;
+        }
+
+        context.RedirectUris.Add(new RedirectUri
+        {
+            Uri = redirectUri,
+            ClientId = client.Id
+        });
+
+        logger.LogInformation("Added RedirectUri {Uri} for client {ClientId}",
+            redirectUri, client.ClientId);
+        return true;
+    }
+
+    private static async Task<bool> SeedRsaKeyPairAsync(
+        EcAuthDbContext context,
+        Organization organization,
+        ILogger logger)
+    {
+        var exists = await context.RsaKeyPairs
+            .IgnoreQueryFilters()
+            .AnyAsync(r => r.OrganizationId == organization.Id);
+
+        if (exists)
+        {
+            return false;
+        }
+
+        using var rsa = RSA.Create(2048);
+        var publicKeyBase64 = Convert.ToBase64String(rsa.ExportRSAPublicKey());
+        var privateKeyBase64 = Convert.ToBase64String(rsa.ExportRSAPrivateKey());
+
+        context.RsaKeyPairs.Add(new RsaKeyPair
+        {
+            Kid = Guid.NewGuid().ToString(),
+            OrganizationId = organization.Id,
+            PublicKey = publicKeyBase64,
+            PrivateKey = privateKeyBase64,
+            IsActive = true
+        });
+
+        logger.LogInformation("Generated RsaKeyPair for organization {OrganizationCode}", organization.Code);
+        return true;
+    }
+
+    /// <summary>
+    /// 固定の Organization 定義と、対応する環境変数プレフィックスの組。
+    /// </summary>
+    private sealed record AccountOrgDefinition(
+        string ConfigPrefix,
+        string Code,
+        string Name,
+        string TenantName);
+}

--- a/IdentityProvider/Data/Seeders/OrganizationClientSeeder.cs
+++ b/IdentityProvider/Data/Seeders/OrganizationClientSeeder.cs
@@ -160,7 +160,10 @@ public class OrganizationClientSeeder : IDbSeeder
             ClientId = clientId,
             ClientSecret = clientSecret,
             AppName = appName ?? clientId,
-            OrganizationId = organization.Id
+            OrganizationId = organization.Id,
+            // EC-CUBE 管理画面用の B2B パスキー Client。Client.SubjectType の
+            // デフォルトは B2C のため、ここで B2B を明示する。
+            SubjectType = SubjectType.B2B
         };
 
         context.Clients.Add(client);

--- a/IdentityProvider/Program.cs
+++ b/IdentityProvider/Program.cs
@@ -31,6 +31,7 @@ builder.Services.AddScoped<IB2BPasskeyService, B2BPasskeyService>();
 
 // データベース初期化（シーダー）
 builder.Services.AddScoped<IDbSeeder, OrganizationClientSeeder>();
+builder.Services.AddScoped<IDbSeeder, AccountsOrganizationSeeder>();
 builder.Services.AddScoped<IDbSeeder, B2BPasskeySeeder>();
 builder.Services.AddScoped<DbInitializer>();
 // Fido2.NetLib設定（動的RP IDに対応するためリクエストごとに設定を変更する必要あり）


### PR DESCRIPTION
## 概要

[EcAuthDocs#79](https://github.com/EcAuth/EcAuthDocs/issues/79)（Account 管理機能の EcAuth 本体実装計画）の **Phase B** を実装します。本番 DB に `accounts` / `stg-accounts` Organization と各管理コンソール Client を投入する基盤を整備します。

Phase A（[#386](https://github.com/EcAuth/EcAuth/pull/386)）でマージ済みのスキーマ・モデル基盤の上に構築します。スキーマ変更は含みません（マイグレーション不要）。

## 変更内容

### 新規 Seeder
- **`AccountsOrganizationSeeder`**: `accounts` / `stg-accounts` の 2 Org と、それぞれの管理コンソール Client（`SubjectType.Account`、`AllowedRpIds` 付き）+ RsaKeyPair を冪等投入
  - 既存 `OrganizationClientSeeder` の DEV/STAGING/PROD プレフィックス分岐とは異なり、**環境非依存**で固定の `ACCOUNTS_*` / `STG_ACCOUNTS_*` 環境変数の有無で投入可否を判定（本番のみ両 Org 投入、staging では未設定のためスキップ）
  - Org の `code` / `tenant_name` はサブドメイン解決と一致させるため固定値
  - `RequiredMigration` は Phase A で 4 マイグレーションが統合された `20260514085625_AddAccountManagementSchema`、`Order = 20`
- `Program.cs` に DI 登録（実行順 10 → 20 → 100）

### 既存 Seeder 変更
- `OrganizationClientSeeder`: EC-CUBE 管理画面用 Client 作成時に `SubjectType.B2B` を明示セット（`Client.SubjectType` のデフォルトは `B2C` のため）

### 環境変数配線
- `.env.dev.tpl`: `ACCOUNTS_*` / `STG_ACCOUNTS_*` ダミー値 + `SENDGRID_API_KEY` プレースホルダを追加（ローカル動作確認用）
- `.github/workflows/production.yml`: `migrate` ジョブの `load-secrets` に `op://EcAuth/ecauth-prod-app/...` 参照を追加。**staging には設定しない**（設計上 Account 機能は本番のみ）

## テスト計画

- [x] `dotnet build EcAuth.sln` が 0 エラー（.NET 10）
- [x] 全ユニットテスト **576 件合格**（Seeder 関連 62 件含む）
- [x] `AccountsOrganizationSeederTests` 新規 10 ケース（2 Org 生成 / `SubjectType.Account` / RsaKeyPair・RedirectUri / スキップ条件 / 冪等性）
- [x] `OrganizationClientSeederTests` に `SubjectType.B2B` 検証を追加
- [x] `dotnet ef migrations has-pending-model-changes` がモデル差分ゼロ

## 残タスク（手動・1Password 操作）

本 PR には含められない 1Password 操作が残ります:
- `ecauth-prod-app` アイテムに `accounts_client_id` / `accounts_client_secret` / `accounts_allowed_rp_ids` / `accounts_redirect_uri` / `stg_accounts_*` / `sendgrid_api_key` フィールドを追加

## レビュー観点

- **`SubjectType.B2B` への変更**: 既存シード Client は dev で B2C フェデレーションにも使われます。`TokenController` は `authCode.SubjectType` で分岐するため理論上は無影響ですが、Phase C / フェデレーション E2E で要確認です。
- 1Password アイテム名は設計書表記（`ecauth-production-app`）ではなく、既存ワークフロー規約の `ecauth-prod-app` に統一しています。

Refs: EcAuthDocs#79

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * アカウント管理組織およびステージング環境向けのデータ投入（管理コンソール用クライアント、許可リダイレクト、RSA鍵ペア）をシーディングに追加
* **Tests**
  * アカウント管理組織シーディングの包括的なテストスイートを追加し、冪等性や設定不足時の挙動を検証
* **Chores**
  * CI/CD パイプラインの環境変数参照を更新し、アカウント管理およびメール配信向け設定を取り込み
  * ローカル開発用のダミー環境変数を追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->