### PR TITLE
ci: テストスイートを reusable workflow 化し main.yml から一括起動

### DIFF
--- a/.github/workflows/dotnet_tests.yml
+++ b/.github/workflows/dotnet_tests.yml
@@ -1,8 +1,11 @@
 name: .NET Tests
 
+# Reusable workflow: main.yml から起動される。workflow_dispatch は Actions UI から
+# このスイートを単体で再実行できるように残している。push / pull_request トリガーは
+# main.yml に集約し、二重起動を避ける。
 on:
-  push:
-  pull_request:
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,34 @@
+name: CI
+
+# オーケストレーター。push / pull_request トリガーはここだけに置き、各テストスイートは
+# reusable workflow（on: workflow_call）として呼び出す。これにより 1 回の CI 実行で
+# 全スイートが駆動され、各スイートが個別に push / PR イベントで多重起動するのを防ぐ。
+# （各スイートは workflow_dispatch も残しているので、Actions UI から個別に再実行できる。）
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+# 最小権限: 全スイートで checkout / NuGet restore（GitHub Packages 読み取り）のみ。
+# reusable workflow 側の GITHUB_TOKEN 権限はここで定義した値が上限になる。
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  # 安価な fail-fast ゲート。ユニットテストと冪等マイグレーション検証を先に通し、
+  # 失敗すれば高コストな E2E スイート（IdP 起動を伴う playwright / selenium）を
+  # 起動せずに早期失敗させる。
+  dotnet-tests:
+    uses: ./.github/workflows/dotnet_tests.yml
+    secrets: inherit
+
+  # E2E スイート。dotnet-tests がグリーンになってから起動するが、互いには並列実行。
+  playwright:
+    needs: dotnet-tests
+    uses: ./.github/workflows/playwright.yml
+    secrets: inherit
+  selenium:
+    needs: dotnet-tests
+    uses: ./.github/workflows/selenium.yml
+    secrets: inherit

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,8 +1,11 @@
 name: Playwright E2E Tests - IdentityProvider
 
+# Reusable workflow: main.yml から起動される。workflow_dispatch は Actions UI から
+# このスイートを単体で再実行できるように残している。push / pull_request トリガーは
+# main.yml に集約し、二重起動を避ける。
 on:
-  push:
-  pull_request:
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/selenium.yml
+++ b/.github/workflows/selenium.yml
@@ -6,9 +6,12 @@ name: Selenium Smoke Tests - IdentityProvider
 # 下の Setup ChromeDriver step を参照）。テスト本体は C#（Selenium.WebDriver /
 # xUnit）の E2ETests.Selenium プロジェクトで管理する。
 
+# Reusable workflow: main.yml から起動される。workflow_dispatch は Actions UI から
+# このスイートを単体で再実行できるように残している。push / pull_request トリガーは
+# main.yml に集約し、二重起動を避ける。
 on:
-  push:
-  pull_request:
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   selenium:


### PR DESCRIPTION
## Summary

- CI 系のテストスイート (`dotnet_tests.yml` / `playwright.yml` / `selenium.yml`) を reusable workflow (`on: workflow_call`) 化し、新規の `main.yml` から一括起動する構成に変更する（EC-CUBE / [nanasess/setup-chromedriver#472](https://github.com/nanasess/setup-chromedriver/pull/472) と同じ方式）。
- `push` / `pull_request` トリガーを `main.yml` に集約し、各スイートが個別にイベント駆動で多重起動するのを防ぐ。
- 安価な `dotnet-tests`（ユニットテスト + 冪等マイグレーション検証）を fail-fast ゲートとし、高コストな E2E スイート（IdP 起動を伴う `playwright` / `selenium`）はそれを `needs` する。

## Changes

- **`main.yml`（新規）**: `push` / `pull_request` / `workflow_dispatch` を起点とするオーケストレーター。
  - `dotnet-tests` を fail-fast ゲートとして先に実行。
  - `playwright` / `selenium` は `needs: dotnet-tests`。両者は互いに並列実行。
  - `secrets: inherit` で各スイートへ secrets を引き渡し（`MOCK_IDP_BASE_URL` / `ORG_PAT` / `PACKAGES_READ_TOKEN` 等）。
  - 権限は `contents: read` / `packages: read`（NuGet restore 用）を上限として明示。
- **`dotnet_tests.yml` / `playwright.yml` / `selenium.yml`**: `on:` を `workflow_call` + `workflow_dispatch` に変更。`workflow_dispatch` は Actions UI からの単体再実行用に残す。
- 対象外: `claude.yml` / `claude-code-review.yml`（イベント駆動）、`staging.yml` / `production.yml`（デプロイ）は変更なし。

## Test plan

- [x] 全ワークフローが YAML として valid（`yaml.safe_load`）
- [x] CI 系 3 スイートが `workflow_call` を持ち、`push` / `pull_request` トリガーは `main.yml` のみ
- [ ] この PR の CI で `dotnet-tests` → E2E の `needs` チェーンと reusable workflow 呼び出しが意図どおり解決すること

### Notes

- ⚠️ ジョブ名が `CI / dotnet-tests / build` のようにネストする。ブランチ保護で required status check を設定している場合はチェック名の更新が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitHub Actions ワークフローの実行パターンを統一しました。.NETテスト、Playwright、Selenium の各テストスイートが一元管理されるメインワークフローから呼び出され、より効率的に実行されるよう改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->