### PR TITLE
feat(account): マジックリンクログイン (Phase D-2) を実装

### DIFF
--- a/.env.dev.tpl
+++ b/.env.dev.tpl
@@ -123,6 +123,15 @@ SENDGRID_API_KEY=dummy_sendgrid_api_key
 Signup__ConfirmBaseUrl__accounts=https://localhost:8081
 Signup__ConfirmBaseUrl__stg_accounts=https://localhost:8081
 
+# マジックリンク URL の基底 (Phase D-2)。MagicLinkService.BuildMagicLinkUrl() がテナント別に
+# MagicLink:BaseUrl:{tenant_name} を「フォールバックなし」で必須参照する (未設定だと例外)。
+# ConfirmBaseUrl と同じくフロント配信元 (Cloudflare Pages) のベース URL を指す。メール内リンクは
+# {base}/signin/magic-link?token=... 形式で、フロントが POST /api/account/magic-link/verify を発行する。
+# env-var 名にハイフンは使えないため stg-accounts は stg_accounts に正規化する。
+# ローカルには専用フロントが無いため IdP 自身の origin を指す。
+MagicLink__BaseUrl__accounts=https://localhost:8081
+MagicLink__BaseUrl__stg_accounts=https://localhost:8081
+
 # =============================================================================
 # EC-CUBE 2系プラグイン Settings (ローカル開発用ダミー値)
 # =============================================================================

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,8 @@ cd E2ETests && pnpm install && pnpm exec playwright test
 | `/api/signup/request` | `validate` / `persist` / `send_email` |
 | `/api/signup/confirm` | `token_lookup` / `confirm` |
 | `/api/signup/status` | `status_lookup` |
+| `/api/account/magic-link/request` | `rate_limit` / `account_lookup` / `persist` / `send_email` |
+| `/api/account/magic-link/verify` | `token_consume` |
 
 #### Application Insights クエリ例
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,16 @@ cd E2ETests && pnpm install && pnpm exec playwright test
 - DbInitializer / シーダーが参照する環境変数は **Azure ランタイム（Terraform `app_settings`）** に設定が必要。CI ワークフローに定義があっても、Terraform に漏れているとアプリ起動時にシーダーがスキップされる
 - B2BPasskeySeeder は DEV 環境では `DEFAULT_*` を、Staging/Production では `STAGING_*` / `PROD_*` プレフィックスの変数を参照する分岐がある。シーダーのコード（`B2BPasskeySeeder.cs`）で実際に参照される全変数名を確認すること
 
+**配線先は「消費箇所」で判断する（4箇所すべてに一律で入れない）:**
+
+> ⚠️ レビュー bot（CodeRabbit / claude-review / github-actions）は「新規環境変数を 4 箇所すべてに追加せよ」と機械的に指摘しがちだが、**配線先はその変数がどこで消費されるかで決まる**。以下の区別に従うこと（この区別は設計判断であり、未追跡の欠落ではない）。
+
+- **CI ステップ（マイグレーション / デプロイ / 起動時シード）が参照する値** → CI ワークフロー（`staging.yml` / `production.yml`）にも配線する。
+  - 例: `ACCOUNTS_*` / `STG_ACCOUNTS_*` / `SENDGRID_API_KEY`（`production.yml` に存在。コメント「実際のランタイム注入は Terraform app_settings。ここは CI 配線」を参照）。
+- **アプリのリクエスト処理時のみ消費される非秘密の設定値** → CI ワークフローには**入れない**。`.env.dev.tpl`（ローカル）+ **Azure ランタイム（Terraform `app_settings`）** のみに配線する。CI はランタイム `app_settings` を運ばないため。
+  - 例: `Signup:ConfirmBaseUrl:{tenant}` / `MagicLink:BaseUrl:{tenant}`（`BuildConfirmUrl` / `BuildMagicLinkUrl` がリクエスト時に参照。`.yml` には無いのが正しい）。
+- **機能が動作する環境にのみ配線する**。例: `accounts` / `stg-accounts`（Account 申込・マジックリンク）機能は**本番 App Service のみ**で動く（staging は F プランで accounts org をシードしない）。よって配線先は `environments/production/main.tf` であって `environments/staging/main.tf` ではなく、staging の `.env.staging.tpl` / `staging.yml` にも入れない。
+
 ### Application Insights 上のステップ別プロファイリング
 
 `/token` `/userinfo` `register/verify` `authenticate/verify` の各エンドポイントは、`IdentityProvider.Telemetry.TimingScope` を使った `using` ブロックで処理ステップ毎の所要時間を `Activity.Current` のタグとして記録している。Azure Monitor が `Activity` タグを自動的に `customDimensions` にマッピングするため、本番テレメトリ上で内訳をクエリできる。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ cd E2ETests && pnpm install && pnpm exec playwright test
 | `/api/signup/confirm` | `token_lookup` / `confirm` |
 | `/api/signup/status` | `status_lookup` |
 | `/api/account/magic-link/request` | `rate_limit` / `account_lookup` / `persist` / `send_email` |
-| `/api/account/magic-link/verify` | `token_consume` |
+| `/api/account/magic-link/verify` | `token_lookup` / `token_consume` |
 
 #### Application Insights クエリ例
 

--- a/IdentityProvider.Test/Services/CloudflareOptionsTests.cs
+++ b/IdentityProvider.Test/Services/CloudflareOptionsTests.cs
@@ -1,0 +1,43 @@
+using System.Net;
+using IdentityProvider.Services;
+using Xunit;
+
+namespace IdentityProvider.Test.Services
+{
+    /// <summary>
+    /// <see cref="CloudflareOptions"/> の既定 CIDR が ForwardedHeaders の KnownNetworks に
+    /// 登録できる形式であることを検証する（タイポによる信頼境界の取りこぼしを防ぐ）。
+    /// </summary>
+    public class CloudflareOptionsTests
+    {
+        [Fact]
+        public void DefaultTrustedIpRanges_AreAllParsableCidrs()
+        {
+            var options = new CloudflareOptions();
+
+            Assert.NotEmpty(options.TrustedIpRanges);
+            foreach (var cidr in options.TrustedIpRanges)
+            {
+                Assert.True(
+                    IPNetwork.TryParse(cidr, out _),
+                    $"Cloudflare の CIDR がパースできません: {cidr}");
+            }
+        }
+
+        [Fact]
+        public void DefaultTrustedIpRanges_ContainBothIpv4AndIpv6()
+        {
+            var options = new CloudflareOptions();
+
+            var hasIpv4 = options.TrustedIpRanges.Exists(c =>
+                IPNetwork.TryParse(c, out var n) && n.BaseAddress.AddressFamily
+                    == System.Net.Sockets.AddressFamily.InterNetwork);
+            var hasIpv6 = options.TrustedIpRanges.Exists(c =>
+                IPNetwork.TryParse(c, out var n) && n.BaseAddress.AddressFamily
+                    == System.Net.Sockets.AddressFamily.InterNetworkV6);
+
+            Assert.True(hasIpv4, "IPv4 レンジが含まれていません。");
+            Assert.True(hasIpv6, "IPv6 レンジが含まれていません。");
+        }
+    }
+}

--- a/IdentityProvider.Test/Services/MagicLinkServiceTests.cs
+++ b/IdentityProvider.Test/Services/MagicLinkServiceTests.cs
@@ -7,6 +7,7 @@ using IdentityProvider.Test.TestHelpers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
@@ -50,8 +51,9 @@ namespace IdentityProvider.Test.Services
                 IAuthorizationCodeService authorizationCodeService,
                 IEmailService emailService,
                 IConfiguration configuration,
+                IOptions<MagicLinkOptions> options,
                 ILogger<MagicLinkService> logger)
-                : base(ctx, tenantService, accountService, authorizationCodeService, emailService, configuration, logger)
+                : base(ctx, tenantService, accountService, authorizationCodeService, emailService, configuration, options, logger)
             {
                 _ctx = ctx;
             }
@@ -154,6 +156,7 @@ namespace IdentityProvider.Test.Services
                 authCodeMock.Object,
                 emailMock.Object,
                 CreateConfiguration(),
+                Options.Create(new MagicLinkOptions()),
                 _logger);
         }
 

--- a/IdentityProvider.Test/Services/MagicLinkServiceTests.cs
+++ b/IdentityProvider.Test/Services/MagicLinkServiceTests.cs
@@ -445,5 +445,33 @@ namespace IdentityProvider.Test.Services
                 a => a.GenerateAuthorizationCodeAsync(It.IsAny<IAuthorizationCodeService.AuthorizationCodeRequest>()),
                 Times.Never);
         }
+
+        [Fact]
+        public async Task VerifyAsync_LoginNotConfigured_DoesNotConsumeToken()
+        {
+            var tenant = CreateTenantService();
+            using var context = TestDbContextHelper.CreateInMemoryContext(tenantService: tenant);
+            SeedAccountsOrg(context);
+            var account = SeedAccount(context);
+            // 管理コンソール Client を投入しない → ResolveAccountClientAsync が login_not_configured(500)。
+
+            var rawToken = await InsertMagicTokenAsync(context, DateTimeOffset.UtcNow.AddMinutes(10));
+
+            var service = CreateService(context, tenant, out _, out var accountMock, out var authCodeMock);
+            accountMock.Setup(a => a.GetBySubjectAsync(AccountSubject)).ReturnsAsync(account);
+
+            var ex = await Assert.ThrowsAsync<MagicLinkException>(() => service.VerifyAsync(rawToken));
+            Assert.Equal(500, ex.StatusCode);
+
+            // 解決失敗は消費の前なので、トークンは消費されない（設定を直せば再試行できる）。
+            context.ChangeTracker.Clear();
+            var token = await context.MagicLoginTokens.AsNoTracking().SingleAsync();
+            Assert.Null(token.UsedAt);
+
+            // 認可コードも発行されていない。
+            authCodeMock.Verify(
+                a => a.GenerateAuthorizationCodeAsync(It.IsAny<IAuthorizationCodeService.AuthorizationCodeRequest>()),
+                Times.Never);
+        }
     }
 }

--- a/IdentityProvider.Test/Services/MagicLinkServiceTests.cs
+++ b/IdentityProvider.Test/Services/MagicLinkServiceTests.cs
@@ -275,6 +275,28 @@ namespace IdentityProvider.Test.Services
             Assert.Equal(429, ex.StatusCode);
         }
 
