### PR TITLE
feat(account): Phase C - TokenController/TokenService の Account 対応

### DIFF
--- a/IdentityProvider.Test/Controllers/B2BPasskeyControllerIntegrationTests.cs
+++ b/IdentityProvider.Test/Controllers/B2BPasskeyControllerIntegrationTests.cs
@@ -123,6 +123,9 @@ namespace IdentityProvider.Test.Controllers
                 ClientSecret = "test-client-secret",
                 AppName = "テストクライアント",
                 OrganizationId = 1,
+                // EC-CUBE 管理画面用の B2B パスキー Client。認可コードの SubjectType は
+                // B2BPasskeyController が client.SubjectType を参照して決定する。
+                SubjectType = SubjectType.B2B,
                 AllowedRpIds = new List<string> { "shop.example.com", "admin.example.com" },
                 CreatedAt = DateTimeOffset.UtcNow,
                 UpdatedAt = DateTimeOffset.UtcNow
@@ -650,10 +653,10 @@ namespace IdentityProvider.Test.Controllers
         }
 
         /// <summary>
-        /// 認可コードの Subject と SubjectType が IsB2B フラグによって正しく設定されることを確認
+        /// 認可コードの Subject と SubjectType が SubjectType 指定によって正しく設定されることを確認
         /// </summary>
         [Fact]
-        public async Task IntegrationTest_AuthorizationCode_SubjectTypeSetBasedOnIsB2BFlag()
+        public async Task IntegrationTest_AuthorizationCode_SubjectTypeSetBasedOnSubjectType()
         {
             // Arrange
             var testUser = await CreateTestB2BUserAsync("550e8400-e29b-41d4-a716-446655440009", "authcode-subjecttype@example.com");
@@ -667,7 +670,7 @@ namespace IdentityProvider.Test.Controllers
                 Scope = "openid profile",
                 State = "test-state",
                 ExpirationMinutes = 10,
-                IsB2B = true  // B2B認証フラグ
+                SubjectType = SubjectType.B2B
             };
 
             // Act

--- a/IdentityProvider.Test/Controllers/TokenControllerTests.cs
+++ b/IdentityProvider.Test/Controllers/TokenControllerTests.cs
@@ -19,6 +19,7 @@ namespace IdentityProvider.Test.Controllers
         private readonly Mock<ITokenService> _mockTokenService;
         private readonly Mock<IUserService> _mockUserService;
         private readonly Mock<IB2BUserService> _mockB2BUserService;
+        private readonly Mock<IAccountService> _mockAccountService;
         private readonly Mock<ILogger<TokenController>> _mockLogger;
         private readonly Mock<IConfiguration> _mockConfiguration;
         private readonly TokenController _controller;
@@ -30,6 +31,7 @@ namespace IdentityProvider.Test.Controllers
             _mockTokenService = new Mock<ITokenService>();
             _mockUserService = new Mock<IUserService>();
             _mockB2BUserService = new Mock<IB2BUserService>();
+            _mockAccountService = new Mock<IAccountService>();
             _mockLogger = new Mock<ILogger<TokenController>>();
             _mockConfiguration = new Mock<IConfiguration>();
 
@@ -39,6 +41,7 @@ namespace IdentityProvider.Test.Controllers
                 _mockTokenService.Object,
                 _mockUserService.Object,
                 _mockB2BUserService.Object,
+                _mockAccountService.Object,
                 _mockLogger.Object,
                 _mockConfiguration.Object);
         }
@@ -122,6 +125,149 @@ namespace IdentityProvider.Test.Controllers
             var updatedAuthCode = await _context.AuthorizationCodes.FirstAsync(ac => ac.Code == "test-code");
             Assert.True(updatedAuthCode.IsUsed);
             Assert.NotNull(updatedAuthCode.UsedAt);
