### PR TITLE
fix(account): 申込 API の CORS フォールバックをフロント配信元(ec-auth.io)に修正

### DIFF
--- a/IdentityProvider.Test/Services/SignupServiceTests.cs
+++ b/IdentityProvider.Test/Services/SignupServiceTests.cs
@@ -79,7 +79,8 @@ namespace IdentityProvider.Test.Services
             var values = new Dictionary<string, string?>();
             if (withConfirmBaseUrl)
             {
-                values[$"Signup:ConfirmBaseUrl:{Tenant}"] = "https://accounts.ec-auth.io";
+                // ConfirmBaseUrl はフロントエンド（確認ページ）の配信元。accounts テナントは本番フロント ec-auth.io。
+                values[$"Signup:ConfirmBaseUrl:{Tenant}"] = "https://ec-auth.io";
             }
             return new ConfigurationBuilder().AddInMemoryCollection(values).Build();
         }
@@ -203,7 +204,8 @@ namespace IdentityProvider.Test.Services
             var config = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string?>
                 {
-                    ["Signup:ConfirmBaseUrl:stg_accounts"] = "https://stg-accounts.ec-auth.io"
+                    // stg_accounts のフロントは専用プレビュー Pages（値はテスト上任意。ここではキー正規化を検証）。
+                    ["Signup:ConfirmBaseUrl:stg_accounts"] = "https://stg-preview.ec-auth.io"
                 })
                 .Build();
 
@@ -223,7 +225,7 @@ namespace IdentityProvider.Test.Services
             await service.RequestAsync(ValidInput());
 
             Assert.NotNull(capturedUrl);
-            Assert.StartsWith("https://stg-accounts.ec-auth.io/signup/confirm?token=", capturedUrl);
+            Assert.StartsWith("https://stg-preview.ec-auth.io/signup/confirm?token=", capturedUrl);
         }
 
         // ---- RequestAsync バリデーションエラー ----