+        [Fact]
+        public async Task RequestAsync_EmailSendFailure_DoesNotThrowAndPersistsToken()
+        {
+            var tenant = CreateTenantService();
+            using var context = TestDbContextHelper.CreateInMemoryContext(tenantService: tenant);
+            SeedAccountsOrg(context);
+            SeedAccount(context);
+
+            var service = CreateService(context, tenant, out var emailMock, out _, out _);
+            // SendGrid 障害・API キー未設定相当（InvalidOperationException）。
+            emailMock
+                .Setup(e => e.SendMagicLoginLinkAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("SendGrid unavailable"));
+
+            // 送信失敗でも例外を伝播させない（登録済みのみ 500・未登録 200 という enumeration を防ぐ）。
+            await service.RequestAsync(AccountEmail, "203.0.113.9", "UnitTest/1.0");
+
+            // トークンは記録されている（リクエスト自体は受理）。
+            var token = await context.MagicLoginTokens.AsNoTracking().SingleAsync();
+            Assert.Equal(AccountSubject, token.AccountSubject);
+        }
+
         // ---- VerifyAsync ----
 
         private static async Task<string> InsertMagicTokenAsync(

--- a/IdentityProvider.Test/Services/MagicLinkServiceTests.cs
+++ b/IdentityProvider.Test/Services/MagicLinkServiceTests.cs
@@ -1,0 +1,424 @@
+using System.Security.Cryptography;
+using System.Text;
+using IdentityProvider.Exceptions;
+using IdentityProvider.Models;
+using IdentityProvider.Services;
+using IdentityProvider.Test.TestHelpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace IdentityProvider.Test.Services
+{
+    /// <summary>
+    /// マジックリンクログイン（Phase D-2）のサービス層テスト。
+    /// <para>
+    /// 並行下のアトミック性（Compare-And-Set）は SQL Server の単一 UPDATE 文に依存し、実 DB（統合 / E2E）で
+    /// 担保する。<c>ExecuteUpdate</c> は InMemory プロバイダー非対応のため、ここでは
+    /// <see cref="TestableMagicLinkService"/> で消費シーム（<c>TryConsumeTokenAsync</c>）を逐次の
+    /// read-check-update に差し替え、逐次の単発契約・期限切れ拒否・レート制限境界・Email enumeration 対策・
+    /// 認可コード発行の配線を InMemory で検証する。
+    /// </para>
+    /// </summary>
+    public class MagicLinkServiceTests
+    {
+        private const string Tenant = "accounts";
+        private const string FrontBaseUrl = "https://ec-auth.io";
+        private const int AccountsOrgId = 1;
+        private const string AccountSubject = "acc-subject-0001";
+        private const string AccountEmail = "owner@example.jp";
+        private const string AdminClientId = "ecauth-admin-console";
+        private const string AdminRedirectUri = "https://accounts.ec-auth.io/auth/callback";
+
+        private readonly ILogger<MagicLinkService> _logger =
+            LoggerFactory.Create(b => b.AddConsole()).CreateLogger<MagicLinkService>();
+
+        /// <summary>
+        /// 消費シームを InMemory でも動く逐次 read-check-update に差し替えたテスト用サービス。
+        /// 本番（<see cref="MagicLinkService"/>）は <c>ExecuteUpdate</c> によるアトミック UPDATE を使う。
+        /// </summary>
+        private sealed class TestableMagicLinkService : MagicLinkService
+        {
+            private readonly EcAuthDbContext _ctx;
+
+            public TestableMagicLinkService(
+                EcAuthDbContext ctx,
+                ITenantService tenantService,
+                IAccountService accountService,
+                IAuthorizationCodeService authorizationCodeService,
+                IEmailService emailService,
+                IConfiguration configuration,
+                ILogger<MagicLinkService> logger)
+                : base(ctx, tenantService, accountService, authorizationCodeService, emailService, configuration, logger)
+            {
+                _ctx = ctx;
+            }
+
+            protected override async Task<int> TryConsumeTokenAsync(
+                string tokenHash, DateTimeOffset now, CancellationToken ct)
+            {
+                var token = await _ctx.MagicLoginTokens
+                    .FirstOrDefaultAsync(
+                        t => t.TokenHash == tokenHash && t.UsedAt == null && t.ExpiresAt > now, ct);
+                if (token == null)
+                {
+                    return 0;
+                }
+                token.UsedAt = now;
+                await _ctx.SaveChangesAsync(ct);
+                return 1;
+            }
+        }
+
+        // ---- セットアップ ----
+
+        private static MockTenantService CreateTenantService(string tenant = Tenant)
+        {
+            var t = new MockTenantService();
+            t.SetTenant(tenant);
+            return t;
+        }
+
+        private static IConfiguration CreateConfiguration() =>
+            new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    [$"MagicLink:BaseUrl:{Tenant}"] = FrontBaseUrl
+                })
+                .Build();
+
+        private static Organization SeedAccountsOrg(EcAuthDbContext context)
+        {
+            var org = new Organization
+            {
+                Id = AccountsOrgId,
+                Code = Tenant,
+                Name = "EcAuth Accounts",
+                TenantName = Tenant
+            };
+            context.Organizations.Add(org);
+            context.SaveChanges();
+            return org;
+        }
+
+        private static Account SeedAccount(EcAuthDbContext context)
+        {
+            var account = new Account
+            {
+                Subject = AccountSubject,
+                Email = AccountEmail,
+                OrganizationId = AccountsOrgId,
+                EmailVerifiedAt = DateTimeOffset.UtcNow
+            };
+            context.Accounts.Add(account);
+            context.SaveChanges();
+            return account;
+        }
+
+        private static Client SeedAdminConsoleClient(EcAuthDbContext context)
+        {
+            var client = new Client
+            {
+                ClientId = AdminClientId,
+                ClientSecret = "admin-console-secret",
+                AppName = "EcAuth Accounts",
+                OrganizationId = AccountsOrgId,
+                SubjectType = SubjectType.Account
+            };
+            client.RedirectUris!.Add(new RedirectUri { Uri = AdminRedirectUri });
+            context.Clients.Add(client);
+            context.SaveChanges();
+            return client;
+        }
+
+        private static string HashToken(string token) =>
+            Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(token))).ToLowerInvariant();
+
+        private TestableMagicLinkService CreateService(
+            EcAuthDbContext context,
+            ITenantService tenantService,
+            out Mock<IEmailService> emailMock,
+            out Mock<IAccountService> accountMock,
+            out Mock<IAuthorizationCodeService> authCodeMock)
+        {
+            emailMock = new Mock<IEmailService>();
+            accountMock = new Mock<IAccountService>();
+            authCodeMock = new Mock<IAuthorizationCodeService>();
+
+            return new TestableMagicLinkService(
+                context,
+                tenantService,
+                accountMock.Object,
+                authCodeMock.Object,
+                emailMock.Object,
+                CreateConfiguration(),
+                _logger);
+        }
+
+        // ---- RequestAsync ----
+
+        [Fact]
+        public async Task RequestAsync_ExistingAccount_SendsMagicLinkAndPersistsToken()
+        {
+            var tenant = CreateTenantService();
+            using var context = TestDbContextHelper.CreateInMemoryContext(tenantService: tenant);
+            SeedAccountsOrg(context);
+            SeedAccount(context);
+
+            var service = CreateService(context, tenant, out var emailMock, out _, out _);
+
+            string? sentUrl = null;
+            emailMock
+                .Setup(e => e.SendMagicLoginLinkAsync(AccountEmail, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Callback<string, string, CancellationToken>((_, url, _) => sentUrl = url)
+                .Returns(Task.CompletedTask);
+
+            await service.RequestAsync(AccountEmail, "203.0.113.1", "UnitTest/1.0");
+
+            emailMock.Verify(
+                e => e.SendMagicLoginLinkAsync(AccountEmail, It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                Times.Once);
+            Assert.NotNull(sentUrl);
+            Assert.StartsWith($"{FrontBaseUrl}/signin/magic-link?token=", sentUrl);
+
+            var token = await context.MagicLoginTokens.AsNoTracking().SingleAsync();
+            Assert.Equal(AccountSubject, token.AccountSubject);
+            Assert.False(string.IsNullOrEmpty(token.TokenHash));
+            // 生トークンは DB に保存されない（URL のトークンと token_hash が一致せず、ハッシュ化後に一致する）。
+            var rawToken = Uri.UnescapeDataString(sentUrl!.Split("token=")[1]);
+            Assert.NotEqual(rawToken, token.TokenHash);
+            Assert.Equal(HashToken(rawToken), token.TokenHash);
+        }
+
+        [Fact]
+        public async Task RequestAsync_UnknownEmail_DoesNotSendEmailButRecordsForRateLimit()
+        {
+            var tenant = CreateTenantService();
+            using var context = TestDbContextHelper.CreateInMemoryContext(tenantService: tenant);
+            SeedAccountsOrg(context);
+
+            var service = CreateService(context, tenant, out var emailMock, out _, out _);
+
+            await service.RequestAsync("nobody@example.jp", "203.0.113.2", "UnitTest/1.0");
+
+            emailMock.Verify(
+                e => e.SendMagicLoginLinkAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+
+            // レート制限の母数として行は記録され、AccountSubject は null。
+            var token = await context.MagicLoginTokens.AsNoTracking().SingleAsync();
+            Assert.Null(token.AccountSubject);
+        }
+
+        [Fact]
+        public async Task RequestAsync_InvalidEmail_NoThrowNoPersistNoEmail()
+        {
+            var tenant = CreateTenantService();
+            using var context = TestDbContextHelper.CreateInMemoryContext(tenantService: tenant);
+            SeedAccountsOrg(context);
+
+            var service = CreateService(context, tenant, out var emailMock, out _, out _);
+
+            // 形式不正は例外を投げず正常終了（enumeration を漏らさない）。記録もメールもしない。
+            await service.RequestAsync("not-an-email", "203.0.113.3", "UnitTest/1.0");
+
+            emailMock.Verify(
+                e => e.SendMagicLoginLinkAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+            Assert.Equal(0, await context.MagicLoginTokens.CountAsync());
+        }
+
+        [Fact]
+        public async Task RequestAsync_SecondRequestWithinFiveMinutes_ThrowsRateLimited()
+        {
+            var tenant = CreateTenantService();
+            using var context = TestDbContextHelper.CreateInMemoryContext(tenantService: tenant);
+            SeedAccountsOrg(context);
+            SeedAccount(context);
+
+            var service = CreateService(context, tenant, out var emailMock, out _, out _);
+            emailMock
+                .Setup(e => e.SendMagicLoginLinkAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            await service.RequestAsync(AccountEmail, "203.0.113.4", "UnitTest/1.0");
+
+            var ex = await Assert.ThrowsAsync<MagicLinkException>(
+                () => service.RequestAsync(AccountEmail, "203.0.113.4", "UnitTest/1.0"));
+            Assert.Equal(429, ex.StatusCode);
+            Assert.Equal("rate_limited", ex.Error);
+        }
+
+        [Fact]
+        public async Task RequestAsync_EleventhRequestFromSameIp_ThrowsRateLimited()
+        {
+            var tenant = CreateTenantService();
+            using var context = TestDbContextHelper.CreateInMemoryContext(tenantService: tenant);
+            SeedAccountsOrg(context);
+
+            var service = CreateService(context, tenant, out _, out _, out _);
+
+            const string ip = "203.0.113.50";
+            // 異なるメール（存在しない）で IP のみ共通にし、メール 5 分制限を回避する。
+            for (var i = 0; i < 10; i++)
+            {
+                await service.RequestAsync($"user{i}@example.jp", ip, "UnitTest/1.0");
+            }
+
+            var ex = await Assert.ThrowsAsync<MagicLinkException>(
+                () => service.RequestAsync("user-overflow@example.jp", ip, "UnitTest/1.0"));
+            Assert.Equal(429, ex.StatusCode);
+        }
+
+        // ---- VerifyAsync ----
+
+        private static async Task<string> InsertMagicTokenAsync(
+            EcAuthDbContext context, DateTimeOffset expiresAt, string? accountSubject = AccountSubject)
+        {
+            var rawToken = $"raw-token-{Guid.NewGuid():N}";
+            context.MagicLoginTokens.Add(new MagicLoginToken
+            {
+                AccountSubject = accountSubject,
+                RequestedEmailHash = HashToken(AccountEmail),
+                TokenHash = HashToken(rawToken),
+                ExpiresAt = expiresAt,
+                CreatedAt = DateTimeOffset.UtcNow
+            });
+            await context.SaveChangesAsync();
+            return rawToken;
+        }
+
+        [Fact]
+        public async Task VerifyAsync_ValidToken_ConsumesAndReturnsRedirectWithCode()
+        {
+            var tenant = CreateTenantService();
+            using var context = TestDbContextHelper.CreateInMemoryContext(tenantService: tenant);
+            SeedAccountsOrg(context);
+            var account = SeedAccount(context);
+            var client = SeedAdminConsoleClient(context);
+
+            var rawToken = await InsertMagicTokenAsync(context, DateTimeOffset.UtcNow.AddMinutes(10));
+
+            var service = CreateService(context, tenant, out _, out var accountMock, out var authCodeMock);
+            accountMock.Setup(a => a.GetBySubjectAsync(AccountSubject)).ReturnsAsync(account);
+
+            IAuthorizationCodeService.AuthorizationCodeRequest? captured = null;
+            authCodeMock
+                .Setup(a => a.GenerateAuthorizationCodeAsync(It.IsAny<IAuthorizationCodeService.AuthorizationCodeRequest>()))
+                .Callback<IAuthorizationCodeService.AuthorizationCodeRequest>(r => captured = r)
+                .ReturnsAsync(new AuthorizationCode { Code = "authcode-xyz" });
+
+            var result = await service.VerifyAsync(rawToken);
+
+            Assert.Equal($"{AdminRedirectUri}?code=authcode-xyz", result.RedirectUri);
+
+            Assert.NotNull(captured);
+            Assert.Equal(AccountSubject, captured!.Subject);
+            Assert.Equal(SubjectType.Account, captured.SubjectType);
+            Assert.Equal(client.Id, captured.ClientId);
+            Assert.Equal(AdminRedirectUri, captured.RedirectUri);
+
+            var token = await context.MagicLoginTokens.AsNoTracking().SingleAsync();
+            Assert.NotNull(token.UsedAt);
+        }
+
+        [Fact]
+        public async Task VerifyAsync_SecondUse_ThrowsInvalidAndIssuesCodeOnlyOnce()
+        {
+            var tenant = CreateTenantService();
+            using var context = TestDbContextHelper.CreateInMemoryContext(tenantService: tenant);
+            SeedAccountsOrg(context);
+            var account = SeedAccount(context);
+            SeedAdminConsoleClient(context);
+
+            var rawToken = await InsertMagicTokenAsync(context, DateTimeOffset.UtcNow.AddMinutes(10));
+
+            var service = CreateService(context, tenant, out _, out var accountMock, out var authCodeMock);
+            accountMock.Setup(a => a.GetBySubjectAsync(AccountSubject)).ReturnsAsync(account);
+            authCodeMock
+                .Setup(a => a.GenerateAuthorizationCodeAsync(It.IsAny<IAuthorizationCodeService.AuthorizationCodeRequest>()))
+                .ReturnsAsync(new AuthorizationCode { Code = "authcode-xyz" });
+
+            await service.VerifyAsync(rawToken);
+
+            // 2 回目は消費できず invalid（逐次の単発契約）。
+            var ex = await Assert.ThrowsAsync<MagicLinkException>(() => service.VerifyAsync(rawToken));
+            Assert.Equal(400, ex.StatusCode);
+            Assert.Equal("invalid_token", ex.Error);
+
+            authCodeMock.Verify(
+                a => a.GenerateAuthorizationCodeAsync(It.IsAny<IAuthorizationCodeService.AuthorizationCodeRequest>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task VerifyAsync_ExpiredToken_ThrowsInvalid()
+        {
+            var tenant = CreateTenantService();
+            using var context = TestDbContextHelper.CreateInMemoryContext(tenantService: tenant);
+            SeedAccountsOrg(context);
+            SeedAccount(context);
+            SeedAdminConsoleClient(context);
+
+            var rawToken = await InsertMagicTokenAsync(context, DateTimeOffset.UtcNow.AddMinutes(-1));
+
+            var service = CreateService(context, tenant, out _, out _, out var authCodeMock);
+
+            var ex = await Assert.ThrowsAsync<MagicLinkException>(() => service.VerifyAsync(rawToken));
+            Assert.Equal(400, ex.StatusCode);
+            authCodeMock.Verify(
+                a => a.GenerateAuthorizationCodeAsync(It.IsAny<IAuthorizationCodeService.AuthorizationCodeRequest>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task VerifyAsync_UnknownToken_ThrowsInvalid()
+        {
+            var tenant = CreateTenantService();
+            using var context = TestDbContextHelper.CreateInMemoryContext(tenantService: tenant);
+            SeedAccountsOrg(context);
+
+            var service = CreateService(context, tenant, out _, out _, out _);
+
+            var ex = await Assert.ThrowsAsync<MagicLinkException>(() => service.VerifyAsync("does-not-exist"));
+            Assert.Equal(400, ex.StatusCode);
+        }
+
+        [Fact]
+        public async Task VerifyAsync_EmptyToken_ThrowsInvalid()
+        {
+            var tenant = CreateTenantService();
+            using var context = TestDbContextHelper.CreateInMemoryContext(tenantService: tenant);
+
+            var service = CreateService(context, tenant, out _, out _, out _);
+
+            var ex = await Assert.ThrowsAsync<MagicLinkException>(() => service.VerifyAsync(""));
+            Assert.Equal(400, ex.StatusCode);
+        }
+
+        [Fact]
+        public async Task VerifyAsync_CrossTenantAccountNotFound_ThrowsInvalid()
+        {
+            var tenant = CreateTenantService();
+            using var context = TestDbContextHelper.CreateInMemoryContext(tenantService: tenant);
+            SeedAccountsOrg(context);
+            SeedAccount(context);
+            SeedAdminConsoleClient(context);
+
+            // トークン行は実在するが、別テナントのホストで使われた等の理由で GetBySubjectAsync が
+            // null を返すケースを再現する（テナントクエリフィルターによる拒否）。
+            var rawToken = await InsertMagicTokenAsync(context, DateTimeOffset.UtcNow.AddMinutes(10));
+
+            var service = CreateService(context, tenant, out _, out var accountMock, out var authCodeMock);
+            accountMock.Setup(a => a.GetBySubjectAsync(It.IsAny<string>())).ReturnsAsync((Account?)null);
+
+            var ex = await Assert.ThrowsAsync<MagicLinkException>(() => service.VerifyAsync(rawToken));
+            Assert.Equal(400, ex.StatusCode);
+            authCodeMock.Verify(
+                a => a.GenerateAuthorizationCodeAsync(It.IsAny<IAuthorizationCodeService.AuthorizationCodeRequest>()),
+                Times.Never);
+        }
+    }
+}

--- a/IdentityProvider/Controllers/MagicLinkController.cs
+++ b/IdentityProvider/Controllers/MagicLinkController.cs
@@ -36,7 +36,7 @@ namespace IdentityProvider.Controllers
         /// </summary>
         [HttpPost]
         [Route("request")]
-        public async Task<IActionResult> Request([FromBody] MagicLinkRequestDto? body, CancellationToken ct)
+        public async Task<IActionResult> RequestMagicLink([FromBody] MagicLinkRequestDto? body, CancellationToken ct)
         {
             var ipAddress = HttpContext.Connection.RemoteIpAddress?.ToString();
             var userAgent = HttpContext.Request.Headers.UserAgent.ToString();

--- a/IdentityProvider/Controllers/MagicLinkController.cs
+++ b/IdentityProvider/Controllers/MagicLinkController.cs
@@ -1,0 +1,112 @@
+using System.Text.Json.Serialization;
+using IdentityProvider.Exceptions;
+using IdentityProvider.Services;
+using Microsoft.AspNetCore.Cors;
+using Microsoft.AspNetCore.Mvc;
+
+namespace IdentityProvider.Controllers
+{
+    /// <summary>
+    /// マジックリンクログイン（パスキー紛失時のリカバリ動線）の API エンドポイント。
+    /// 申込フローと同じくフロントエンド（Cloudflare Pages）から呼ばれるクロスオリジン API のため、
+    /// <see cref="SignupController.CorsPolicy"/> を共用する。
+    /// <para>
+    /// メールリンク（<c>/signin/magic-link?token=...</c>）はフロントエンドのページを指し、
+    /// ユーザー操作で <c>POST /verify</c> を発行する（D-1 確認ページと同方針）。これにより、
+    /// メールセキュリティスキャナの先読み（プリフェッチ）で状態変更 GET が誤消費される問題を回避する。
+    /// </para>
+    /// </summary>
+    [Route("api/account/magic-link")]
+    [ApiController]
+    [EnableCors(SignupController.CorsPolicy)]
+    public class MagicLinkController : ControllerBase
+    {
+        private readonly IMagicLinkService _magicLinkService;
+        private readonly ILogger<MagicLinkController> _logger;
+
+        public MagicLinkController(IMagicLinkService magicLinkService, ILogger<MagicLinkController> logger)
+        {
+            _magicLinkService = magicLinkService;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// マジックリンクの発行を要求する。Email enumeration 対策のため、Account の存在有無に関わらず
+        /// 常に同一の HTTP 200 + 同一メッセージを返す。レート制限超過時のみ 429 を返す。
+        /// </summary>
+        [HttpPost]
+        [Route("request")]
+        public async Task<IActionResult> Request([FromBody] MagicLinkRequestDto? body, CancellationToken ct)
+        {
+            var ipAddress = HttpContext.Connection.RemoteIpAddress?.ToString();
+            var userAgent = HttpContext.Request.Headers.UserAgent.ToString();
+
+            try
+            {
+                await _magicLinkService.RequestAsync(body?.Email, ipAddress, userAgent, ct);
+            }
+            catch (MagicLinkException ex)
+            {
+                // レート制限（429）。閾値は Account 存在有無に依存しないため enumeration は漏れない。
+                _logger.LogWarning("マジックリンク要求が拒否されました: Error={Error}", ex.Error);
+                return StatusCode(ex.StatusCode, new
+                {
+                    error = ex.Error,
+                    error_description = ex.ErrorDescription
+                });
+            }
+
+            // Account の存在有無を漏らさないため常に同一メッセージを返す。
+            return Ok(new
+            {
+                message = "メールアドレスが登録されている場合、ログインリンクをお送りしました。"
+            });
+        }
+
+        /// <summary>
+        /// マジックリンクのトークンを検証して単発消費し、認可コードを付与したリダイレクト先を返す。
+        /// フロントエンドはレスポンスの <c>location</c> へブラウザ遷移する。
+        /// </summary>
+        [HttpPost]
+        [Route("verify")]
+        public async Task<IActionResult> Verify([FromBody] MagicLinkVerifyDto? body, CancellationToken ct)
+        {
+            try
+            {
+                var result = await _magicLinkService.VerifyAsync(body?.Token ?? string.Empty, ct);
+                return Ok(new
+                {
+                    location = result.RedirectUri
+                });
+            }
+            catch (MagicLinkException ex)
+            {
+                _logger.LogWarning("マジックリンク検証に失敗しました: Error={Error}", ex.Error);
+                return StatusCode(ex.StatusCode, new
+                {
+                    error = ex.Error,
+                    error_description = ex.ErrorDescription
+                });
+            }
+        }
+
+        /// <summary>
+        /// <c>POST /api/account/magic-link/request</c> のリクエストボディ（snake_case）。
+        /// </summary>
+        public sealed class MagicLinkRequestDto
+        {
+            [JsonPropertyName("email")]
+            public string? Email { get; set; }
+        }
+
+        /// <summary>
+        /// <c>POST /api/account/magic-link/verify</c> のリクエストボディ（snake_case）。
+        /// トークンを URL に載せないためボディで受け取る（Azure Monitor の requests.url 露出を避ける）。
+        /// </summary>
+        public sealed class MagicLinkVerifyDto
+        {
+            [JsonPropertyName("token")]
+            public string? Token { get; set; }
+        }
+    }
+}

--- a/IdentityProvider/Exceptions/MagicLinkException.cs
+++ b/IdentityProvider/Exceptions/MagicLinkException.cs
@@ -1,0 +1,35 @@
+namespace IdentityProvider.Exceptions
+{
+    /// <summary>
+    /// マジックリンクログイン（<c>POST /api/account/magic-link/request</c> /
+    /// <c>POST /api/account/magic-link/verify</c>）の処理エラーを表す例外。
+    /// <para>
+    /// Controller は <see cref="Error"/> / <see cref="ErrorDescription"/> を
+    /// レスポンスボディに展開し、<see cref="StatusCode"/> を HTTP ステータスとして返す。
+    /// レート制限超過は 429、トークン検証失敗（無効／期限切れ／使用済みを区別しない）は 400 を想定する。
+    /// </para>
+    /// <para>
+    /// Email enumeration 対策のため、トークン検証失敗時のメッセージは原因（無効／期限切れ／使用済み）を
+    /// 区別せず、レート制限は Account 存在有無に関わらず同一閾値・同一レスポンスとする。
+    /// </para>
+    /// </summary>
+    public class MagicLinkException : Exception
+    {
+        /// <summary>機械可読なエラーコード（例: <c>rate_limited</c> / <c>invalid_token</c>）。</summary>
+        public string Error { get; }
+
+        /// <summary>利用者に表示する説明文（日本語）。</summary>
+        public string ErrorDescription { get; }
+
+        /// <summary>HTTP ステータスコード（レート制限は 429、トークン検証失敗は 400）。</summary>
+        public int StatusCode { get; }
+
+        public MagicLinkException(string error, string errorDescription, int statusCode = 400)
+            : base($"{error}: {errorDescription}")
+        {
+            Error = error;
+            ErrorDescription = errorDescription;
+            StatusCode = statusCode;
+        }
+    }
+}

--- a/IdentityProvider/Program.cs
+++ b/IdentityProvider/Program.cs
@@ -21,7 +21,7 @@ builder.Services.AddHttpContextAccessor();
 // CF-Connecting-IP を ForwardedFor として読み、RemoteIpAddress を実クライアント IP に復元する。
 // これにより IP ベースのレート制限（MagicLinkService）や Application Insights の client_IP が
 // 実クライアント IP を参照できる。コントローラ側は RemoteIpAddress を読むだけでよい（横断対応）。
-// KnownNetworks に Cloudflare のエッジ CIDR を登録し、Cloudflare 以外から来た CF-Connecting-IP は
+// KnownIPNetworks に Cloudflare のエッジ CIDR を登録し、Cloudflare 以外から来た CF-Connecting-IP は
 // 信頼しない（偽装によるレート制限回避を防ぐ）。最終的な信頼境界は本番のオリジンロック
 // （Azure access restriction = Cloudflare IP 限定、ecauth-infrastructure 側）で担保する。
 builder.Services.Configure<CloudflareOptions>(
@@ -34,17 +34,30 @@ builder.Services.Configure<ForwardedHeadersOptions>(options =>
     options.ForwardedHeaders = ForwardedHeaders.XForwardedFor;
     // Cloudflare は実クライアント IP を CF-Connecting-IP に単一値で格納する（X-Forwarded-For は多段で連なる）。
     options.ForwardedForHeaderName = "CF-Connecting-IP";
-    // 既知プロキシ（Cloudflare エッジ）である限り遡る。信頼は KnownNetworks で制御する。
+    // 既知プロキシ（Cloudflare エッジ）である限り遡る。信頼は KnownIPNetworks で制御する。
     options.ForwardLimit = null;
 
-    // CIDR のパースは System.Net.IPNetwork（CIDR 文字列の TryParse 対応）で行い、
-    // KnownNetworks が要求する Microsoft.AspNetCore.HttpOverrides.IPNetwork に変換する。
-    foreach (var cidr in cloudflare.TrustedIpRanges)
+    // 設定上書きで空配列や無効な CIDR（typo 等）が入ると、信頼する Cloudflare CIDR が登録されず
+    // ForwardedHeaders が CF-Connecting-IP を信頼できなくなる（全リクエストが単一の Cloudflare
+    // エッジ IP から来たように見え、IP ベースのレート制限が機能しなくなる）。設定ミスを起動時に
+    // 検知するため、空・無効 CIDR は黙って無視せず例外で停止する（fail-closed）。
+    if (cloudflare.TrustedIpRanges is not { Count: > 0 } trustedIpRanges)
     {
-        if (System.Net.IPNetwork.TryParse(cidr, out var parsed))
+        throw new InvalidOperationException(
+            "Cloudflare:TrustedIpRanges には少なくとも 1 件の CIDR を設定してください。");
+    }
+
+    // .NET 10 では ForwardedHeadersOptions.KnownNetworks と Microsoft.AspNetCore.HttpOverrides.IPNetwork
+    // は obsolete（ASPDEPR005）。KnownIPNetworks + System.Net.IPNetwork を使う。
+    foreach (var cidr in trustedIpRanges)
+    {
+        if (!System.Net.IPNetwork.TryParse(cidr, out var parsed))
         {
-            options.KnownNetworks.Add(new IPNetwork(parsed.BaseAddress, parsed.PrefixLength));
+            throw new InvalidOperationException(
+                $"Cloudflare:TrustedIpRanges に無効な CIDR が含まれています: {cidr}");
         }
+
+        options.KnownIPNetworks.Add(parsed);
     }
 });
 builder.Services.AddScoped<IIssuerResolver, IssuerResolver>();

--- a/IdentityProvider/Program.cs
+++ b/IdentityProvider/Program.cs
@@ -8,12 +8,45 @@ using IdentityProvider.Models;
 using IdentityProvider.Services;
 using Asp.Versioning;
 using Azure.Monitor.OpenTelemetry.AspNetCore;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.EntityFrameworkCore;
 using OpenTelemetry;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddHttpContextAccessor();
+
+// リバースプロキシ（Cloudflare）からの実クライアント IP 復元設定。
+// 本番 API ホストは Cloudflare プロキシ配下のため RemoteIpAddress は Cloudflare のエッジ IP になる。
+// CF-Connecting-IP を ForwardedFor として読み、RemoteIpAddress を実クライアント IP に復元する。
+// これにより IP ベースのレート制限（MagicLinkService）や Application Insights の client_IP が
+// 実クライアント IP を参照できる。コントローラ側は RemoteIpAddress を読むだけでよい（横断対応）。
+// KnownNetworks に Cloudflare のエッジ CIDR を登録し、Cloudflare 以外から来た CF-Connecting-IP は
+// 信頼しない（偽装によるレート制限回避を防ぐ）。最終的な信頼境界は本番のオリジンロック
+// （Azure access restriction = Cloudflare IP 限定、ecauth-infrastructure 側）で担保する。
+builder.Services.Configure<CloudflareOptions>(
+    builder.Configuration.GetSection(CloudflareOptions.SectionName));
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    var cloudflare = builder.Configuration.GetSection(CloudflareOptions.SectionName)
+        .Get<CloudflareOptions>() ?? new CloudflareOptions();
+
+    options.ForwardedHeaders = ForwardedHeaders.XForwardedFor;
+    // Cloudflare は実クライアント IP を CF-Connecting-IP に単一値で格納する（X-Forwarded-For は多段で連なる）。
+    options.ForwardedForHeaderName = "CF-Connecting-IP";
+    // 既知プロキシ（Cloudflare エッジ）である限り遡る。信頼は KnownNetworks で制御する。
+    options.ForwardLimit = null;
+
+    // CIDR のパースは System.Net.IPNetwork（CIDR 文字列の TryParse 対応）で行い、
+    // KnownNetworks が要求する Microsoft.AspNetCore.HttpOverrides.IPNetwork に変換する。
+    foreach (var cidr in cloudflare.TrustedIpRanges)
+    {
+        if (System.Net.IPNetwork.TryParse(cidr, out var parsed))
+        {
+            options.KnownNetworks.Add(new IPNetwork(parsed.BaseAddress, parsed.PrefixLength));
+        }
+    }
+});
 builder.Services.AddScoped<IIssuerResolver, IssuerResolver>();
 builder.Services.AddScoped<ITenantService, TenantService>();
 builder.Services.AddScoped<IUserService, UserService>();
@@ -180,6 +213,12 @@ using (var scope = app.Services.CreateScope())
 }
 
 // Configure the HTTP request pipeline.
+
+// リバースプロキシ（Cloudflare）からの実クライアント IP 復元。RemoteIpAddress を参照する
+// 後続のミドルウェア・OpenTelemetry instrumentation（Application Insights の client_IP）より
+// 前に置く必要があるため、パイプライン先頭で実行する。
+app.UseForwardedHeaders();
+
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();

--- a/IdentityProvider/Program.cs
+++ b/IdentityProvider/Program.cs
@@ -37,8 +37,12 @@ builder.Services.AddScoped<IEmailService, SendGridEmailService>();
 builder.Services.AddSingleton<IDisposableEmailChecker, DisposableEmailChecker>();
 
 // マジックリンクログイン（Phase D-2）関連サービス
+// 時間・回数ポリシーは MagicLinkOptions に集約。未設定でも既定値で動作し、
+// 構成セクション "MagicLink"（例: MagicLink__RetentionDays）があれば上書きされる。
+builder.Services.Configure<MagicLinkOptions>(
+    builder.Configuration.GetSection(MagicLinkOptions.SectionName));
 builder.Services.AddScoped<IMagicLinkService, MagicLinkService>();
-// 期限切れトークンの日次クリーンアップ（保持期間 7 日）
+// 期限切れトークンの日次クリーンアップ（既定の保持期間 7 日）
 builder.Services.AddHostedService<MagicLinkCleanupService>();
 
 // データベース初期化（シーダー）

--- a/IdentityProvider/Program.cs
+++ b/IdentityProvider/Program.cs
@@ -36,6 +36,11 @@ builder.Services.AddScoped<IEmailService, SendGridEmailService>();
 // ブロックリストは不変のため singleton 登録（DisposableEmailChecker の設計）
 builder.Services.AddSingleton<IDisposableEmailChecker, DisposableEmailChecker>();
 
+// マジックリンクログイン（Phase D-2）関連サービス
+builder.Services.AddScoped<IMagicLinkService, MagicLinkService>();
+// 期限切れトークンの日次クリーンアップ（保持期間 7 日）
+builder.Services.AddHostedService<MagicLinkCleanupService>();
+
 // データベース初期化（シーダー）
 builder.Services.AddScoped<IDbSeeder, OrganizationClientSeeder>();
 builder.Services.AddScoped<IDbSeeder, AccountsOrganizationSeeder>();

--- a/IdentityProvider/Services/CloudflareOptions.cs
+++ b/IdentityProvider/Services/CloudflareOptions.cs
@@ -1,0 +1,59 @@
+namespace IdentityProvider.Services
+{
+    /// <summary>
+    /// リバースプロキシ（Cloudflare）からの転送ヘッダを信頼するための設定。
+    /// <para>
+    /// 本番 API ホスト（<c>*.ec-auth.io</c>）は Cloudflare プロキシ配下（<c>proxied = true</c>）のため、
+    /// <c>HttpContext.Connection.RemoteIpAddress</c> は Cloudflare のエッジ IP になる。実クライアント IP は
+    /// Cloudflare が付与する <c>CF-Connecting-IP</c> から復元する（<c>Program.cs</c> の ForwardedHeaders 設定）。
+    /// </para>
+    /// <para>
+    /// <c>TrustedIpRanges</c> は転送ヘッダを信頼してよい接続元（= Cloudflare のエッジ）の CIDR。
+    /// これを既知ネットワークとして登録し、Cloudflare 以外から来た <c>CF-Connecting-IP</c> は信頼しない
+    /// （IP 偽装によるレート制限回避・標的型 DoS を防ぐ）。ただし最終的な信頼境界は本番 App Service の
+    /// オリジンロック（Azure access restriction = Cloudflare IP 限定）で担保する。
+    /// </para>
+    /// <para>
+    /// 既定値は Cloudflare 公開リスト（<c>https://www.cloudflare.com/ips-v4/</c> /
+    /// <c>https://www.cloudflare.com/ips-v6/</c>）。Cloudflare がレンジを変更した場合は、本番 infra の
+    /// access restriction と<strong>合わせて</strong>更新すること（信頼境界の出典を一致させる）。
+    /// 構成セクション <c>Cloudflare:TrustedIpRanges</c> で上書き可能。
+    /// </para>
+    /// </summary>
+    public sealed class CloudflareOptions
+    {
+        public const string SectionName = "Cloudflare";
+
+        /// <summary>
+        /// 転送ヘッダを信頼する Cloudflare エッジの CIDR レンジ（IPv4 / IPv6）。
+        /// 出典: https://www.cloudflare.com/ips-v4/ , https://www.cloudflare.com/ips-v6/
+        /// </summary>
+        public List<string> TrustedIpRanges { get; set; } = new()
+        {
+            // IPv4
+            "173.245.48.0/20",
+            "103.21.244.0/22",
+            "103.22.200.0/22",
+            "103.31.4.0/22",
+            "141.101.64.0/18",
+            "108.162.192.0/18",
+            "190.93.240.0/20",
+            "188.114.96.0/20",
+            "197.234.240.0/22",
+            "198.41.128.0/17",
+            "162.158.0.0/15",
+            "104.16.0.0/13",
+            "104.24.0.0/14",
+            "172.64.0.0/13",
+            "131.0.72.0/22",
+            // IPv6
+            "2400:cb00::/32",
+            "2606:4700::/32",
+            "2803:f800::/32",
+            "2405:b500::/32",
+            "2405:8100::/32",
+            "2a06:98c0::/29",
+            "2c0f:f248::/32",
+        };
+    }
+}

--- a/IdentityProvider/Services/IEmailService.cs
+++ b/IdentityProvider/Services/IEmailService.cs
@@ -15,5 +15,13 @@ namespace IdentityProvider.Services
         /// <param name="confirmUrl">申込確認用 URL</param>
         /// <param name="ct">キャンセルトークン</param>
         Task SendSignupConfirmationAsync(string toEmail, string organizationName, string confirmUrl, CancellationToken ct = default);
+
+        /// <summary>
+        /// パスキー紛失時のリカバリ動線として、マジックリンクログイン用のリンクをメール送信する。
+        /// </summary>
+        /// <param name="toEmail">送信先メールアドレス（Account の登録メール）</param>
+        /// <param name="magicLinkUrl">マジックリンクのログイン URL（フロントエンドの <c>/signin/magic-link</c>）</param>
+        /// <param name="ct">キャンセルトークン</param>
+        Task SendMagicLoginLinkAsync(string toEmail, string magicLinkUrl, CancellationToken ct = default);
     }
 }

--- a/IdentityProvider/Services/IMagicLinkService.cs
+++ b/IdentityProvider/Services/IMagicLinkService.cs
@@ -1,0 +1,43 @@
+namespace IdentityProvider.Services
+{
+    /// <summary>
+    /// パスキー紛失時のリカバリ動線として、メール経由のマジックリンクログインを提供するサービス。
+    /// 設計書「マジックリンクログインフロー」を参照。
+    /// </summary>
+    public interface IMagicLinkService
+    {
+        /// <summary>
+        /// マジックリンクの発行を要求する。Account が存在する場合のみログインリンクをメール送信する。
+        /// <para>
+        /// Email enumeration 対策のため、Account の存在有無に関わらず本メソッドは正常終了する
+        /// （存在しない場合もダミーのハッシュ計算で処理時間を合わせる）。呼び出し側は常に同一の
+        /// レスポンスを返すこと。レート制限を超過した場合のみ <see cref="Exceptions.MagicLinkException"/>
+        /// （429）をスローする（閾値は Account 存在有無に依存しない）。
+        /// </para>
+        /// </summary>
+        /// <param name="email">ログインを要求するメールアドレス（未正規化で可）</param>
+        /// <param name="ipAddress">リクエスト元 IP（レート制限・監査用、取得不能なら null）</param>
+        /// <param name="userAgent">リクエスト元 User-Agent（監査用、取得不能なら null）</param>
+        /// <param name="ct">キャンセルトークン</param>
+        Task RequestAsync(string? email, string? ipAddress, string? userAgent, CancellationToken ct = default);
+
+        /// <summary>
+        /// マジックリンクのトークンを検証して単発消費し、認可コードを発行する。
+        /// <para>
+        /// 単発使用は Compare-And-Set（<c>used_at IS NULL</c> 条件の原子的 UPDATE）で保証する。
+        /// 無効／期限切れ／使用済みはいずれも区別せず同一の <see cref="Exceptions.MagicLinkException"/>（400）をスローする。
+        /// </para>
+        /// </summary>
+        /// <param name="token">メールリンクから受け取った平文トークン</param>
+        /// <param name="ct">キャンセルトークン</param>
+        /// <returns>認可コードを付与したクライアントのリダイレクト先 URL</returns>
+        Task<MagicLinkVerifyResult> VerifyAsync(string token, CancellationToken ct = default);
+    }
+
+    /// <summary>
+    /// マジックリンク検証の結果。フロントエンドは <see cref="RedirectUri"/> へブラウザ遷移し、
+    /// クライアント（管理コンソール）が認可コードをトークンに交換する。
+    /// </summary>
+    /// <param name="RedirectUri">認可コード（<c>code</c>）を付与したクライアントのリダイレクト先 URL</param>
+    public sealed record MagicLinkVerifyResult(string RedirectUri);
+}

--- a/IdentityProvider/Services/MagicLinkCleanupService.cs
+++ b/IdentityProvider/Services/MagicLinkCleanupService.cs
@@ -1,5 +1,6 @@
 using IdentityProvider.Models;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 
 namespace IdentityProvider.Services
 {
@@ -13,27 +14,28 @@ namespace IdentityProvider.Services
     /// </summary>
     public class MagicLinkCleanupService : BackgroundService
     {
-        // クリーンアップ実行間隔（日次）。
-        private static readonly TimeSpan Interval = TimeSpan.FromHours(24);
-
-        // トークンの保持期間。作成から 7 日を過ぎた行を削除する。
-        private static readonly TimeSpan Retention = TimeSpan.FromDays(7);
+        // クリーンアップ実行間隔と保持期間（既定は日次・7 日）。MagicLinkOptions から導出する。
+        private readonly TimeSpan _interval;
+        private readonly TimeSpan _retention;
 
         private readonly IServiceScopeFactory _scopeFactory;
         private readonly ILogger<MagicLinkCleanupService> _logger;
 
         public MagicLinkCleanupService(
             IServiceScopeFactory scopeFactory,
+            IOptions<MagicLinkOptions> options,
             ILogger<MagicLinkCleanupService> logger)
         {
             _scopeFactory = scopeFactory;
+            _interval = TimeSpan.FromHours(options.Value.CleanupIntervalHours);
+            _retention = TimeSpan.FromDays(options.Value.RetentionDays);
             _logger = logger;
         }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            // 起動直後に 1 回実行し、以降は Interval ごとに実行する。
-            using var timer = new PeriodicTimer(Interval);
+            // 起動直後に 1 回実行し、以降は設定された間隔ごとに実行する。
+            using var timer = new PeriodicTimer(_interval);
             do
             {
                 try
@@ -59,7 +61,7 @@ namespace IdentityProvider.Services
             using var scope = _scopeFactory.CreateScope();
             var context = scope.ServiceProvider.GetRequiredService<EcAuthDbContext>();
 
-            var cutoff = DateTimeOffset.UtcNow - Retention;
+            var cutoff = DateTimeOffset.UtcNow - _retention;
             var deleted = await context.MagicLoginTokens
                 .Where(t => t.CreatedAt < cutoff)
                 .ExecuteDeleteAsync(ct);
@@ -68,7 +70,7 @@ namespace IdentityProvider.Services
             {
                 _logger.LogInformation(
                     "期限切れマジックリンクトークンを {Count} 件削除しました（保持期間: {RetentionDays} 日）。",
-                    deleted, Retention.TotalDays);
+                    deleted, _retention.TotalDays);
             }
         }
     }

--- a/IdentityProvider/Services/MagicLinkCleanupService.cs
+++ b/IdentityProvider/Services/MagicLinkCleanupService.cs
@@ -1,0 +1,75 @@
+using IdentityProvider.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace IdentityProvider.Services
+{
+    /// <summary>
+    /// 期限切れ・使用済みのマジックリンクトークンを日次で削除するバックグラウンドサービス。
+    /// 保持期間（7 日）を過ぎた <see cref="MagicLoginToken"/> を <c>ExecuteDelete</c> で一括削除する。
+    /// <para>
+    /// <see cref="BackgroundService"/> は singleton のため、scoped な <see cref="EcAuthDbContext"/> は
+    /// <see cref="IServiceScopeFactory"/> でリクエストスコープを作って解決する。
+    /// </para>
+    /// </summary>
+    public class MagicLinkCleanupService : BackgroundService
+    {
+        // クリーンアップ実行間隔（日次）。
+        private static readonly TimeSpan Interval = TimeSpan.FromHours(24);
+
+        // トークンの保持期間。作成から 7 日を過ぎた行を削除する。
+        private static readonly TimeSpan Retention = TimeSpan.FromDays(7);
+
+        private readonly IServiceScopeFactory _scopeFactory;
+        private readonly ILogger<MagicLinkCleanupService> _logger;
+
+        public MagicLinkCleanupService(
+            IServiceScopeFactory scopeFactory,
+            ILogger<MagicLinkCleanupService> logger)
+        {
+            _scopeFactory = scopeFactory;
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            // 起動直後に 1 回実行し、以降は Interval ごとに実行する。
+            using var timer = new PeriodicTimer(Interval);
+            do
+            {
+                try
+                {
+                    await CleanupAsync(stoppingToken);
+                }
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                {
+                    // シャットダウンに伴うキャンセルは正常終了として扱う。
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    // クリーンアップの失敗はサービス継続を妨げない（次回実行で再試行）。
+                    _logger.LogError(ex, "マジックリンクトークンのクリーンアップに失敗しました。");
+                }
+            }
+            while (await timer.WaitForNextTickAsync(stoppingToken));
+        }
+
+        private async Task CleanupAsync(CancellationToken ct)
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<EcAuthDbContext>();
+
+            var cutoff = DateTimeOffset.UtcNow - Retention;
+            var deleted = await context.MagicLoginTokens
+                .Where(t => t.CreatedAt < cutoff)
+                .ExecuteDeleteAsync(ct);
+
+            if (deleted > 0)
+            {
+                _logger.LogInformation(
+                    "期限切れマジックリンクトークンを {Count} 件削除しました（保持期間: {RetentionDays} 日）。",
+                    deleted, Retention.TotalDays);
+            }
+        }
+    }
+}

--- a/IdentityProvider/Services/MagicLinkOptions.cs
+++ b/IdentityProvider/Services/MagicLinkOptions.cs
@@ -1,0 +1,39 @@
+namespace IdentityProvider.Services
+{
+    /// <summary>
+    /// マジックリンクログイン（Phase D-2）の時間・回数ポリシーを集約した設定。
+    /// <para>
+    /// 既定値はコード内に持つため設定の配線（app_settings 等）は不要で、未設定でもそのまま動作する。
+    /// 構成セクション <c>MagicLink</c> にキーがあれば上書きされる（例: 環境変数
+    /// <c>MagicLink__RetentionDays</c>）。仕様が未確定で変更可能性が高いため、関連値を 1 か所に集約し
+    /// 一望・変更しやすくする目的のクラス（環境別運用が必要になった場合は配線を追加するだけでよい）。
+    /// </para>
+    /// <para>
+    /// トークンのバイト長（エントロピー）はセキュリティパラメータのため設定化せず、サービス側の
+    /// 定数として固定する。
+    /// </para>
+    /// </summary>
+    public sealed class MagicLinkOptions
+    {
+        /// <summary>構成セクション名（<c>MagicLink:BaseUrl:{tenant}</c> と同じ <c>MagicLink</c> 配下）。</summary>
+        public const string SectionName = "MagicLink";
+
+        /// <summary>マジックリンクトークンの有効期限（分）。設計上の既定は 10 分。</summary>
+        public int TokenLifetimeMinutes { get; set; } = 10;
+
+        /// <summary>同一メールアドレスのレート制限ウィンドウ（分）。このウィンドウ内は 1 回のみ許可。</summary>
+        public int EmailRateLimitWindowMinutes { get; set; } = 5;
+
+        /// <summary>同一 IP のレート制限ウィンドウ（分）。既定は 60 分。</summary>
+        public int IpRateLimitWindowMinutes { get; set; } = 60;
+
+        /// <summary>同一 IP がレート制限ウィンドウ内に発行できる最大回数。既定は 10 回。</summary>
+        public int IpRateLimitMaxRequests { get; set; } = 10;
+
+        /// <summary>期限切れトークン削除バッチの実行間隔（時間）。既定は 24 時間（日次）。</summary>
+        public int CleanupIntervalHours { get; set; } = 24;
+
+        /// <summary>トークンの保持期間（日）。作成からこの日数を過ぎた行を削除する。既定は 7 日。</summary>
+        public int RetentionDays { get; set; } = 7;
+    }
+}

--- a/IdentityProvider/Services/MagicLinkService.cs
+++ b/IdentityProvider/Services/MagicLinkService.cs
@@ -5,24 +5,16 @@ using IdentityProvider.Exceptions;
 using IdentityProvider.Models;
 using IdentityProvider.Telemetry;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 
 namespace IdentityProvider.Services
 {
     /// <inheritdoc cref="IMagicLinkService" />
     public class MagicLinkService : IMagicLinkService
     {
-        // マジックリンクトークンの有効期限（設計上 10 分）。
-        private static readonly TimeSpan TokenLifetime = TimeSpan.FromMinutes(10);
-
-        // トークンのバイト長（32 byte = 256 bit）。
+        // トークンのバイト長（32 byte = 256 bit）。エントロピーはセキュリティパラメータのため
+        // 設定化せず定数で固定する（MagicLinkOptions のコメント参照）。
         private const int TokenBytes = 32;
-
-        // レート制限: 同一メールは 5 分に 1 回。
-        private static readonly TimeSpan EmailRateWindow = TimeSpan.FromMinutes(5);
-
-        // レート制限: 同一 IP は 1 時間に 10 回。
-        private static readonly TimeSpan IpRateWindow = TimeSpan.FromHours(1);
-        private const int IpRateLimit = 10;
 
         // 設定キーのテナント部を環境変数名に使える形へ正規化する正規表現（SignupService と同方針）。
         // 環境変数名はハイフンを含められない（Azure Linux App Service が拒否）ため、
@@ -35,6 +27,7 @@ namespace IdentityProvider.Services
         private readonly IAuthorizationCodeService _authorizationCodeService;
         private readonly IEmailService _emailService;
         private readonly IConfiguration _configuration;
+        private readonly MagicLinkOptions _options;
         private readonly ILogger<MagicLinkService> _logger;
 
         public MagicLinkService(
@@ -44,6 +37,7 @@ namespace IdentityProvider.Services
             IAuthorizationCodeService authorizationCodeService,
             IEmailService emailService,
             IConfiguration configuration,
+            IOptions<MagicLinkOptions> options,
             ILogger<MagicLinkService> logger)
         {
             _context = context;
@@ -52,6 +46,7 @@ namespace IdentityProvider.Services
             _authorizationCodeService = authorizationCodeService;
             _emailService = emailService;
             _configuration = configuration;
+            _options = options.Value;
             _logger = logger;
         }
 
@@ -98,7 +93,7 @@ namespace IdentityProvider.Services
                 AccountSubject = account?.Subject,
                 RequestedEmailHash = emailHash,
                 TokenHash = tokenHash,
-                ExpiresAt = now + TokenLifetime,
+                ExpiresAt = now + TimeSpan.FromMinutes(_options.TokenLifetimeMinutes),
                 RequestedIp = Truncate(ipAddress, 45),
                 RequestedUserAgent = Truncate(userAgent, 1000),
                 CreatedAt = now
@@ -228,8 +223,8 @@ namespace IdentityProvider.Services
         private async Task EnforceRateLimitAsync(
             string emailHash, string? ipAddress, DateTimeOffset now, CancellationToken ct)
         {
-            // 同一メールは 5 分に 1 回（直近ウィンドウ内に 1 件でもあれば拒否）。
-            var emailWindowStart = now - EmailRateWindow;
+            // 同一メールはウィンドウ内に 1 回のみ（直近ウィンドウ内に 1 件でもあれば拒否）。
+            var emailWindowStart = now - TimeSpan.FromMinutes(_options.EmailRateLimitWindowMinutes);
             var recentByEmail = await _context.MagicLoginTokens
                 .CountAsync(t => t.RequestedEmailHash == emailHash && t.CreatedAt > emailWindowStart, ct);
             if (recentByEmail >= 1)
@@ -237,13 +232,13 @@ namespace IdentityProvider.Services
                 throw RateLimited();
             }
 
-            // 同一 IP は 1 時間に 10 回。IP が取得できない場合は IP ベースの制限を適用しない。
+            // 同一 IP はウィンドウ内に上限回数まで。IP が取得できない場合は IP ベースの制限を適用しない。
             if (!string.IsNullOrWhiteSpace(ipAddress))
             {
-                var ipWindowStart = now - IpRateWindow;
+                var ipWindowStart = now - TimeSpan.FromMinutes(_options.IpRateLimitWindowMinutes);
                 var recentByIp = await _context.MagicLoginTokens
                     .CountAsync(t => t.RequestedIp == ipAddress && t.CreatedAt > ipWindowStart, ct);
-                if (recentByIp >= IpRateLimit)
+                if (recentByIp >= _options.IpRateLimitMaxRequests)
                 {
                     throw RateLimited();
                 }

--- a/IdentityProvider/Services/MagicLinkService.cs
+++ b/IdentityProvider/Services/MagicLinkService.cs
@@ -121,7 +121,21 @@ namespace IdentityProvider.Services
             var magicLinkUrl = BuildMagicLinkUrl(token);
             using (TimingScope.Begin("send_email"))
             {
-                await _emailService.SendMagicLoginLinkAsync(account.Email, magicLinkUrl, ct);
+                // メール送信失敗（SendGrid 4xx/5xx・API キー未設定等で InvalidOperationException）を
+                // 呼び出し元に伝播させると、登録済みメールのみ 500・未登録は 200 となり Account 存否が
+                // 漏れる（Email enumeration）。送信失敗は内部に留め（ログのみ）、Account 存在有無に
+                // 関わらず常に正常 return する。送信失敗の検知は運用ログに委ねる。
+                try
+                {
+                    await _emailService.SendMagicLoginLinkAsync(account.Email, magicLinkUrl, ct);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(
+                        ex,
+                        "マジックリンクメールの送信に失敗しました（enumeration 防止のため握りつぶし）: Tenant={Tenant}, TokenHash={TokenHash}",
+                        _tenantService.TenantName, TokenHashPrefix(token));
+                }
             }
         }
 

--- a/IdentityProvider/Services/MagicLinkService.cs
+++ b/IdentityProvider/Services/MagicLinkService.cs
@@ -113,7 +113,8 @@ namespace IdentityProvider.Services
             if (account == null)
             {
                 // 存在しない宛先にはメールを送らない。送信処理ぶんの時間差で存在を推測されないよう
-                // ダミーのハッシュ計算で処理時間を合わせる。
+                // ダミーのハッシュ計算で処理時間を近づける（PerformDummyHash の現状仕様・既知の制約を参照。
+                // SendGrid の ms オーダーとは完全には揃わない。後続課題 EcAuthDocs#91 で追跡）。
                 PerformDummyHash();
                 return;
             }
@@ -380,7 +381,20 @@ namespace IdentityProvider.Services
 
         /// <summary>
         /// Account 不在時やメール形式不正時に、処理時間を Account 存在時に近づけるためのダミー計算。
-        /// SHA-256 を 1 回計算して破棄する（タイミング差による enumeration を緩和する）。
+        /// SHA-256 を 1 回計算して破棄する。
+        /// <para>
+        /// <strong>【現状仕様・既知の制約】タイミングサイドチャネルは完全には解消していない。</strong>
+        /// Account 存在時はメール送信（SendGrid への HTTP ラウンドトリップ, 数十〜数百 ms）を伴う一方、
+        /// 本ダミー計算は μs オーダーのため、レスポンスタイムを精密計測すると Account の存否を推測しうる
+        /// （レビュー bot がこの点を繰り返し指摘するが、以下のとおり意図的な現状仕様）。
+        /// </para>
+        /// <para>
+        /// 完全な均一化にはメール送信のバックグラウンド化（fire-and-forget）等の構造変更が必要だが、
+        /// リスクは中〜低（漏れるのは存在判定の偵察のみで直接侵入ではない。レート制限
+        /// （email 5 分 1 回 / IP 1 時間 10 回）が列挙速度を抑制）と評価し、本対応は見送る。
+        /// HTTP 200 + 同一メッセージによる enumeration 対策は維持する。タイミング解消は後続課題として
+        /// 追跡する: EcAuthDocs#91「マジックリンク request の Email enumeration タイミングサイドチャネル対策」。
+        /// </para>
         /// </summary>
         private static void PerformDummyHash()
         {

--- a/IdentityProvider/Services/MagicLinkService.cs
+++ b/IdentityProvider/Services/MagicLinkService.cs
@@ -255,8 +255,9 @@ namespace IdentityProvider.Services
         private async Task<(Client client, string redirectUri)> ResolveAccountClientAsync(
             int organizationId, CancellationToken ct)
         {
+            // account は GetBySubjectAsync でテナント分離済み。その OrganizationId で Client を絞るため、
+            // テナントクエリフィルター（将来 Client に追加された場合も含む）はそのまま尊重する。
             var client = await _context.Clients
-                .IgnoreQueryFilters()
                 .Include(c => c.RedirectUris)
                 .FirstOrDefaultAsync(
                     c => c.OrganizationId == organizationId && c.SubjectType == SubjectType.Account, ct);

--- a/IdentityProvider/Services/MagicLinkService.cs
+++ b/IdentityProvider/Services/MagicLinkService.cs
@@ -1,0 +1,423 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+using IdentityProvider.Exceptions;
+using IdentityProvider.Models;
+using IdentityProvider.Telemetry;
+using Microsoft.EntityFrameworkCore;
+
+namespace IdentityProvider.Services
+{
+    /// <inheritdoc cref="IMagicLinkService" />
+    public class MagicLinkService : IMagicLinkService
+    {
+        // マジックリンクトークンの有効期限（設計上 10 分）。
+        private static readonly TimeSpan TokenLifetime = TimeSpan.FromMinutes(10);
+
+        // トークンのバイト長（32 byte = 256 bit）。
+        private const int TokenBytes = 32;
+
+        // レート制限: 同一メールは 5 分に 1 回。
+        private static readonly TimeSpan EmailRateWindow = TimeSpan.FromMinutes(5);
+
+        // レート制限: 同一 IP は 1 時間に 10 回。
+        private static readonly TimeSpan IpRateWindow = TimeSpan.FromHours(1);
+        private const int IpRateLimit = 10;
+
+        // 設定キーのテナント部を環境変数名に使える形へ正規化する正規表現（SignupService と同方針）。
+        // 環境変数名はハイフンを含められない（Azure Linux App Service が拒否）ため、
+        // [A-Za-z0-9_] 以外を "_" に置換する（例: "stg-accounts" -> "stg_accounts"）。
+        private static readonly Regex NonConfigKeyChar = new("[^A-Za-z0-9_]", RegexOptions.Compiled);
+
+        private readonly EcAuthDbContext _context;
+        private readonly ITenantService _tenantService;
+        private readonly IAccountService _accountService;
+        private readonly IAuthorizationCodeService _authorizationCodeService;
+        private readonly IEmailService _emailService;
+        private readonly IConfiguration _configuration;
+        private readonly ILogger<MagicLinkService> _logger;
+
+        public MagicLinkService(
+            EcAuthDbContext context,
+            ITenantService tenantService,
+            IAccountService accountService,
+            IAuthorizationCodeService authorizationCodeService,
+            IEmailService emailService,
+            IConfiguration configuration,
+            ILogger<MagicLinkService> logger)
+        {
+            _context = context;
+            _tenantService = tenantService;
+            _accountService = accountService;
+            _authorizationCodeService = authorizationCodeService;
+            _emailService = emailService;
+            _configuration = configuration;
+            _logger = logger;
+        }
+
+        /// <inheritdoc />
+        public async Task RequestAsync(string? email, string? ipAddress, string? userAgent, CancellationToken ct = default)
+        {
+            var normalizedEmail = NormalizeEmail(email);
+
+            // 形式不正なメールは Account の存在判定とは無関係なため記録もメール送信もしないが、
+            // enumeration を漏らさないようダミーのハッシュ計算で処理時間を合わせて正常終了する。
+            if (normalizedEmail == null)
+            {
+                PerformDummyHash();
+                return;
+            }
+
+            var emailHash = HashEmail(normalizedEmail);
+            var now = DateTimeOffset.UtcNow;
+
+            // レート制限判定（Account 存在有無に関わらず同一閾値）。
+            // MagicLoginToken はテナント横断（クエリフィルターなし）でカウントする。
+            using (TimingScope.Begin("rate_limit"))
+            {
+                await EnforceRateLimitAsync(emailHash, ipAddress, now, ct);
+            }
+
+            // Account を検索する（テナントクエリフィルターにより現テナントの Account のみが対象）。
+            Account? account;
+            using (TimingScope.Begin("account_lookup"))
+            {
+                account = await _context.Accounts
+                    .FirstOrDefaultAsync(a => a.Email == normalizedEmail, ct);
+            }
+
+            // 生トークンとその SHA-256 ハッシュを生成する。
+            // Account 不在のリクエストも、レート制限カウントの母数として MagicLoginToken に記録する
+            //（設計書: Account 不在のリクエストも同テーブルに記録する）。token_hash は unique 制約があるため
+            // 不在時もランダム値を保存する（誰も verify しない）。
+            var token = GenerateToken();
+            var tokenHash = HashToken(token);
+
+            var magicToken = new MagicLoginToken
+            {
+                AccountSubject = account?.Subject,
+                RequestedEmailHash = emailHash,
+                TokenHash = tokenHash,
+                ExpiresAt = now + TokenLifetime,
+                RequestedIp = Truncate(ipAddress, 45),
+                RequestedUserAgent = Truncate(userAgent, 1000),
+                CreatedAt = now
+            };
+
+            using (TimingScope.Begin("persist"))
+            {
+                _context.MagicLoginTokens.Add(magicToken);
+                await _context.SaveChangesAsync(ct);
+            }
+
+            // 平文トークンはログに出さない（ハッシュ先頭 8 文字のみ）。
+            _logger.LogInformation(
+                "マジックリンク発行リクエストを受け付けました: Tenant={Tenant}, AccountExists={AccountExists}, TokenHash={TokenHash}",
+                _tenantService.TenantName, account != null, TokenHashPrefix(token));
+
+            if (account == null)
+            {
+                // 存在しない宛先にはメールを送らない。送信処理ぶんの時間差で存在を推測されないよう
+                // ダミーのハッシュ計算で処理時間を合わせる。
+                PerformDummyHash();
+                return;
+            }
+
+            var magicLinkUrl = BuildMagicLinkUrl(token);
+            using (TimingScope.Begin("send_email"))
+            {
+                await _emailService.SendMagicLoginLinkAsync(account.Email, magicLinkUrl, ct);
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task<MagicLinkVerifyResult> VerifyAsync(string token, CancellationToken ct = default)
+        {
+            if (string.IsNullOrWhiteSpace(token))
+            {
+                throw InvalidToken();
+            }
+
+            var tokenHash = HashToken(token);
+            var now = DateTimeOffset.UtcNow;
+
+            // 単発使用は Compare-And-Set で保証する。read -> check -> update の 3 ステップでは
+            // Race Condition により複数回ログインが成立しうるため、未使用かつ未期限切れの行のみを
+            // 対象とするアトミックな UPDATE を実行し、影響行数 1 を成功とする（設計書のセキュリティ要件）。
+            int affected;
+            using (TimingScope.Begin("token_consume"))
+            {
+                affected = await TryConsumeTokenAsync(tokenHash, now, ct);
+            }
+
+            if (affected != 1)
+            {
+                // 無効／期限切れ／使用済みを区別せず同一エラーとする（情報を漏らさない）。
+                _logger.LogWarning(
+                    "マジックリンクトークンの消費に失敗しました（無効／期限切れ／使用済み）: Tenant={Tenant}, TokenHash={TokenHash}",
+                    _tenantService.TenantName, TokenHashPrefix(token));
+                throw InvalidToken();
+            }
+
+            // 消費に成功した行を取得する（ExecuteUpdate はトラッキングを経由しないため再取得する）。
+            var magicToken = await _context.MagicLoginTokens
+                .AsNoTracking()
+                .FirstOrDefaultAsync(t => t.TokenHash == tokenHash, ct);
+
+            if (magicToken?.AccountSubject == null)
+            {
+                // Account 不在のリクエストで作られた行（レート制限カウント用）。通常は到達しない。
+                _logger.LogWarning(
+                    "消費したマジックリンクトークンに AccountSubject がありません: Tenant={Tenant}, TokenHash={TokenHash}",
+                    _tenantService.TenantName, TokenHashPrefix(token));
+                throw InvalidToken();
+            }
+
+            // Account を取得する。テナントクエリフィルターにより、別テナントで発行された
+            // トークンを現テナントのホストで使おうとした場合は null になり弾かれる（クロステナント防止）。
+            var account = await _accountService.GetBySubjectAsync(magicToken.AccountSubject);
+            if (account == null)
+            {
+                _logger.LogWarning(
+                    "マジックリンクトークンの Account が現テナントで見つかりません: Tenant={Tenant}, TokenHash={TokenHash}",
+                    _tenantService.TenantName, TokenHashPrefix(token));
+                throw InvalidToken();
+            }
+
+            // ログイン先（管理コンソール）の Client と登録済みリダイレクト URI を解決する。
+            var (client, redirectUri) = await ResolveAccountClientAsync(account.OrganizationId, ct);
+
+            var authCode = await _authorizationCodeService.GenerateAuthorizationCodeAsync(
+                new IAuthorizationCodeService.AuthorizationCodeRequest
+                {
+                    Subject = account.Subject,
+                    ClientId = client.Id,
+                    RedirectUri = redirectUri,
+                    SubjectType = SubjectType.Account,
+                    ExpirationMinutes = 10
+                });
+
+            _logger.LogInformation(
+                "マジックリンクログインを検証し認可コードを発行しました: Tenant={Tenant}, Subject={Subject}, ClientId={ClientId}",
+                _tenantService.TenantName, account.Subject, client.ClientId);
+
+            return new MagicLinkVerifyResult(AppendAuthorizationCode(redirectUri, authCode.Code));
+        }
+
+        /// <summary>
+        /// トークンを単発消費する（Compare-And-Set）。未使用かつ未期限切れの行のみを対象に
+        /// <c>used_at</c> を原子的に更新し、影響行数を返す（成功 = 1）。read → check → update の
+        /// 3 ステップでは Race Condition により複数回ログインが成立しうるため、必ずアトミックな
+        /// 単一 UPDATE で実装する（設計書のセキュリティ要件）。
+        /// <para>
+        /// この並行下のアトミック性は SQL Server の単一 UPDATE 文のセマンティクスに依存するため、
+        /// 実 DB（統合テスト / E2E）で担保する。<c>ExecuteUpdate</c> は EF Core の InMemory
+        /// プロバイダー非対応のため、ユニットテストではこのメソッドを override して逐次の単発契約のみ検証する。
+        /// </para>
+        /// </summary>
+        protected virtual Task<int> TryConsumeTokenAsync(
+            string tokenHash, DateTimeOffset now, CancellationToken ct)
+        {
+            return _context.MagicLoginTokens
+                .Where(t => t.TokenHash == tokenHash && t.UsedAt == null && t.ExpiresAt > now)
+                .ExecuteUpdateAsync(s => s.SetProperty(t => t.UsedAt, now), ct);
+        }
+
+        // ---- レート制限 ----
+
+        private async Task EnforceRateLimitAsync(
+            string emailHash, string? ipAddress, DateTimeOffset now, CancellationToken ct)
+        {
+            // 同一メールは 5 分に 1 回（直近ウィンドウ内に 1 件でもあれば拒否）。
+            var emailWindowStart = now - EmailRateWindow;
+            var recentByEmail = await _context.MagicLoginTokens
+                .CountAsync(t => t.RequestedEmailHash == emailHash && t.CreatedAt > emailWindowStart, ct);
+            if (recentByEmail >= 1)
+            {
+                throw RateLimited();
+            }
+
+            // 同一 IP は 1 時間に 10 回。IP が取得できない場合は IP ベースの制限を適用しない。
+            if (!string.IsNullOrWhiteSpace(ipAddress))
+            {
+                var ipWindowStart = now - IpRateWindow;
+                var recentByIp = await _context.MagicLoginTokens
+                    .CountAsync(t => t.RequestedIp == ipAddress && t.CreatedAt > ipWindowStart, ct);
+                if (recentByIp >= IpRateLimit)
+                {
+                    throw RateLimited();
+                }
+            }
+        }
+
+        // ---- Client / リダイレクト URI 解決 ----
+
+        /// <summary>
+        /// 受付テナント（accounts / stg-accounts）の管理コンソール Client（<see cref="SubjectType.Account"/>）と、
+        /// その登録済みリダイレクト URI を解決する。<see cref="Data.Seeders.AccountsOrganizationSeeder"/> が
+        /// 投入する Client / RedirectUri に対応する。
+        /// </summary>
+        private async Task<(Client client, string redirectUri)> ResolveAccountClientAsync(
+            int organizationId, CancellationToken ct)
+        {
+            var client = await _context.Clients
+                .IgnoreQueryFilters()
+                .Include(c => c.RedirectUris)
+                .FirstOrDefaultAsync(
+                    c => c.OrganizationId == organizationId && c.SubjectType == SubjectType.Account, ct);
+
+            var redirectUri = client?.RedirectUris?.FirstOrDefault()?.Uri;
+
+            if (client == null || string.IsNullOrWhiteSpace(redirectUri))
+            {
+                _logger.LogError(
+                    "管理コンソール Client またはリダイレクト URI が見つかりません: Tenant={Tenant}, OrganizationId={OrganizationId}",
+                    _tenantService.TenantName, organizationId);
+                throw new MagicLinkException(
+                    "login_not_configured",
+                    "ログイン環境が正しく構成されていません。サポートにお問い合わせください。",
+                    statusCode: 500);
+            }
+
+            return (client, redirectUri);
+        }
+
+        /// <summary>
+        /// リダイレクト URI に認可コードをクエリ <c>code</c> として付与する。
+        /// 既にクエリを持つ URI でも壊さないよう区切り文字を判定する。
+        /// </summary>
+        private static string AppendAuthorizationCode(string redirectUri, string code)
+        {
+            var separator = redirectUri.Contains('?') ? '&' : '?';
+            return $"{redirectUri}{separator}code={Uri.EscapeDataString(code)}";
+        }
+
+        // ---- URL 構築 ----
+
+        /// <summary>
+        /// マジックリンクの URL を組み立てる。基底 URL はテナント別の信頼済み設定値
+        /// <c>MagicLink:BaseUrl:{tenant_name}</c>（フロントエンドの配信元）からのみ取得する。
+        /// Host ヘッダ偽装によるトークン窃取を防ぐため <c>Request.Host</c> へはフォールバックしない
+        /// （SignupService.BuildConfirmUrl と同方針）。テナント名のハイフンは環境変数名に使えないため
+        /// <c>[A-Za-z0-9_]</c> 以外を <c>_</c> に正規化する（例: <c>stg-accounts</c> → <c>stg_accounts</c>）。
+        /// </summary>
+        private string BuildMagicLinkUrl(string token)
+        {
+            var encodedToken = Uri.EscapeDataString(token);
+
+            var tenantName = _tenantService.TenantName;
+            var configKey = $"MagicLink:BaseUrl:{NonConfigKeyChar.Replace(tenantName, "_")}";
+            var configuredBase = _configuration[configKey];
+
+            if (string.IsNullOrWhiteSpace(configuredBase)
+                || !Uri.TryCreate(configuredBase, UriKind.Absolute, out var baseUri)
+                || baseUri.Scheme != Uri.UriSchemeHttps)
+            {
+                _logger.LogError(
+                    "マジックリンク URL の基底が未設定または不正です: Tenant={Tenant}, Key={Key}",
+                    tenantName, configKey);
+                throw new InvalidOperationException(
+                    $"マジックリンク URL の基底を決定できません。{configKey} に有効な https:// URL を設定してください。");
+            }
+
+            return $"{configuredBase.TrimEnd('/')}/signin/magic-link?token={encodedToken}";
+        }
+
+        // ---- トークン・ハッシュ・補助 ----
+
+        private static string GenerateToken()
+        {
+            var bytes = RandomNumberGenerator.GetBytes(TokenBytes);
+            return Base64UrlEncode(bytes);
+        }
+
+        private static string Base64UrlEncode(byte[] bytes)
+        {
+            return Convert.ToBase64String(bytes)
+                .TrimEnd('=')
+                .Replace('+', '-')
+                .Replace('/', '_');
+        }
+
+        /// <summary>
+        /// トークンを SHA-256 でハッシュ化し、16 進小文字（64 文字）で返す。
+        /// 高エントロピーのランダム値のためソルトは不要。DB にはこのハッシュのみ保存する。
+        /// </summary>
+        private static string HashToken(string token)
+        {
+            return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(token)))
+                .ToLowerInvariant();
+        }
+
+        /// <summary>
+        /// 正規化済みメールアドレスを SHA-256 でハッシュ化し、16 進小文字（64 文字）で返す。
+        /// レート制限の判定キー（<c>requested_email_hash</c>）に使用する。
+        /// </summary>
+        private static string HashEmail(string normalizedEmail)
+        {
+            return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(normalizedEmail)))
+                .ToLowerInvariant();
+        }
+
+        /// <summary>
+        /// Account 不在時やメール形式不正時に、処理時間を Account 存在時に近づけるためのダミー計算。
+        /// SHA-256 を 1 回計算して破棄する（タイミング差による enumeration を緩和する）。
+        /// </summary>
+        private static void PerformDummyHash()
+        {
+            var dummy = RandomNumberGenerator.GetBytes(TokenBytes);
+            _ = SHA256.HashData(dummy);
+        }
+
+        private static string TokenHashPrefix(string token)
+        {
+            var hash = SHA256.HashData(Encoding.UTF8.GetBytes(token));
+            return Convert.ToHexString(hash)[..8].ToLowerInvariant();
+        }
+
+        /// <summary>
+        /// メールアドレスを正規化（trim + lowercase）する。空・255 超・形式不正は null を返す。
+        /// </summary>
+        private static string? NormalizeEmail(string? rawEmail)
+        {
+            var email = rawEmail?.Trim().ToLowerInvariant();
+            if (string.IsNullOrEmpty(email) || email.Length > 255 || !IsValidEmail(email))
+            {
+                return null;
+            }
+            return email;
+        }
+
+        private static bool IsValidEmail(string email)
+        {
+            try
+            {
+                var addr = new System.Net.Mail.MailAddress(email);
+                return string.Equals(addr.Address, email, StringComparison.Ordinal);
+            }
+            catch (FormatException)
+            {
+                return false;
+            }
+        }
+
+        private static string? Truncate(string? value, int maxLength)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return value;
+            }
+            return value.Length <= maxLength ? value : value[..maxLength];
+        }
+
+        private static MagicLinkException InvalidToken() => new(
+            "invalid_token",
+            "ログインリンクが無効か、有効期限が切れています。お手数ですが再度お試しください。",
+            statusCode: 400);
+
+        private static MagicLinkException RateLimited() => new(
+            "rate_limited",
+            "リクエストが多すぎます。しばらく時間をおいて再度お試しください。",
+            statusCode: 429);
+    }
+}

--- a/IdentityProvider/Services/MagicLinkService.cs
+++ b/IdentityProvider/Services/MagicLinkService.cs
@@ -150,34 +150,25 @@ namespace IdentityProvider.Services
             var tokenHash = HashToken(token);
             var now = DateTimeOffset.UtcNow;
 
-            // 単発使用は Compare-And-Set で保証する。read -> check -> update の 3 ステップでは
-            // Race Condition により複数回ログインが成立しうるため、未使用かつ未期限切れの行のみを
-            // 対象とするアトミックな UPDATE を実行し、影響行数 1 を成功とする（設計書のセキュリティ要件）。
-            int affected;
-            using (TimingScope.Begin("token_consume"))
+            // まずトークンを read で事前検証する（消費はまだ行わない）。Account / Client の解決を
+            // 消費の前に済ませることで、設定ミス（login_not_configured）や Account 欠落で失敗しても
+            // ワンタイムトークンを焼かない（設定を直せば配信済みリンクが再び使える）。
+            // 最終的な単発保証は後段の Compare-And-Set 消費で行う。この事前 read と消費の間に別リクエストが
+            // 割り込んでも、アトミックな UPDATE の影響行数で 1 件だけが成立する（二重ログインは起きない）。
+            MagicLoginToken? magicToken;
+            using (TimingScope.Begin("token_lookup"))
             {
-                affected = await TryConsumeTokenAsync(tokenHash, now, ct);
+                magicToken = await _context.MagicLoginTokens
+                    .AsNoTracking()
+                    .FirstOrDefaultAsync(
+                        t => t.TokenHash == tokenHash && t.UsedAt == null && t.ExpiresAt > now, ct);
             }
-
-            if (affected != 1)
-            {
-                // 無効／期限切れ／使用済みを区別せず同一エラーとする（情報を漏らさない）。
-                _logger.LogWarning(
-                    "マジックリンクトークンの消費に失敗しました（無効／期限切れ／使用済み）: Tenant={Tenant}, TokenHash={TokenHash}",
-                    _tenantService.TenantName, TokenHashPrefix(token));
-                throw InvalidToken();
-            }
-
-            // 消費に成功した行を取得する（ExecuteUpdate はトラッキングを経由しないため再取得する）。
-            var magicToken = await _context.MagicLoginTokens
-                .AsNoTracking()
-                .FirstOrDefaultAsync(t => t.TokenHash == tokenHash, ct);
 
             if (magicToken?.AccountSubject == null)
             {
-                // Account 不在のリクエストで作られた行（レート制限カウント用）。通常は到達しない。
+                // 無効／期限切れ／使用済み／Account 不在（レート制限用の行）を区別せず同一エラーとする。
                 _logger.LogWarning(
-                    "消費したマジックリンクトークンに AccountSubject がありません: Tenant={Tenant}, TokenHash={TokenHash}",
+                    "マジックリンクトークンが無効です（無効／期限切れ／使用済み／Account 不在）: Tenant={Tenant}, TokenHash={TokenHash}",
                     _tenantService.TenantName, TokenHashPrefix(token));
                 throw InvalidToken();
             }
@@ -194,7 +185,25 @@ namespace IdentityProvider.Services
             }
 
             // ログイン先（管理コンソール）の Client と登録済みリダイレクト URI を解決する。
+            // ここまでを消費の前に行うため、解決失敗時にトークンは焼けない。
             var (client, redirectUri) = await ResolveAccountClientAsync(account.OrganizationId, ct);
+
+            // 単発使用は Compare-And-Set で保証する。未使用かつ未期限切れの行のみを対象とする
+            // アトミックな UPDATE を実行し、影響行数 1 を成功とする（並行リクエストはここで 1 件だけ通る）。
+            int affected;
+            using (TimingScope.Begin("token_consume"))
+            {
+                affected = await TryConsumeTokenAsync(tokenHash, now, ct);
+            }
+
+            if (affected != 1)
+            {
+                // 事前 read 後・消費前に別リクエストが消費した／期限切れになった等。同一エラーで返す。
+                _logger.LogWarning(
+                    "マジックリンクトークンの消費に失敗しました（並行使用／期限切れ）: Tenant={Tenant}, TokenHash={TokenHash}",
+                    _tenantService.TenantName, TokenHashPrefix(token));
+                throw InvalidToken();
+            }
 
             var authCode = await _authorizationCodeService.GenerateAuthorizationCodeAsync(
                 new IAuthorizationCodeService.AuthorizationCodeRequest

--- a/IdentityProvider/Services/SendGridEmailService.cs
+++ b/IdentityProvider/Services/SendGridEmailService.cs
@@ -94,6 +94,77 @@ namespace IdentityProvider.Services
                 MaskEmail(toEmail), displayOrganization);
         }
 
+        /// <inheritdoc />
+        public async Task SendMagicLoginLinkAsync(string toEmail, string magicLinkUrl, CancellationToken ct = default)
+        {
+            if (string.IsNullOrWhiteSpace(toEmail))
+                throw new ArgumentException("toEmail cannot be null or empty.", nameof(toEmail));
+            if (string.IsNullOrWhiteSpace(magicLinkUrl))
+                throw new ArgumentException("magicLinkUrl cannot be null or empty.", nameof(magicLinkUrl));
+
+            // API キーは IConfiguration（SendGrid:ApiKey）→ 環境変数（SENDGRID_API_KEY）の順で解決する。
+            var apiKey = _configuration["SendGrid:ApiKey"]
+                ?? _configuration["SENDGRID_API_KEY"];
+
+            if (string.IsNullOrWhiteSpace(apiKey))
+            {
+                // API キー未設定でメールが届かないと、利用者はログインリンクを受け取れずログイン不能になる。
+                // 設定不備として例外を投げ、呼び出し側（500）に伝播させる（fail-closed）。
+                _logger.LogError(
+                    "SENDGRID_API_KEY が未設定のためマジックリンクを送信できません: To={ToEmail}",
+                    MaskEmail(toEmail));
+                throw new InvalidOperationException(
+                    "SendGrid API キー（SendGrid:ApiKey / SENDGRID_API_KEY）が設定されていません。");
+            }
+
+            var fromEmail = _configuration["SendGrid:FromEmail"]
+                ?? _configuration["SENDGRID_FROM_EMAIL"]
+                ?? "noreply@ecauth.jp";
+            var fromName = _configuration["SendGrid:FromName"]
+                ?? _configuration["SENDGRID_FROM_NAME"]
+                ?? "EcAuth";
+
+            var subject = "【EcAuth】ログインリンクのお知らせ";
+
+            var plainTextContent =
+                $"EcAuth へのログインリクエストを受け付けました。\n\n" +
+                $"以下の URL にアクセスしてログインを完了してください（有効期限: 10 分）。\n\n" +
+                $"{magicLinkUrl}\n\n" +
+                $"このリンクは一度のみ使用できます。\n" +
+                $"心当たりがない場合は、このメールを破棄してください（操作は不要です）。\n\n" +
+                $"-- \nEcAuth";
+
+            var htmlContent =
+                $"<p>EcAuth へのログインリクエストを受け付けました。</p>" +
+                $"<p>下記のボタン（リンク）からログインを完了してください（有効期限: 10 分）。</p>" +
+                $"<p><a href=\"{System.Net.WebUtility.HtmlEncode(magicLinkUrl)}\">ログインする</a></p>" +
+                $"<p>ボタンが動作しない場合は、以下の URL をブラウザに貼り付けてアクセスしてください。<br>" +
+                $"{System.Net.WebUtility.HtmlEncode(magicLinkUrl)}</p>" +
+                $"<p>このリンクは一度のみ使用できます。<br>" +
+                $"心当たりがない場合は、このメールを破棄してください（操作は不要です）。</p>" +
+                $"<p>--<br>EcAuth</p>";
+
+            var client = new SendGridClient(apiKey);
+            var from = new EmailAddress(fromEmail, fromName);
+            var to = new EmailAddress(toEmail);
+            var message = MailHelper.CreateSingleEmail(from, to, subject, plainTextContent, htmlContent);
+
+            var response = await client.SendEmailAsync(message, ct);
+
+            if ((int)response.StatusCode >= 400)
+            {
+                _logger.LogError(
+                    "マジックリンクの送信に失敗しました: To={ToEmail}, StatusCode={StatusCode}",
+                    MaskEmail(toEmail), (int)response.StatusCode);
+                throw new InvalidOperationException(
+                    $"SendGrid によるメール送信に失敗しました (StatusCode={(int)response.StatusCode})。");
+            }
+
+            _logger.LogInformation(
+                "マジックリンクを送信しました: To={ToEmail}",
+                MaskEmail(toEmail));
+        }
+
         /// <summary>
         /// ログ出力用にメールアドレスをマスクする。ローカル部の先頭 1 文字のみ残し、
         /// 残りを伏字にしたうえでドメインを保持する（例: <c>owner@example.com</c> → <c>o****@example.com</c>）。


### PR DESCRIPTION
## 概要

EcAuthDocs Issue #79 **Phase D-2: マジックリンクログイン (PR 5)** を実装します。パスキー紛失時のリカバリ動線として、メール経由のマジックリンクログインを追加します。

## 設計判断（D-1 と同方針 + 設計書訂正点）

設計書（`account-management-architecture.html`）は当初 `GET /signin/magic-link?token=...` を **IdP が直接処理**（トークン検証→認可コード発行→リダイレクト、URL は `accounts.ec-auth.io` 形式）と定めていましたが、これは D-1 で対策した「**メールセキュリティスキャナの先読み（プリフェッチ）で状態変更 GET が誤消費される**」問題が再燃します。マジックリンクも GET + 状態変更（`used_at` UPDATE）を伴うため、D-1 確認ページと同じ **フロント（Cloudflare Pages）仲介 + POST verify** に統一しました。

- メールリンク: `{MagicLink:BaseUrl:tenant}/signin/magic-link?token=...`（フロント配信元、GET は safe）
- フロントがトークン抽出 → ユーザー操作で `POST /api/account/magic-link/verify` → 認可コード付きリダイレクト先を返却
- ※ この設計変更に伴う設計書（EcAuthDocs）の訂正は別 PR で対応予定

## 実装

- **`IMagicLinkService` / `MagicLinkService`**
  - 32 byte URL-safe random トークン + SHA-256 ハッシュ保存（平文は DB 非保存、ログは `token_hash` 先頭 8 文字のみ）
  - レート制限（email 5 分 1 回 / IP 1 時間 10 回、DB ベース。`(requested_email_hash, created_at)` / `(requested_ip, created_at)` インデックス活用）
  - Email enumeration 対策（Account 存在有無に関わらず HTTP 200 + 同一メッセージ。不在時もダミー SHA-256 で時間調整、レート制限母数として記録）
  - 単発使用は **Compare-And-Set**（`used_at IS NULL` 条件の原子的 UPDATE、影響行数 1 判定）
  - 検証成功時に `SubjectType.Account` で認可コードを発行（`TokenController` の Account 分岐は実装済みのため流用）
- **`MagicLinkController`**: `POST /api/account/magic-link/request` / `/verify`（CORS は申込 API と同じフロント配信元ポリシーを共用）
- **`MagicLinkCleanupService`**（`IHostedService`）: 期限切れトークンの日次削除（7 日保持）
- **`IEmailService.SendMagicLoginLinkAsync`** 追加
- マジックリンク URL の基底は **`MagicLink:BaseUrl:{tenant}`**（フロント配信元、Host 偽装対策でフォールバックなし）。`.env.dev.tpl` に追加（本番 Terraform app_settings 注入は別 PR）

## テスト戦略（テスト基盤の判断）

単発使用の**並行下のアトミック性**は SQL Server の単一 UPDATE 文のセマンティクスに依存し、ユニットテストでは再現できません（InMemory は `ExecuteUpdate` 非対応、SQLite は本番と別エンジン + `DateTimeOffset` 翻訳不可 + 脆弱性依存を招く）。そこで:

- **本番は `ExecuteUpdate` でアトミック維持**。消費処理を `TryConsumeTokenAsync` シームに切り出し、ユニットテストでは逐次の単発契約のみ override で検証
- **実 race は実 DB（統合 / E2E、Phase F）で担保**
- ユニットテストは InMemory で検証可能なものに集中（URL 構築・レート制限境界・Email enumeration 挙動・逐次の単発/期限切れ拒否・認可コード配線・クロステナント拒否）

→ SQLite・本番 DbContext へのテスト都合の分岐・脆弱性依存をすべて回避。

## 検証

- `dotnet build EcAuth.sln`: 0 エラー
- `dotnet test`: **635 件 pass**（既存 624 + 新規 11）
- `dotnet ef migrations has-pending-model-changes`: 差分なし（`MagicLoginToken` は Phase A 統合マイグレーションに既存）

## 残タスク（別 PR）

- EcAuthDocs: 設計書のマジックリンクフロー訂正（IdP 直 GET → フロント仲介 + POST）
- ecauth-infrastructure: 本番 `app_settings` に `MagicLink__BaseUrl__accounts` / `__stg_accounts` を注入
- Phase F: stg-accounts での E2E（実 race / 単発使用の実 DB 検証含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * マジックリンクログイン用API（リクエスト/検証）を追加し、検証結果に基づくリダイレクト情報を返します。
  * マジックリンク基底URLのローカル開発向け設定を追加しました。
* **Bug Fixes**
  * Cloudflare 経由の実クライアントIP取得を改善しました。
* **Tests**
  * マジックリンクの要求・検証を網羅するテストを追加しました。
* **Chores**
  * 期限切れトークンの定期クリーンアップとマジックリンク関連設定を実装しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->