+        }
+
+        [Fact]
+        public async Task Token_AccountAuthorizationCode_ReturnsTokensWithManagedOrgs()
+        {
+            // Arrange
+            var organization = new Organization
+            {
+                Id = 1,
+                Code = "accounts",
+                Name = "EcAuth Accounts",
+                TenantName = "test-tenant",
+                CreatedAt = DateTimeOffset.UtcNow,
+                UpdatedAt = DateTimeOffset.UtcNow
+            };
+            _context.Organizations.Add(organization);
+
+            var client = new Client
+            {
+                Id = 1,
+                ClientId = "ecauth-admin-console",
+                ClientSecret = "account-secret",
+                AppName = "EcAuth Admin Console",
+                OrganizationId = 1,
+                SubjectType = SubjectType.Account
+            };
+            _context.Clients.Add(client);
+
+            var authCode = new AuthorizationCode
+            {
+                Code = "account-code",
+                Subject = "account-subject",
+                SubjectType = SubjectType.Account,
+                ClientId = 1,
+                RedirectUri = "https://accounts.ec-auth.io/callback",
+                Scope = "openid b2b",
+                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(10),
+                IsUsed = false
+            };
+            _context.AuthorizationCodes.Add(authCode);
+            await _context.SaveChangesAsync();
+
+            var account = new Account
+            {
+                Id = 1,
+                Subject = "account-subject",
+                Email = "owner@example.com",
+                OrganizationId = 1
+            };
+            var managedOrgs = new List<IAccountService.ManagedOrganization>
+            {
+                new(123, "customer-shop", "owner")
+            };
+
+            _mockAccountService.Setup(x => x.GetBySubjectAsync("account-subject"))
+                .ReturnsAsync(account);
+            _mockAccountService.Setup(x => x.GetManagedOrganizationsAsync("account-subject"))
+                .ReturnsAsync(managedOrgs);
+
+            ITokenService.TokenRequest? capturedRequest = null;
+            _mockTokenService.Setup(x => x.GenerateTokensAsync(It.IsAny<ITokenService.TokenRequest>()))
+                .Callback<ITokenService.TokenRequest>(r => capturedRequest = r)
+                .ReturnsAsync(new ITokenService.TokenResponse
+                {
+                    AccessToken = "access-token",
+                    IdToken = "id-token",
+                    ExpiresIn = 3600,
+                    TokenType = "Bearer"
+                });
+
+            // Act
+            var result = await _controller.Token(
+                "authorization_code",
+                "account-code",
+                "https://accounts.ec-auth.io/callback",
+                "ecauth-admin-console",
+                "account-secret");
+
+            // Assert
+            Assert.IsType<OkObjectResult>(result);
+            Assert.NotNull(capturedRequest);
+            Assert.Equal(SubjectType.Account, capturedRequest!.SubjectType);
+            Assert.Same(account, capturedRequest.User);
+            Assert.NotNull(capturedRequest.ManagedOrgs);
+            Assert.Single(capturedRequest.ManagedOrgs!);
+
+            var updatedAuthCode = await _context.AuthorizationCodes.FirstAsync(ac => ac.Code == "account-code");
+            Assert.True(updatedAuthCode.IsUsed);
+        }
+
+        [Fact]
+        public async Task Token_AccountNotFound_ReturnsBadRequest()
+        {
+            // Arrange
+            var organization = new Organization
+            {
+                Id = 1,
+                Code = "accounts",
+                Name = "EcAuth Accounts",
+                TenantName = "test-tenant",
+                CreatedAt = DateTimeOffset.UtcNow,
+                UpdatedAt = DateTimeOffset.UtcNow
+            };
+            _context.Organizations.Add(organization);
+
+            var client = new Client
+            {
+                Id = 1,
+                ClientId = "ecauth-admin-console",
+                ClientSecret = "account-secret",
+                AppName = "EcAuth Admin Console",
+                OrganizationId = 1,
+                SubjectType = SubjectType.Account
+            };
+            _context.Clients.Add(client);
+
+            var authCode = new AuthorizationCode
+            {
+                Code = "account-code",
+                Subject = "missing-account-subject",
+                SubjectType = SubjectType.Account,
+                ClientId = 1,
+                RedirectUri = "https://accounts.ec-auth.io/callback",
+                Scope = "openid b2b",
+                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(10),
+                IsUsed = false
+            };
+            _context.AuthorizationCodes.Add(authCode);
+            await _context.SaveChangesAsync();
+
+            _mockAccountService.Setup(x => x.GetBySubjectAsync("missing-account-subject"))
+                .ReturnsAsync((Account?)null);
+
+            // Act
+            var result = await _controller.Token(
+                "authorization_code",
+                "account-code",
+                "https://accounts.ec-auth.io/callback",
+                "ecauth-admin-console",
+                "account-secret");
+
+            // Assert
+            Assert.IsType<BadRequestObjectResult>(result);
         }
 
         [Fact]

--- a/IdentityProvider.Test/Services/AccountServiceTests.cs
+++ b/IdentityProvider.Test/Services/AccountServiceTests.cs
@@ -1,0 +1,102 @@
+using IdentityProvider.Models;
+using IdentityProvider.Services;
+using IdentityProvider.Test.TestHelpers;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace IdentityProvider.Test.Services
+{
+    public class AccountServiceTests
+    {
+        private readonly ILogger<AccountService> _logger;
+
+        public AccountServiceTests()
+        {
+            var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
+            _logger = loggerFactory.CreateLogger<AccountService>();
+        }
+
+        [Fact]
+        public async Task GetBySubjectAsync_ExistingAccount_ReturnsAccount()
+        {
+            // Arrange - Account が所属するテナント（accounts）を解決した状態を再現
+            var tenantService = new MockTenantService();
+            tenantService.SetTenant("accounts");
+            using var context = TestDbContextHelper.CreateInMemoryContext(tenantService: tenantService);
+
+            var accountsOrg = new Organization { Id = 1, Code = "accounts", Name = "EcAuth Accounts", TenantName = "accounts" };
+            context.Organizations.Add(accountsOrg);
+            context.Accounts.Add(new Account
+            {
+                Id = 1,
+                Subject = "account-subject",
+                Email = "owner@example.com",
+                OrganizationId = 1
+            });
+            await context.SaveChangesAsync();
+
+            var service = new AccountService(context, _logger);
+
+            // Act
+            var account = await service.GetBySubjectAsync("account-subject");
+
+            // Assert
+            Assert.NotNull(account);
+            Assert.Equal("owner@example.com", account!.Email);
+        }
+
+        [Fact]
+        public async Task GetBySubjectAsync_UnknownSubject_ReturnsNull()
+        {
+            using var context = TestDbContextHelper.CreateInMemoryContext();
+            var service = new AccountService(context, _logger);
+
+            var account = await service.GetBySubjectAsync("nonexistent");
+
+            Assert.Null(account);
+        }
+
+        [Fact]
+        public async Task GetManagedOrganizationsAsync_ReturnsCrossTenantOrgsWithCodeAndRole()
+        {
+            // Arrange - 管理対象は別テナント（顧客 Org）。IgnoreQueryFilters で横断取得できることを確認
+            var tenantService = new MockTenantService();
+            tenantService.SetTenant("accounts");
+            using var context = TestDbContextHelper.CreateInMemoryContext(tenantService: tenantService);
+
+            var customerA = new Organization { Id = 10, Code = "customer-shop", Name = "Customer Shop", TenantName = "customer-shop" };
+            var customerB = new Organization { Id = 11, Code = "another-shop", Name = "Another Shop", TenantName = "another-shop" };
+            context.Organizations.AddRange(customerA, customerB);
+
+            context.AccountOrganizations.AddRange(
+                new AccountOrganization { AccountSubject = "account-subject", OrganizationId = 10, Role = "owner" },
+                new AccountOrganization { AccountSubject = "account-subject", OrganizationId = 11, Role = "admin" });
+            await context.SaveChangesAsync();
+
+            var service = new AccountService(context, _logger);
+
+            // Act
+            var managed = await service.GetManagedOrganizationsAsync("account-subject");
+
+            // Assert
+            Assert.Equal(2, managed.Count);
+            var owner = Assert.Single(managed, m => m.OrganizationId == 10);
+            Assert.Equal("customer-shop", owner.Code);
+            Assert.Equal("owner", owner.Role);
+            var admin = Assert.Single(managed, m => m.OrganizationId == 11);
+            Assert.Equal("another-shop", admin.Code);
+            Assert.Equal("admin", admin.Role);
+        }
+
+        [Fact]
+        public async Task GetManagedOrganizationsAsync_NoManagedOrgs_ReturnsEmpty()
+        {
+            using var context = TestDbContextHelper.CreateInMemoryContext();
+            var service = new AccountService(context, _logger);
+
+            var managed = await service.GetManagedOrganizationsAsync("account-subject");
+
+            Assert.Empty(managed);
+        }
+    }
+}

