### PR TITLE
test: B2BパスキーE2EをPlaywright 1.61.0のcredentials APIに置換

### DIFF
--- a/E2ETests/package.json
+++ b/E2ETests/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "devDependencies": {
-    "@playwright/test": "^1.60.0",
+    "@playwright/test": "^1.61.0",
     "@types/node": "^25.9.2"
   },
   "scripts": {},

--- a/E2ETests/pnpm-lock.yaml
+++ b/E2ETests/pnpm-lock.yaml
@@ -9,16 +9,16 @@ importers:
   .:
     devDependencies:
       '@playwright/test':
-        specifier: ^1.60.0
-        version: 1.60.0
+        specifier: ^1.61.0
+        version: 1.61.0
       '@types/node':
         specifier: ^25.9.2
         version: 25.9.2
 
 packages:
 
-  '@playwright/test@1.60.0':
-    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+  '@playwright/test@1.61.0':
+    resolution: {integrity: sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -30,13 +30,13 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  playwright-core@1.60.0:
-    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+  playwright-core@1.61.0:
+    resolution: {integrity: sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.60.0:
-    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+  playwright@1.61.0:
+    resolution: {integrity: sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -45,9 +45,9 @@ packages:
 
 snapshots:
 
-  '@playwright/test@1.60.0':
+  '@playwright/test@1.61.0':
     dependencies:
-      playwright: 1.60.0
+      playwright: 1.61.0
 
   '@types/node@25.9.2':
     dependencies:
@@ -56,11 +56,11 @@ snapshots:
   fsevents@2.3.2:
     optional: true
 
-  playwright-core@1.60.0: {}
+  playwright-core@1.61.0: {}
 
-  playwright@1.60.0:
+  playwright@1.61.0:
     dependencies:
-      playwright-core: 1.60.0
+      playwright-core: 1.61.0
     optionalDependencies:
       fsevents: 2.3.2
 

--- a/E2ETests/tests/specs/b2b_passkey_authentication.spec.ts
+++ b/E2ETests/tests/specs/b2b_passkey_authentication.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, BrowserContext, Page, CDPSession, APIRequestContext, request } from '@playwright/test';
+import { test, expect, BrowserContext, Page, APIRequestContext, request } from '@playwright/test';
 import { randomUUID } from 'crypto';
 
 test.describe.serial('B2Bパスキー認証フローのE2Eテスト', () => {
@@ -20,42 +20,31 @@ test.describe.serial('B2Bパスキー認証フローのE2Eテスト', () => {
 
   let context: BrowserContext;
   let page: Page;
-  let cdpSession: CDPSession;
 
   // テスト間で共有するデータ
   let authorizationCode: string;
   let accessToken: string;
   let credentialId: string;
 
-  let authenticatorId: string;
   let apiContext: APIRequestContext;
 
   test.beforeAll(async ({ browser }) => {
     context = await browser.newContext({
       ignoreHTTPSErrors: true,
     });
+
+    // Playwright 1.61.0 の仮想 WebAuthn オーセンティケータをインストール。
+    // navigator.credentials.create()/get() を横取りし、ページ側で実行する本物の
+    // 登録/認証セレモニーをこの仮想オーセンティケータで処理する（旧 CDP の
+    // WebAuthn.addVirtualAuthenticator 相当）。シードされるクレデンシャルは
+    // discoverable(resident) のため、サーバー側の ResidentKey=Preferred を満たす。
+    await context.credentials.install();
+
     page = await context.newPage();
 
-    // ページを先に開いてから CDP セッションを作成
+    // ページを開く（install() 済みのため navigator.credentials は横取り済み）
     await page.goto(`${baseUrl}/b2b-passkey-test.html`);
     await page.waitForLoadState('domcontentloaded');
-
-    // CDP Virtual Authenticator セットアップ
-    cdpSession = await page.context().newCDPSession(page);
-    await cdpSession.send('WebAuthn.enable');
-    const result = await cdpSession.send('WebAuthn.addVirtualAuthenticator', {
-      options: {
-        protocol: 'ctap2',
-        hasUserVerification: true,
-        automaticPresenceSimulation: true,
-        isUserVerified: true,
-        hasResidentKey: true,
-        transport: 'internal',
-      },
-    });
-    authenticatorId = result.authenticatorId;
-
-    console.log('Virtual Authenticator configured, id:', authenticatorId);
 
     apiContext = await request.newContext({
       ignoreHTTPSErrors: true,
@@ -64,12 +53,6 @@ test.describe.serial('B2Bパスキー認証フローのE2Eテスト', () => {
 
   test.afterAll(async () => {
     await apiContext?.dispose();
-    if (authenticatorId) {
-      await cdpSession?.send('WebAuthn.removeVirtualAuthenticator', {
-        authenticatorId,
-      });
-    }
-    await cdpSession?.detach();
     await context?.close();
   });
 


### PR DESCRIPTION
## 概要

[Playwright 1.61.0](https://github.com/microsoft/playwright/releases/tag/v1.61.0) で追加された WebAuthn passkeys サポート（`context.credentials` API）を使って、B2BパスキーE2Eテストの仮想オーセンティケータ構築を CDP から置き換えます。

## 背景

現状の `b2b_passkey_authentication.spec.ts` は CDP（`WebAuthn.enable` + `WebAuthn.addVirtualAuthenticator`）を直接叩いて仮想オーセンティケータを構築しており、Chromium 限定かつ低レベルなセットアップ/クリーンアップコードを抱えていました。1.61.0 で `BrowserContext.credentials.install()` が追加され、これを 1 行に集約できます。

## 変更内容

- `@playwright/test` を `^1.60.0` → `^1.61.0` に更新（`pnpm-lock.yaml` も追従）
- `beforeAll`/`afterAll` の CDP セッション生成・仮想オーセンティケータ追加/削除・`detach` を削除し、`await context.credentials.install();` に置換
- ページ側で実行する**本物の登録/認証セレモニー**（`navigator.credentials.create()/get()`）は `install()` が横取りするため従来どおり動作
- `timeout=0` を上書きするページ側ラッパーは API 非依存のため維持

## 妥当性の根拠

- インストール済み 1.61.0 の型定義に `BrowserContext.credentials: Credentials` が存在し、置換後の spec は `tsc --noEmit`（exit 0）を通過
- サーバー側 `B2BPasskeyService` の `AuthenticatorSelection` は `ResidentKey = Preferred` / `UserVerification = Preferred`。新 API が生成する discoverable(resident) クレデンシャルで要件を満たす想定

## 確認事項（CI）

- `install()` は UV 等の細かいオプション引数を持たない。サーバーが `Preferred` 設定のため通る見込みだが、**UV フラグが最終的に検証を通るかは CI の実走で確認**する（このPRの主目的）。
- CI は `pnpm install --frozen-lockfile` + chromium のみインストール。本変更は chromium プロジェクトで動作する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * テストフレームワークのマイナーバージョンを更新しました。

* **Tests**
  * B2Bパスキー認証テストの仮想認証器実装を最新化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->