### PR TITLE
fix: Claude Code Review のコメント投稿者を claude[bot] に変更

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -57,7 +57,6 @@ jobs:
         uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1 # v1.0.140
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: |


### PR DESCRIPTION
## 概要

`claude-code-review.yml` から `github_token: ${{ secrets.GITHUB_TOKEN }}` を削除し、レビューコメントの投稿者を `github-actions[bot]` から `claude[bot]` に変更します。

## 背景

`anthropics/claude-code-action` に `github_token` を渡すと、その標準トークン（`github-actions[bot]`）名義でコメントが投稿される。公式ドキュメント [`docs/usage.md`](https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md) の `github_token` 項には次の注記がある:

> GitHub token for Claude to operate with. **Only include this if you're connecting a custom GitHub app of your own!**

EcAuth org には Claude GitHub App がインストール済みのため、`github_token` を渡さなければ action が App のインストールトークンを自動取得し、`claude[bot]` 名義で投稿される。

## 影響

- 行単位（inline）レビューコメントは App トークンでも従来どおり投稿可能（`createReviewComment` は `pull-requests: write` で動作）。
- `allowed_non_write_users` は未使用のため、`github_token` 必須となる例外には該当しない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)