--- a/IdentityProvider.Test/Services/TokenServiceTests.cs
+++ b/IdentityProvider.Test/Services/TokenServiceTests.cs
@@ -799,5 +799,182 @@ namespace IdentityProvider.Test.Services
             Assert.False(savedToken.IsRevoked);
             Assert.True(savedToken.ExpiresAt > DateTime.UtcNow);
         }
+
+        // ===== Account（SubjectType.Account）対応のテスト =====
+
+        /// <summary>
+        /// Account の管理コンソール Client と Account ユーザー、管理対象 Org 2 件を用意する。
+        /// </summary>
+        private static async Task<(Client client, Account account, List<IAccountService.ManagedOrganization> managedOrgs)>
+            SetupAccountTestDataAsync(EcAuthDbContext context)
+        {
+            // MockTenantService の既定テナント（test-tenant）と一致させ、AccessToken の読み戻しが
+            // クエリフィルターに弾かれないようにする（claim 検証が本テストの主眼）。
+            var accountsOrg = new Organization { Id = 1, Code = "accounts", Name = "EcAuth Accounts", TenantName = "test-tenant" };
+            context.Organizations.Add(accountsOrg);
+
+            var client = new Client
+            {
+                Id = 1,
+                ClientId = "ecauth-admin-console",
+                ClientSecret = "account-secret",
+                AppName = "EcAuth Admin Console",
+                OrganizationId = 1,
+                SubjectType = SubjectType.Account
+            };
+            context.Clients.Add(client);
+
+            var account = new Account
+            {
+                Id = 1,
+                Subject = "550e8400-e29b-41d4-a716-446655440099",
+                Email = "owner@example.com",
+                OrganizationId = 1,
+                DisplayName = "Owner"
+            };
+            context.Accounts.Add(account);
+
+            TestDbContextHelper.GenerateAndAddRsaKeyPair(context, accountsOrg, 1);
+            await context.SaveChangesAsync();
+
+            var managedOrgs = new List<IAccountService.ManagedOrganization>
+            {
+                new(123, "customer-shop", "owner"),
+                new(124, "another-shop", "admin")
+            };
+
+            return (client, account, managedOrgs);
+        }
+
+        [Fact]
+        public async Task GenerateAccessTokenAsync_AccountSubjectType_ShouldContainAccountSubTypeAndManagedOrgs()
+        {
+            using var context = TestDbContextHelper.CreateInMemoryContext();
+            var service = new TokenService(context, _logger, _issuerResolver);
+
+            // Arrange
+            var (client, account, managedOrgs) = await SetupAccountTestDataAsync(context);
+
+            var request = new ITokenService.TokenRequest
+            {
+                User = account,
+                Client = client,
+                RequestedScopes = new[] { "openid" },
+                SubjectType = SubjectType.Account,
+                ManagedOrgs = managedOrgs
+            };
+
+            // Act
+            var accessToken = await service.GenerateAccessTokenAsync(request);
+
+            // Assert
+            var handler = new JwtSecurityTokenHandler();
+            var jwtToken = handler.ReadJwtToken(accessToken);
+
+            Assert.Equal(account.Subject, jwtToken.Claims.FirstOrDefault(c => c.Type == JwtRegisteredClaimNames.Sub)?.Value);
+            Assert.Equal("account", jwtToken.Claims.FirstOrDefault(c => c.Type == "sub_type")?.Value);
+
+            // managed_orgs は JSON 配列のため、要素ごとに Claim へ展開される
+            var managedClaims = jwtToken.Claims.Where(c => c.Type == "managed_orgs").ToList();
+            Assert.Equal(2, managedClaims.Count);
+            var joined = string.Join(",", managedClaims.Select(c => c.Value));
+            Assert.Contains("customer-shop", joined);
+            Assert.Contains("another-shop", joined);
+            Assert.Contains("owner", joined);
+            Assert.Contains("admin", joined);
+
+            // DB の AccessToken メタデータに SubjectType.Account が記録される
+            var jti = jwtToken.Claims.FirstOrDefault(c => c.Type == JwtRegisteredClaimNames.Jti)?.Value;
+            var saved = await context.AccessTokens.FirstOrDefaultAsync(at => at.Token == jti);
+            Assert.NotNull(saved);
+            Assert.Equal(SubjectType.Account, saved.SubjectType);
+        }
+
+        [Fact]
+        public async Task GenerateIdTokenAsync_AccountSubjectType_ShouldContainManagedOrgs()
+        {
+            using var context = TestDbContextHelper.CreateInMemoryContext();
+            var service = new TokenService(context, _logger, _issuerResolver);
+
+            // Arrange
+            var (client, account, managedOrgs) = await SetupAccountTestDataAsync(context);
+
+            var request = new ITokenService.TokenRequest
+            {
+                User = account,
+                Client = client,
+                RequestedScopes = new[] { "openid" },
+                SubjectType = SubjectType.Account,
+                ManagedOrgs = managedOrgs
+            };
+
+            // Act
+            var idToken = await service.GenerateIdTokenAsync(request);
+
+            // Assert
+            var handler = new JwtSecurityTokenHandler();
+            var jwtToken = handler.ReadJwtToken(idToken);
+
+            Assert.Equal(account.Subject, jwtToken.Claims.FirstOrDefault(c => c.Type == JwtRegisteredClaimNames.Sub)?.Value);
+            var managedClaims = jwtToken.Claims.Where(c => c.Type == "managed_orgs").ToList();
+            Assert.Equal(2, managedClaims.Count);
+        }
+
+        [Fact]
+        public async Task GenerateAccessTokenAsync_AccountSubjectType_WithoutManagedOrgs_ShouldOmitClaim()
+        {
+            using var context = TestDbContextHelper.CreateInMemoryContext();
+            var service = new TokenService(context, _logger, _issuerResolver);
+
+            // Arrange - ManagedOrgs を指定しない
+            var (client, account, _) = await SetupAccountTestDataAsync(context);
+
+            var request = new ITokenService.TokenRequest
+            {
+                User = account,
+                Client = client,
+                RequestedScopes = new[] { "openid" },
+                SubjectType = SubjectType.Account
+            };
+
+            // Act
+            var accessToken = await service.GenerateAccessTokenAsync(request);
+
+            // Assert
+            var handler = new JwtSecurityTokenHandler();
+            var jwtToken = handler.ReadJwtToken(accessToken);
+            Assert.Equal("account", jwtToken.Claims.FirstOrDefault(c => c.Type == "sub_type")?.Value);
+            Assert.DoesNotContain(jwtToken.Claims, c => c.Type == "managed_orgs");
+        }
+
+        [Fact]
+        public async Task ValidateAccessTokenWithTypeAsync_AccountToken_ShouldReturnAccountSubjectType()
+        {
+            using var context = TestDbContextHelper.CreateInMemoryContext();
+            var service = new TokenService(context, _logger, _issuerResolver);
+
+            // Arrange
+            var (client, account, managedOrgs) = await SetupAccountTestDataAsync(context);
+
+            var request = new ITokenService.TokenRequest
+            {
+                User = account,
+                Client = client,
+                RequestedScopes = new[] { "openid" },
+                SubjectType = SubjectType.Account,
+                ManagedOrgs = managedOrgs
+            };
+
+            var accessToken = await service.GenerateAccessTokenAsync(request);
+
+            // Act
+            var result = await service.ValidateAccessTokenWithTypeAsync(accessToken);
+
+            // Assert
+            Assert.True(result.IsValid);
+            Assert.Equal(account.Subject, result.Subject);
+            Assert.Equal(SubjectType.Account, result.SubjectType);
+            Assert.Equal(client.ClientId, result.ClientId);
+        }
     }
 }

