### PR TITLE
fix: claude.yml の @claude 起動条件を組織リポジトリ対応に修正

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,13 +12,15 @@ on:
 
 jobs:
   claude:
+    # 起動条件: 組織メンバー/コラボレーター/オーナーが @claude メンションした場合のみ。
+    # （旧条件 `github.repository_owner == github.actor` は組織リポジトリでは
+    #   owner=組織名 / actor=ユーザー名 となり常に false になるため author_association で判定する）
     if: |
-      github.repository_owner == github.actor &&
       (
-          (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-          (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-          (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-          (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+          (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+          (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+          (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
+          (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
        )
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## 概要

`claude.yml`（`@claude` メンション応答 = tag モード）が EcAuth org のリポジトリで**一度も起動していない**不具合を修正します。

## 原因（実証済み）

起動条件 `github.repository_owner == github.actor` は、組織リポジトリでは
- `github.repository_owner` = `EcAuth`（組織名）
- `github.actor` = `nanasess`（コメント者）

となり**常に false** です。実際、`claude.yml` の実行履歴は `issue_comment` / `pull_request_review_comment` 含め**全て `skipped`** で、`@claude` を付けたテストコメント（PR #407）でも `skipped` を確認しました。このため、インラインレビューコメントへの返信を含む `@claude` 対話が一切機能していませんでした。

## 変更内容

起動条件を各イベントの `author_association` ベースに変更し、**OWNER / MEMBER / COLLABORATOR が `@claude` メンションした場合のみ**起動するようにしました（組織メンバー・コラボレーターが利用可能・第三者は不可）。

- `issue_comment` / `pull_request_review_comment` → `github.event.comment.author_association`
- `pull_request_review` → `github.event.review.author_association`
- `issues` → `github.event.issue.author_association`

## 検証方法（マージ後）

`issue_comment` 等のイベントは**デフォルトブランチのワークフロー定義を使う**仕様のため、本修正は**マージ後に有効化**されます。マージ後に PR/issue へ `@claude` メンションコメントを投稿し、`claude.yml` が `skipped` ではなく起動することを確認します。

Refs: EcAuth/EcAuthDocs#86

🤖 Generated with [Claude Code](https://claude.com/claude-code)