### PR TITLE
test: claude-code-review の投稿者名義検証（検証後クローズ）

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,5 @@ docker compose -p ec-auth --ansi never exec db /opt/mssql-tools18/bin/sqlcmd -S 
 ## See Also
 
 - https://github.com/efcore/EFCore.FSharp/blob/master/GETTING_STARTED.md
+
+<!-- claude review author 検証用の一時追記（このPRはマージしません） -->

--- a/review-verification/Sample.cs
+++ b/review-verification/Sample.cs
@@ -1,0 +1,9 @@
+// 一時検証用ファイル（このPRはマージしません / ビルド対象外パス）
+public class ReviewVerificationSample
+{
+    public string GetValue(string input)
+    {
+        // 意図的な問題: null チェックなし・マジックナンバー・範囲外の可能性
+        return input.ToString().Substring(0, 100);
+    }
+}


### PR DESCRIPTION
main マージ済みの `claude-code-review.yml`（github_token 削除済み）で、レビューコメントが `claude[bot]` 名義になるかを検証するための一時 PR。検証後にクローズします。