--- a/IdentityProvider.Test/Services/TokenServiceTests.cs
+++ b/IdentityProvider.Test/Services/TokenServiceTests.cs
@@ -948,6 +948,34 @@ namespace IdentityProvider.Test.Services
         }
 
         [Fact]
+        public async Task GenerateAccessTokenAsync_AccountSubjectType_EmptyManagedOrgs_ShouldOmitClaim()
+        {
+            using var context = TestDbContextHelper.CreateInMemoryContext();
+            var service = new TokenService(context, _logger, _issuerResolver);
+
+            // Arrange - ManagedOrgs を空リストで指定（クレーム自体を省略する）
+            var (client, account, _) = await SetupAccountTestDataAsync(context);
+
+            var request = new ITokenService.TokenRequest
+            {
+                User = account,
+                Client = client,
+                RequestedScopes = new[] { "openid" },
+                SubjectType = SubjectType.Account,
+                ManagedOrgs = new List<IAccountService.ManagedOrganization>()
+            };
+
+            // Act
+            var accessToken = await service.GenerateAccessTokenAsync(request);
+
+            // Assert
+            var handler = new JwtSecurityTokenHandler();
+            var jwtToken = handler.ReadJwtToken(accessToken);
+            Assert.Equal("account", jwtToken.Claims.FirstOrDefault(c => c.Type == "sub_type")?.Value);
+            Assert.DoesNotContain(jwtToken.Claims, c => c.Type == "managed_orgs");
+        }
+
+        [Fact]
         public async Task ValidateAccessTokenWithTypeAsync_AccountToken_ShouldReturnAccountSubjectType()
         {
             using var context = TestDbContextHelper.CreateInMemoryContext();

--- a/IdentityProvider/Controllers/AuthorizationCallbackController.cs
+++ b/IdentityProvider/Controllers/AuthorizationCallbackController.cs
@@ -144,7 +144,7 @@ namespace IdentityProvider.Controllers
                     Scope = stateData.Scope,
                     State = state,
                     ExpirationMinutes = 10,
-                    IsB2B = false  // B2C認証（外部IdPフェデレーション）のため明示的にfalseを設定
+                    SubjectType = SubjectType.B2C  // B2C認証（外部IdPフェデレーション）
                 };
 
                 var authorizationCode = await _authorizationCodeService.GenerateAuthorizationCodeAsync(authCodeRequest);