--- a/IdentityProvider/Program.cs
+++ b/IdentityProvider/Program.cs
@@ -83,8 +83,12 @@ builder.Services.AddCors(options =>
 {
     options.AddPolicy(PlatformApiConstants.CorsPolicy, policy =>
     {
-        var allowedOrigins = builder.Configuration.GetSection("PlatformApi:AllowedOrigins").Get<string[]>()
-            ?? throw new InvalidOperationException("PlatformApi:AllowedOrigins が appsettings に定義されていません。");
+        var allowedOrigins = NormalizeOrigins(
+            builder.Configuration.GetSection("PlatformApi:AllowedOrigins").Get<string[]>());
+        if (allowedOrigins.Length == 0)
+        {
+            throw new InvalidOperationException("PlatformApi:AllowedOrigins が appsettings に定義されていません。");
+        }
         policy.WithOrigins(allowedOrigins)
               .SetIsOriginAllowedToAllowWildcardSubdomains()
               .AllowAnyHeader()
@@ -100,9 +104,12 @@ builder.Services.AddCors(options =>
     //    フロントの配信元ではない点に注意（フォールバックには含めない）。
     options.AddPolicy(IdentityProvider.Controllers.SignupController.CorsPolicy, policy =>
     {
-        var allowedOrigins =
-            builder.Configuration.GetSection("Signup:AllowedOrigins").Get<string[]>()
-            ?? new[] { "https://ec-auth.io", "https://www.ec-auth.io" };
+        var allowedOrigins = NormalizeOrigins(
+            builder.Configuration.GetSection("Signup:AllowedOrigins").Get<string[]>());
+        if (allowedOrigins.Length == 0)
+        {
+            allowedOrigins = new[] { "https://ec-auth.io", "https://www.ec-auth.io" };
+        }
         policy.WithOrigins(allowedOrigins)
               .AllowAnyHeader()
               .WithMethods("GET", "POST", "OPTIONS");
@@ -231,3 +238,15 @@ app.MapGet("/healthz", async (EcAuthDbContext dbContext) =>
 });
 
 app.Run();
+
+// CORS の WithOrigins は origin を完全一致（scheme + host + port）で比較するため、
+// 末尾スラッシュ付き・前後空白・空値が混入するとマッチしない。設定ミス時の原因切り分けが
+// 難しくなるのを避けるため、両 CORS ポリシーのフォールバック値を共通でサニタイズする。
+// （正規化後に空かどうかの扱いは呼び出し側で判断する: PlatformApi は例外、Signup は既定値）
+static string[] NormalizeOrigins(string[]? origins) =>
+    (origins ?? Array.Empty<string>())
+        .Select(o => o?.Trim().TrimEnd('/'))
+        .Where(o => !string.IsNullOrWhiteSpace(o))
+        .Select(o => o!)
+        .Distinct()
+        .ToArray();

--- a/IdentityProvider/Program.cs
+++ b/IdentityProvider/Program.cs
@@ -92,13 +92,17 @@ builder.Services.AddCors(options =>
     });
 
     // Account 申込 API（/api/signup）の CORS 設定。
-    // 申込フォーム／確認ページを配信する accounts / stg-accounts サイトのみを許可する
-    // （いずれも本番 App Service 上のテナント。Signup:ConfirmBaseUrl:* と同じホスト）。
+    // 申込フォーム／確認ページはフロントエンド（Cloudflare Pages）から配信され、API は別ホスト
+    // （accounts.ec-auth.io / stg-accounts.ec-auth.io）に露出するためクロスオリジンになる。
+    // 本番フロントは ec-auth.io / www.ec-auth.io。staging プレビュー Pages など追加のオリジンは
+    // Signup:AllowedOrigins（本番 Terraform app_settings で注入）で上書きする。
+    // ※ accounts / stg-accounts は B2B パスキー org 用テナント（= API のホスト）であって
+    //    フロントの配信元ではない点に注意（フォールバックには含めない）。
     options.AddPolicy(IdentityProvider.Controllers.SignupController.CorsPolicy, policy =>
     {
         var allowedOrigins =
             builder.Configuration.GetSection("Signup:AllowedOrigins").Get<string[]>()
-            ?? new[] { "https://accounts.ec-auth.io", "https://stg-accounts.ec-auth.io" };
+            ?? new[] { "https://ec-auth.io", "https://www.ec-auth.io" };
         policy.WithOrigins(allowedOrigins)
               .AllowAnyHeader()
               .WithMethods("GET", "POST", "OPTIONS");


### PR DESCRIPTION
## 概要

#410 で申込 API（`/api/signup/*`）の CORS フォールバックを `accounts.ec-auth.io` / `stg-accounts.ec-auth.io` に変更したが、これは設計と矛盾していたため修正する。

## 背景（設計の再確認）

[account-management-architecture.html](https://github.com/EcAuth/EcAuthDocs/blob/main/html/account-management-architecture.html) / EcAuthDocs #39 より:

- **申込フォーム・確認ページ（フロントエンド）** は Cloudflare Pages（本番 `ec-auth.io`）から配信される
- **申込 API** は別ホスト（`accounts.ec-auth.io` / `stg-accounts.ec-auth.io`）に露出 → フロントからはクロスオリジン
- `accounts.ec-auth.io` / `stg-accounts.ec-auth.io` は **B2B パスキー org 用テナント（= API のホスト）** であって、フロントの配信元ではない

→ `/api/signup/*` の CORS で許可すべきは **フロントの配信元 `ec-auth.io` / `www.ec-auth.io`**。#410 の `accounts`/`stg-accounts` 許可は誤りで、本番フォームからのリクエストが CORS でブロックされる状態だった。

## 変更内容

- `Program.cs`: 申込 API の CORS フォールバックを `https://ec-auth.io` / `https://www.ec-auth.io` に修正（元の設計値に復帰）
- staging プレビュー Pages 等の追加オリジンは `Signup:AllowedOrigins`（本番 Terraform `app_settings`）で上書きする方針は維持
- `SignupServiceTests` の `ConfirmBaseUrl` テスト値をフロント配信元基準に整合（キー正規化の検証目的は不変）

## 関連

- 確認ページの配信先を Cloudflare Pages に確定（方針 A）
- 本番 `app_settings` 側（`Signup__AllowedOrigins` / `Signup__ConfirmBaseUrl__*`）は ecauth-infrastructure の別 PR で対応
- 設計書の確認ページ origin 記述（L652/L632）は EcAuthDocs の別 PR で訂正

## 検証

- `dotnet build EcAuth.sln` 0 エラー
- `dotnet test` 624 件すべて合格


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores

* クロスオリジン（CORS）で許可オリジンの正規化を導入し、プラットフォーム/API と新規登録のデフォルト設定を調整しました  
* メール確認ページのベースURL（accounts/ステージ環境）を更新しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->