### PR TITLE
fix: 起動シーダーログの App Insights 出力 + ForwardedHeaders scheme 復元 (#415)

### DIFF
--- a/IdentityProvider/Program.cs
+++ b/IdentityProvider/Program.cs
@@ -33,7 +33,13 @@ builder.Services.Configure<ForwardedHeadersOptions>(options =>
     var cloudflare = builder.Configuration.GetSection(CloudflareOptions.SectionName)
         .Get<CloudflareOptions>() ?? new CloudflareOptions();
 
-    options.ForwardedHeaders = ForwardedHeaders.XForwardedFor;
+    // XForwardedProto を含めないと、TLS 終端（Cloudflare / Azure フロントエンド）配下で
+    // リクエスト scheme が http のままになり、OIDC discovery の issuer / jwks_uri が http:// で
+    // 生成される（→ JWKS が http→https リダイレクト 301 を返しフェデレーションが壊れる）。
+    // このオプションは Azure App Service が自動有効化する ForwardedHeaders ミドルウェア
+    // （ASPNETCORE_FORWARDEDHEADERS_ENABLED）と明示 UseForwardedHeaders() の双方に適用されるため、
+    // XForwardedFor だけに絞ると scheme 復元（既定の Proto 処理）まで無効化してしまう点に注意。
+    options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
     // Cloudflare は実クライアント IP を CF-Connecting-IP に単一値で格納する（X-Forwarded-For は多段で連なる）。
     options.ForwardedForHeaderName = "CF-Connecting-IP";
     // 既知プロキシ（Cloudflare エッジ）である限り遡る。信頼は KnownIPNetworks で制御する。

--- a/IdentityProvider/Program.cs
+++ b/IdentityProvider/Program.cs
@@ -11,6 +11,8 @@ using Azure.Monitor.OpenTelemetry.AspNetCore;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.EntityFrameworkCore;
 using OpenTelemetry;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Trace;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -223,6 +225,20 @@ using (var scope = app.Services.CreateScope())
             logger.LogError(ex, "DbInitializer failed. Continuing startup in Production environment.");
         }
     }
+}
+
+// 起動時シーダー（DbInitializer / OrganizationClientSeeder 等）のログ・トレースは app.Run() より前、
+// すなわち OpenTelemetry のバッチ送信（BatchExportProcessor の遅延フラッシュ）が回り切る前の区間で
+// 発生する。デプロイ起動時にプロセスが入れ替わると、これら起動診断ログ（シーダーの実行/スキップ/
+// B2C→B2B 補正/失敗）がフラッシュ前に失われ、本番 App Insights に出ない。
+// （Issue #415: 起動ログが本番テレメトリに現れず、シーダーが「実行されたが補正しなかった」のか
+//  「そもそも実行されていない」のかを切り分けられなかった問題への対応）
+// シード完了直後に明示フラッシュして、起動診断ログを確実にエクスポートする。
+// 接続文字列がある場合のみ OpenTelemetry を有効化しているため、同条件でのみプロバイダを解決する。
+if (!string.IsNullOrWhiteSpace(appInsightsConnectionString))
+{
+    app.Services.GetService<LoggerProvider>()?.ForceFlush();
+    app.Services.GetService<TracerProvider>()?.ForceFlush();
 }
 
 // Configure the HTTP request pipeline.


### PR DESCRIPTION
## 概要

Issue #415 の付随問題「本番で startup/シーダーログが App Insights に出ない」に対応する。検証過程で、別途 main に混入していた OIDC scheme リグレッション（PR #418 由来）も発見・修正した。

## 変更内容（`EcAuth/IdentityProvider/Program.cs`）

### 1. 起動シーダーログを App Insights へ確実にエクスポート（本題: #415）

`DbInitializer` / `OrganizationClientSeeder` の起動診断ログ（実行/スキップ/`B2C→B2B` 補正/失敗）が本番 App Insights に現れず、シーダーが「実行されたが補正しなかった」のか「そもそも実行されていない」のか切り分けられなかった。

- 真因はログレベルではない（リクエスト処理時の Information ログは現に出ている）。起動時シーダーのログは `app.Run()` **より前** = OpenTelemetry のバッチ送信が回り切る前の区間で発生し、デプロイ起動時のプロセス入れ替わりでフラッシュ前に失われていた。
- シード完了直後に `LoggerProvider` / `TracerProvider` を明示 `ForceFlush()`。フラッシュは `try/catch` 外に配置し、本番で握り潰さず続行する失敗ログも確実に送信。App Insights 有効時のみプロバイダ解決（ローカル/CI は no-op）。

### 2. ForwardedHeaders に `XForwardedProto` を追加（検証中に発見した main リグレッション）

PR #418 が CF-Connecting-IP 復元のため ForwardedHeaders を `XForwardedFor` のみで明示構成した結果、TLS 終端（Cloudflare / Azure フロントエンド）配下で scheme が http のままになり、OIDC discovery の `issuer` / `jwks_uri` が `http://` で生成 → JWKS が 301 を返し staging verify が失敗していた。

- この `Configure<ForwardedHeadersOptions>` は Azure 自動有効化の ForwardedHeaders ミドルウェア（`ASPNETCORE_FORWARDEDHEADERS_ENABLED`）にも適用されるため、`XForwardedFor` だけに絞ると既定の Proto 処理（scheme 復元）まで無効化していた。
- `XForwardedFor | XForwardedProto` とし scheme=https を復元。
- **本番影響あり**: 本番も Cloudflare/Azure 配下のため、未修正だと本番デプロイで OIDC discovery/JWKS が壊れる実バグだった。

## 検証

- [x] `dotnet build -c Release` エラー 0
- [x] staging verify 失敗の真因を特定（08:09 main=`issuer=https` success → 08:27 #418 マージ後 `issuer=http`/JWKS 301 failure）。PR #429 の変更とは独立。
- [ ] staging 再デプロイで verify green（issuer=https / JWKS 200）を確認
- [ ] production デプロイ後、App Insights に `DbInitializer: ...` / `SubjectType を B2C から B2B へ補正しました` 等の起動ログが出ることを確認（#415 本題の検証は本番のみ。staging は App Insights 無効）

## スコープ外（Issue #415 の別受け入れ条件）

- デプロイ後に手動再起動なしで `subject_type` 補正が確実に走る保証（restart / verify ステップ）

Refs #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)