--- a/IdentityProvider/Controllers/B2BPasskeyController.cs
+++ b/IdentityProvider/Controllers/B2BPasskeyController.cs
@@ -507,7 +507,9 @@ namespace IdentityProvider.Controllers
                     State = request.State,
                     Scope = "openid b2b",
                     ExpirationMinutes = 10,
-                    IsB2B = true  // B2B認証フラグ
+                    // Client の SubjectType を反映（B2B 管理画面 = B2B、Account 管理コンソール = Account）。
+                    // 認証機構（パスキー）は共通のため、認可コードの種別は Client 定義に従う。
+                    SubjectType = client.SubjectType
                 };
 
                 var authCode = await _authorizationCodeService.GenerateAuthorizationCodeAsync(authCodeRequest);

--- a/IdentityProvider/Controllers/TokenController.cs
+++ b/IdentityProvider/Controllers/TokenController.cs
@@ -20,6 +20,7 @@ namespace IdentityProvider.Controllers
         private readonly ITokenService _tokenService;
         private readonly IUserService _userService;
         private readonly IB2BUserService _b2bUserService;
+        private readonly IAccountService _accountService;
         private readonly ILogger<TokenController> _logger;
         private readonly IConfiguration _configuration;
 
@@ -29,6 +30,7 @@ namespace IdentityProvider.Controllers
             ITokenService tokenService,
             IUserService userService,
             IB2BUserService b2bUserService,
+            IAccountService accountService,
             ILogger<TokenController> logger,
             IConfiguration configuration)
         {
@@ -37,6 +39,7 @@ namespace IdentityProvider.Controllers
             _tokenService = tokenService;
             _userService = userService;
             _b2bUserService = b2bUserService;
+            _accountService = accountService;
             _logger = logger;
             _configuration = configuration;
         }
@@ -309,9 +312,41 @@ namespace IdentityProvider.Controllers
                     _logger.LogInformation("Token request created for user: {Subject}, client: {ClientId}, scopes: {Scopes}",
                         user.Subject, client.ClientId, string.Join(", ", scopes ?? new[] { "none" }));
                 }
