### PR TITLE
test: Claude Code Review インラインコメント投稿経路の検証（マージ禁止）

### DIFF
--- a/IdentityProvider/InlineReviewCheck.cs
+++ b/IdentityProvider/InlineReviewCheck.cs
@@ -1,0 +1,19 @@
+namespace IdentityProvider;
+
+// [検証用 / マージ禁止] Claude Code Review のインラインコメント投稿経路
+// (mcp__github_inline_comment__create_inline_comment) を実地確認するための
+// ダミーコード。意図的にバグを含めている。検証後にこのファイルごと削除する。
+public static class InlineReviewCheck
+{
+    // バグ1: denominator が 0 のとき DivideByZeroException を送出する。
+    public static int Divide(int numerator, int denominator)
+    {
+        return numerator / denominator;
+    }
+
+    // バグ2: value が null のとき NullReferenceException を送出する。
+    public static int GetLength(string? value)
+    {
+        return value.Length;
+    }
+}


### PR DESCRIPTION
## 目的（検証用・マージ禁止）

EcAuthDocs#86 の修正後、`mcp__github_inline_comment__create_inline_comment` 経由のインラインコメントが実際に PR へ投稿されるかを実地検証するための使い捨て PR です。**マージしません。** 確認後にクローズ・ブランチ削除します。

意図的なバグ（ゼロ除算 / null 逆参照）を含む `InlineReviewCheck.cs` を追加しています。Claude Code Review がこれをインライン指摘として投稿することを確認します。

Refs: EcAuth/EcAuthDocs#86