### PR TITLE
fix: Claude Code Review がコメントを投稿しない不具合を修正

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -61,10 +61,10 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: |
-            /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+            /code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
 
             Use the repository's CLAUDE.md for guidance on style and conventions.
             日本語で回答してください。
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'


### PR DESCRIPTION
## 概要

Claude Code Review がレビューを実行しているのに PR にコメントを 1 件も投稿しない不具合を修正します。

## 真因（一次情報で確認）

当初 issue で想定していた「MCP 投稿サーバーが起動していない」だけが原因ではなく、調査の結果**2 点**が判明しました。

### 1. プロンプトに `--comment` フラグが無かった（主因）

`code-review` プラグイン（`code-review@claude-code-plugins`）のコマンド定義 [`commands/code-review.md`](https://github.com/anthropics/claude-code/blob/main/plugins/code-review/commands/code-review.md) の **step 7** に以下が明記されています:

> If `--comment` argument was NOT provided, stop here. Do not post any GitHub comments.

そのためレビューは `is_error: false` / `num_turns` が回るものの、**投稿フェーズに進まず**コメントが付かないまま終了していました（`No buffered inline comments`）。

### 2. インライン投稿ツールが allowed-tools に無かった

`--allowed-tools` を明示すると、`claude-code-action` は allowed-tools に `mcp__github_inline_comment__*` が含まれる時だけ `github_inline_comment` MCP サーバーを起動します（`src/mcp/install-mcp-server.ts`）。従来は未指定でインライン指摘の投稿経路が開通していませんでした。

## 変更内容

- `prompt` に `--comment` を付与し、投稿フェーズ（step 8-9）を有効化
- `claude_args` の allowed-tools に `mcp__github_inline_comment__create_inline_comment` を追加

これで allowed-tools は code-review プラグインの `allowed-tools` フロントマターと一致します。投稿経路は **サマリー = `gh pr comment`（既存の Bash 許可）**、**インライン = `create_inline_comment`** です。`mcp__github_comment__update_claude_comment` はプラグインが使わないため追加していません。

## 検証

この PR への push（`synchronize`）で `claude[bot]` のレビューコメントが実際に投稿されること、Actions ログで `permission_denials_count` と `No buffered inline comments` が解消することを確認します。

Refs: EcAuth/EcAuthDocs#86

🤖 Generated with [Claude Code](https://claude.com/claude-code)