+                else if (subjectType == SubjectType.Account)
+                {
+                    // Account認証の場合: Account を取得し、管理対象 Organization を managed_orgs に含める
+                    Account? account;
+                    using (TimingScope.Begin("user_lookup"))
+                    {
+                        account = await _accountService.GetBySubjectAsync(subject);
+                    }
+                    if (account == null)
+                    {
+                        _logger.LogError("Account not found for subject: {Subject}", subject);
+                        return BadRequest(new
+                        {
+                            error = "invalid_grant",
+                            error_description = "Accountが見つかりません。"
+                        });
+                    }
+
+                    var managedOrgs = await _accountService.GetManagedOrganizationsAsync(subject);
+
+                    tokenRequest = new ITokenService.TokenRequest
+                    {
+                        User = account,
+                        Client = client,
+                        RequestedScopes = scopes,
+                        SubjectType = SubjectType.Account,
+                        ManagedOrgs = managedOrgs
+                    };
+
+                    _logger.LogInformation("Token request created for account: {Subject}, client: {ClientId}, managedOrgs: {Count}, scopes: {Scopes}",
+                        account.Subject, client.ClientId, managedOrgs.Count, string.Join(", ", scopes ?? new[] { "none" }));
+                }
                 else
                 {
-                    // Account等のサポートされていないSubjectType
+                    // サポートされていないSubjectType
                     _logger.LogError("Unsupported SubjectType: {SubjectType}", subjectType);
                     return BadRequest(new
                     {

--- a/IdentityProvider/Data/Seeders/OrganizationClientSeeder.cs
+++ b/IdentityProvider/Data/Seeders/OrganizationClientSeeder.cs
@@ -145,7 +145,24 @@ public class OrganizationClientSeeder : IDbSeeder
 
         if (existing != null)
         {
-            logger.LogInformation("Client {ClientId} already exists, skipping", clientId);
+            // SubjectType 列の追加（Phase A）より前に作成された既存 Client は
+            // default の B2C のまま残っている。本 Seeder が管理する Client は
+            // EC-CUBE 管理画面用の B2B パスキー Client のため、B2C のまま残っていれば
+            // B2B へ補正する。既に B2B/Account のものは触らない（冪等）。
+            // フェデレーション（外部 IdP）フローは AuthorizationCallbackController が
+            // 認可コードを B2C 固定で発行するため、本補正の影響を受けない。
+            if (existing.SubjectType == SubjectType.B2C)
+            {
+                existing.SubjectType = SubjectType.B2B;
+                existing.UpdatedAt = DateTimeOffset.UtcNow;
+                await context.SaveChangesAsync();
+                logger.LogInformation(
+                    "Client {ClientId} の SubjectType を B2C から B2B へ補正しました", clientId);
+            }
+            else
+            {
+                logger.LogInformation("Client {ClientId} already exists, skipping", clientId);
+            }
             return (existing, false);
         }
 

--- a/IdentityProvider/Program.cs
+++ b/IdentityProvider/Program.cs
@@ -17,6 +17,7 @@ builder.Services.AddHttpContextAccessor();
 builder.Services.AddScoped<IIssuerResolver, IssuerResolver>();
 builder.Services.AddScoped<ITenantService, TenantService>();
 builder.Services.AddScoped<IUserService, UserService>();
+builder.Services.AddScoped<IAccountService, AccountService>();
 builder.Services.AddScoped<ITokenService, TokenService>();
 builder.Services.AddScoped<IAuthorizationCodeService, AuthorizationCodeService>();
 builder.Services.AddScoped<IExternalIdpTokenService, ExternalIdpTokenService>();

--- a/IdentityProvider/Services/AccountService.cs
+++ b/IdentityProvider/Services/AccountService.cs
@@ -1,0 +1,61 @@
+using IdentityProvider.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace IdentityProvider.Services
+{
+    /// <inheritdoc cref="IAccountService" />
+    public class AccountService : IAccountService
+    {
+        private readonly EcAuthDbContext _context;
+        private readonly ILogger<AccountService> _logger;
+
+        public AccountService(EcAuthDbContext context, ILogger<AccountService> logger)
+        {
+            _context = context;
+            _logger = logger;
+        }
+
+        /// <inheritdoc />
+        public async Task<Account?> GetBySubjectAsync(string subject)
+        {
+            if (string.IsNullOrWhiteSpace(subject))
+            {
+                return null;
+            }
+
+            var account = await _context.Accounts
+                .Include(a => a.Organization)
+                .FirstOrDefaultAsync(a => a.Subject == subject);
+
+            if (account == null)
+            {
+                _logger.LogDebug("Account が見つかりません: Subject={Subject}", subject);
+            }
+
+            return account;
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyList<IAccountService.ManagedOrganization>> GetManagedOrganizationsAsync(string subject)
+        {
+            if (string.IsNullOrWhiteSpace(subject))
+            {
+                return Array.Empty<IAccountService.ManagedOrganization>();
+            }
+
+            // account_organization はテナント横断（クエリフィルター対象外）。
+            // 管理対象 Organization も別テナントのため、Organization 側も IgnoreQueryFilters で引く。
+            var managed = await _context.AccountOrganizations
+                .IgnoreQueryFilters()
+                .Where(ao => ao.AccountSubject == subject)
+                .Join(
+                    _context.Organizations.IgnoreQueryFilters(),
+                    ao => ao.OrganizationId,
+                    o => o.Id,
+                    (ao, o) => new IAccountService.ManagedOrganization(o.Id, o.Code, ao.Role))
+                .ToListAsync();
+
+            return managed;
+        }
+    }
+}

--- a/IdentityProvider/Services/AuthorizationCodeService.cs
+++ b/IdentityProvider/Services/AuthorizationCodeService.cs
@@ -80,8 +80,8 @@ namespace IdentityProvider.Services
                 }
             } while (await CodeExistsAsync(code));
 
-            // SubjectType を決定（IsB2B フラグから推測）
-            var subjectType = request.IsB2B ? Models.SubjectType.B2B : Models.SubjectType.B2C;
+            // SubjectType はリクエストで指定された種別をそのまま記録する
+            var subjectType = request.SubjectType;
 
             // 認可コードエンティティ作成
             var authorizationCode = new AuthorizationCode

--- a/IdentityProvider/Services/IAccountService.cs
+++ b/IdentityProvider/Services/IAccountService.cs
@@ -1,0 +1,34 @@
+using IdentityProvider.Models;
+
+namespace IdentityProvider.Services
+{
+    /// <summary>
+    /// EcAuth サービス利用者（Account）の取得サービス。
+    /// Account は B2BUser と Subject を共有するため認証自体は B2BPasskeyController を流用し、
+    /// 本サービスは Account 固有情報（補助情報・管理対象 Organization）の取得に責務を絞る。
+    /// </summary>
+    public interface IAccountService
+    {
+        /// <summary>
+        /// Account が管理する Organization 1 件分の情報。
+        /// managed_orgs クレームの 1 要素に対応する。
+        /// </summary>
+        /// <param name="OrganizationId">管理対象 Organization の内部 ID</param>
+        /// <param name="Code">管理対象 Organization のコード（サブドメイン解決に使う安定値）</param>
+        /// <param name="Role">Account のその Organization に対するロール（owner / admin / member）</param>
+        public record ManagedOrganization(int OrganizationId, string Code, string Role);
+
+        /// <summary>
+        /// Subject で Account を取得する。
+        /// Account は所属テナント（accounts / stg-accounts）のクエリフィルター対象のため、
+        /// テナントが正しく解決されたリクエスト内で呼び出すことを前提とする。
+        /// </summary>
+        Task<Account?> GetBySubjectAsync(string subject);
+
+        /// <summary>
+        /// Account が管理する Organization 一覧を取得する。
+        /// 管理対象は顧客テナント（別テナント）のため、<c>IgnoreQueryFilters</c> で横断的に引き当てる。
+        /// </summary>
+        Task<IReadOnlyList<ManagedOrganization>> GetManagedOrganizationsAsync(string subject);
+    }
+}

--- a/IdentityProvider/Services/IAuthorizationCodeService.cs
+++ b/IdentityProvider/Services/IAuthorizationCodeService.cs
@@ -15,7 +15,12 @@ namespace IdentityProvider.Services
             public string? Scope { get; set; }            // スコープ（オプション）
             public string? State { get; set; }            // Stateパラメータ（オプション）
             public int ExpirationMinutes { get; set; } = 10; // 有効期限（デフォルト10分）
-            public bool IsB2B { get; set; } = false;      // B2B認証の場合true
+
+            /// <summary>
+            /// 認可コードに記録する Subject の種別（B2C=0, B2B=1, Account=2）。
+            /// 指定しない場合は B2C（外部 IdP フェデレーション）として扱う。
+            /// </summary>
+            public SubjectType SubjectType { get; set; } = SubjectType.B2C;
         }
 
         /// <summary>

--- a/IdentityProvider/Services/ITokenService.cs
+++ b/IdentityProvider/Services/ITokenService.cs
@@ -24,6 +24,13 @@ namespace IdentityProvider.Services
             /// 指定しない場合はB2C（デフォルト）として扱う
             /// </summary>
             public SubjectType SubjectType { get; set; } = SubjectType.B2C;
+
+            /// <summary>
+            /// Account（<see cref="SubjectType.Account"/>）が管理する Organization 一覧。
+            /// 指定された場合、ID/Access トークンに <c>managed_orgs</c> クレームとして付与する。
+            /// Account 以外の SubjectType では使用しない。
+            /// </summary>
+            public IReadOnlyList<IAccountService.ManagedOrganization>? ManagedOrgs { get; set; }
         }
 
         /// <summary>

--- a/IdentityProvider/Services/TokenService.cs
+++ b/IdentityProvider/Services/TokenService.cs
@@ -5,6 +5,7 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json;
 
 namespace IdentityProvider.Services
 {
@@ -43,10 +44,10 @@ namespace IdentityProvider.Services
             if (request.User == null)
                 throw new ArgumentException("User cannot be null.", nameof(request.User));
 
-            if (request.SubjectType != SubjectType.B2C && request.SubjectType != SubjectType.B2B)
+            if (!IsSupportedSubjectType(request.SubjectType))
                 throw new ArgumentException($"Unsupported SubjectType: {request.SubjectType}", nameof(request.SubjectType));
 
-            // ISubjectProvider から Subject を取得（B2C/B2B 共通）
+            // ISubjectProvider から Subject を取得（B2C/B2B/Account 共通）
             var subject = request.User.Subject;
             if (string.IsNullOrWhiteSpace(subject))
                 throw new ArgumentException("Subject cannot be null or empty.", nameof(request.User));
@@ -99,6 +100,13 @@ namespace IdentityProvider.Services
                     claims.Add(new Claim(JwtRegisteredClaimNames.Nonce, request.Nonce));
                 }
 
+                // Account の場合、管理対象 Organization 一覧を managed_orgs クレームとして付与
+                var idManagedOrgsClaim = BuildManagedOrgsClaim(request);
+                if (idManagedOrgsClaim != null)
+                {
+                    claims.Add(idManagedOrgsClaim);
+                }
+
                 // 追加のクレーム（スコープに基づいて）
                 if (request.RequestedScopes?.Contains("email") == true)
                 {
@@ -133,10 +141,10 @@ namespace IdentityProvider.Services
             if (request.User == null)
                 throw new ArgumentException("User cannot be null.", nameof(request.User));
 
-            if (request.SubjectType != SubjectType.B2C && request.SubjectType != SubjectType.B2B)
+            if (!IsSupportedSubjectType(request.SubjectType))
                 throw new ArgumentException($"Unsupported SubjectType: {request.SubjectType}", nameof(request.SubjectType));
 
-            // ISubjectProvider から Subject を取得（B2C/B2B 共通）
+            // ISubjectProvider から Subject を取得（B2C/B2B/Account 共通）
             var subject = request.User.Subject;
             if (string.IsNullOrWhiteSpace(subject))
                 throw new ArgumentException("Subject cannot be null or empty.", nameof(request.User));
@@ -173,7 +181,7 @@ namespace IdentityProvider.Services
                 if (request.Client.OrganizationId is null)
                     throw new InvalidOperationException($"OrganizationId is required for client {request.Client.Id}");
 
-                var subjectTypeString = request.SubjectType == SubjectType.B2B ? "b2b" : "b2c";
+                var subjectTypeString = ToSubTypeString(request.SubjectType);
 
                 var claims = new List<Claim>
                 {
@@ -190,6 +198,13 @@ namespace IdentityProvider.Services
                 if (!string.IsNullOrEmpty(scopes))
                 {
                     claims.Add(new Claim("scope", scopes));
+                }
+
+                // Account の場合、管理対象 Organization 一覧を managed_orgs クレームとして付与
+                var accessManagedOrgsClaim = BuildManagedOrgsClaim(request);
+                if (accessManagedOrgsClaim != null)
+                {
+                    claims.Add(accessManagedOrgsClaim);
                 }
 
                 var tokenDescriptor = new SecurityTokenDescriptor
@@ -300,6 +315,44 @@ namespace IdentityProvider.Services
         // issuer 値は IIssuerResolver に単一ソース化した。
         // 既存トークンとの後方互換のため出力（{Scheme}://{Host}）は不変。
         private string GetIssuer() => _issuerResolver.GetIssuer();
+
+        /// <summary>
+        /// トークン発行を許可する SubjectType か判定する（B2C / B2B / Account）。
+        /// </summary>
+        private static bool IsSupportedSubjectType(SubjectType subjectType)
+            => subjectType is SubjectType.B2C or SubjectType.B2B or SubjectType.Account;
+
+        /// <summary>
+        /// SubjectType を sub_type クレーム文字列に変換する。
+        /// </summary>
+        private static string ToSubTypeString(SubjectType subjectType) => subjectType switch
+        {
+            SubjectType.B2B => "b2b",
+            SubjectType.Account => "account",
+            _ => "b2c"
+        };
+
+        /// <summary>
+        /// Account の管理対象 Organization を managed_orgs クレーム（JSON 配列）として組み立てる。
+        /// Account 以外、または管理対象が指定されていない場合は null を返す。
+        /// </summary>
+        private static Claim? BuildManagedOrgsClaim(ITokenService.TokenRequest request)
+        {
+            if (request.SubjectType != SubjectType.Account || request.ManagedOrgs == null)
+            {
+                return null;
+            }
+
+            var payload = request.ManagedOrgs
+                .Select(m => new { org_id = m.OrganizationId, code = m.Code, role = m.Role })
+                .ToList();
+
+            var json = JsonSerializer.Serialize(payload);
+
+            // JsonClaimValueTypes.JsonArray を指定することで、JWT に文字列ではなく
+            // JSON 配列としてシリアライズされる。
+            return new Claim("managed_orgs", json, JsonClaimValueTypes.JsonArray);
+        }
 
         public async Task<string?> ValidateAccessTokenAsync(string token)
         {
@@ -435,13 +488,18 @@ namespace IdentityProvider.Services
                     return new ITokenService.AccessTokenValidationResult { IsValid = false };
                 }
 
-                if (subTypeClaim != "b2b" && subTypeClaim != "b2c")
+                if (subTypeClaim != "b2b" && subTypeClaim != "b2c" && subTypeClaim != "account")
                 {
                     _logger.LogWarning("Access token has invalid sub_type: {SubType}", subTypeClaim);
                     return new ITokenService.AccessTokenValidationResult { IsValid = false };
                 }
 
-                SubjectType subjectType = subTypeClaim == "b2b" ? SubjectType.B2B : SubjectType.B2C;
+                SubjectType subjectType = subTypeClaim switch
+                {
+                    "b2b" => SubjectType.B2B,
+                    "account" => SubjectType.Account,
+                    _ => SubjectType.B2C
+                };
 
                 _logger.LogDebug("Access token validated successfully for subject {Subject} (type: {SubjectType})",
                     subject, subjectType);

--- a/IdentityProvider/Services/TokenService.cs
+++ b/IdentityProvider/Services/TokenService.cs
@@ -338,14 +338,14 @@ namespace IdentityProvider.Services
         /// </summary>
         private static Claim? BuildManagedOrgsClaim(ITokenService.TokenRequest request)
         {
-            if (request.SubjectType != SubjectType.Account || request.ManagedOrgs == null)
+            // 管理対象が無い場合は空配列を載せず、クレーム自体を省略してトークンサイズを抑える
+            if (request.SubjectType != SubjectType.Account || request.ManagedOrgs == null || request.ManagedOrgs.Count == 0)
             {
                 return null;
             }
 
             var payload = request.ManagedOrgs
-                .Select(m => new { org_id = m.OrganizationId, code = m.Code, role = m.Role })
-                .ToList();
+                .Select(m => new { org_id = m.OrganizationId, code = m.Code, role = m.Role });
 
             var json = JsonSerializer.Serialize(payload);
 


### PR DESCRIPTION
## 概要

[EcAuthDocs Issue #79](https://github.com/EcAuth/EcAuthDocs/issues/79) の **Phase C**。既存の B2BPasskeyController を流用したまま、認可コード → トークン交換ルートで `SubjectType.Account` を有効化し、EcAuth サービス利用者（Account）が管理コンソールにログインできるようにする。

設計書: [Account 管理アーキテクチャ](https://github.com/EcAuth/EcAuthDocs/blob/main/html/account-management-architecture.html)

## 変更内容

### Account トークン発行ルートの有効化
- **`IAccountService` / `AccountService` 新設**: Subject による Account 取得と、管理対象 Organization 一覧（`org_id` + `code` + `role`）を `IgnoreQueryFilters` でテナント横断に引き当てる。
- **`TokenController`**: `SubjectType.Account` 分岐を追加。Account を取得し `managed_orgs` を詰めて `TokenRequest` を構築（従来は `else` で `invalid_grant`）。
- **`TokenService` / `ITokenService`**:
  - ID/Access トークン生成の検証を Account 許可に緩和。
  - AccessToken の `sub_type` に `"account"` を追加。
  - ID/Access 両トークンに `managed_orgs` クレーム（JSON 配列）を付与。
  - `ValidateAccessTokenWithTypeAsync` の `sub_type` 判定を `account` 対応。

`managed_orgs` クレーム形式（管理画面 SPA が subdomain/code でテナント解決できるよう code を含める）:
```json
"managed_orgs": [
  {"org_id": 123, "code": "customer-shop", "role": "owner"},
  {"org_id": 124, "code": "another-shop", "role": "admin"}
]
```

### 認可コードの種別受け渡し
- `AuthorizationCodeRequest.IsB2B`（bool）を **`SubjectType`（enum）に置換**。
- `B2BPasskeyController` は認証成功時に `client.SubjectType` を反映（B2B 管理画面 → B2B、Account 管理コンソール → Account）。従来は `IsB2B = true` ハードコードだった。
- `AuthorizationCallbackController`（外部 IdP フェデレーション）は `SubjectType.B2C` を明示。

### 既存 Client の SubjectType 補正（Phase B 繰り越し / CodeRabbit 指摘）
- `OrganizationClientSeeder` で、SubjectType 列追加前に作成され `B2C` のまま残った EC-CUBE 管理画面 Client を `B2B` へ補正（冪等）。
- 補正対象はこの Seeder が管理する Client のみに自然に限定。フェデレーションフローは認可コードを B2C 固定で発行するため、本補正の影響を受けない。

## テスト

- `dotnet build`: 0 エラー（.NET 10）
- `dotnet test`: **586 件すべて合格**
- `dotnet ef migrations has-pending-model-changes`: **差分ゼロ**（Phase C はスキーマ変更なし）

追加テスト:
- `TokenServiceTests`: Account の `sub_type="account"` / `managed_orgs` クレーム検証（ID/Access）、managed_orgs 未指定時の省略、`ValidateAccessTokenWithTypeAsync` の Account 受理。
- `AccountServiceTests`: Account 取得、管理対象 Org のテナント横断取得（code + role）。
- `TokenControllerTests`: Account 認可コード → トークン交換の正常系、Account 不在時 `invalid_grant`。
- `B2BPasskeyControllerIntegrationTests` / `AuthorizationCodeService`: `IsB2B` → `SubjectType` 置換の回帰。

## レビュー観点
- `managed_orgs` のクレーム形式（`org_id` + `code` + `role`）でよいか。
- 既存 Client の B2C→B2B 補正がフェデレーション E2E に影響しないという判断（認可コードは callback 側で B2C 固定）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)