### PR TITLE
fix: 起動シーダーログを App Insights へ確実にエクスポート (#415)

### DIFF
--- a/IdentityProvider/Program.cs
+++ b/IdentityProvider/Program.cs
@@ -224,10 +224,15 @@ using (var scope = app.Services.CreateScope())
 //  「そもそも実行されていない」のかを切り分けられなかった問題への対応）
 // シード完了直後に明示フラッシュして、起動診断ログを確実にエクスポートする。
 // 接続文字列がある場合のみ OpenTelemetry を有効化しているため、同条件でのみプロバイダを解決する。
+// ForceFlush の既定は Timeout.Infinite（無限待機）。app.Run() 前のこの区間で App Insights 側の
+// 瞬断・遅延が起きると起動が無限ブロックし、コンテナ起動タイムアウト→デプロイ失敗を招きうるため、
+// 有限タイムアウト（5 秒）で best-effort に留める。未送信分は通常の BatchExportProcessor が
+// 背景送信を継続するため、タイムアウトしても即時のログ欠落にはならない。
+const int flushTimeoutMs = 5000;
 if (!string.IsNullOrWhiteSpace(appInsightsConnectionString))
 {
-    app.Services.GetService<LoggerProvider>()?.ForceFlush();
-    app.Services.GetService<TracerProvider>()?.ForceFlush();
+    app.Services.GetService<LoggerProvider>()?.ForceFlush(flushTimeoutMs);
+    app.Services.GetService<TracerProvider>()?.ForceFlush(flushTimeoutMs);
 }
 
 // Configure the HTTP request pipeline.

--- a/IdentityProvider/Program.cs
+++ b/IdentityProvider/Program.cs
@@ -11,6 +11,8 @@ using Azure.Monitor.OpenTelemetry.AspNetCore;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.EntityFrameworkCore;
 using OpenTelemetry;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Trace;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -212,6 +214,20 @@ using (var scope = app.Services.CreateScope())
             logger.LogError(ex, "DbInitializer failed. Continuing startup in Production environment.");
         }
     }
+}
+
+// 起動時シーダー（DbInitializer / OrganizationClientSeeder 等）のログ・トレースは app.Run() より前、
+// すなわち OpenTelemetry のバッチ送信（BatchExportProcessor の遅延フラッシュ）が回り切る前の区間で
+// 発生する。デプロイ起動時にプロセスが入れ替わると、これら起動診断ログ（シーダーの実行/スキップ/
+// B2C→B2B 補正/失敗）がフラッシュ前に失われ、本番 App Insights に出ない。
+// （Issue #415: 起動ログが本番テレメトリに現れず、シーダーが「実行されたが補正しなかった」のか
+//  「そもそも実行されていない」のかを切り分けられなかった問題への対応）
+// シード完了直後に明示フラッシュして、起動診断ログを確実にエクスポートする。
+// 接続文字列がある場合のみ OpenTelemetry を有効化しているため、同条件でのみプロバイダを解決する。
+if (!string.IsNullOrWhiteSpace(appInsightsConnectionString))
+{
+    app.Services.GetService<LoggerProvider>()?.ForceFlush();
+    app.Services.GetService<TracerProvider>()?.ForceFlush();
 }
 
 // Configure the HTTP request pipeline.


### PR DESCRIPTION
## 概要

Issue #415 の付随問題「本番で startup/シーダーログが App Insights に出ない」に対応する。

クローズした PR #429 から、本題のログ修正部分（`ForceFlush`）のみを取り出し、#430（ForwardedHeaders 修正）マージ後の main の上に再ランディングしたもの。#429 の `XForwardedProto` 暫定修正は #430 が正しく置き換えたため本 PR には含めない。

## 背景

`DbInitializer` / `OrganizationClientSeeder` の起動診断ログ（実行/スキップ/`B2C→B2B` 補正/失敗）が本番 App Insights に現れず、シーダーが「実行されたが補正しなかった」のか「そもそも実行されていない」のかをログから切り分けられなかった（Issue #415 本文・コメント参照）。

## 根本原因

- ログレベルではない。リクエスト処理時の Information ログは現に本番 App Insights に出ている（ベースの `appsettings.json` は `Default: Information`）。
- 起動時シーダーのログは `app.Run()` **より前** = OpenTelemetry のバッチ送信（`BatchExportProcessor` の遅延フラッシュ）が回り切る前の区間で発生する。デプロイ起動時にプロセスが入れ替わると、これら起動診断ログがフラッシュ前に失われていた（Error レベルの失敗ログすら欠落していた事実と整合）。

## 変更内容（`IdentityProvider/Program.cs`）

- シード完了直後に OpenTelemetry の `LoggerProvider` / `TracerProvider` を明示 `ForceFlush()`。
- フラッシュはシーダーの `try/catch` ブロック**外**に配置。本番では catch が再スローせず続行するため、シーダー失敗時の `LogError` も確実に送信される。
- App Insights 有効時（接続文字列あり）のみプロバイダを解決。ローカル/CI（接続文字列なし）では `GetService` が `null` → no-op。

## 検証

- [x] `dotnet build -c Release` エラー 0
- [ ] **production** デプロイ後、App Insights に `DbInitializer: ...` / `Client {ClientId} の SubjectType を B2C から B2B へ補正しました` 等の起動ログが出ることを確認（staging は App Insights 無効のため検証不可。#415 本題の検証は本番限定）

## スコープ外（Issue #415 の別受け入れ条件）

- デプロイ後に手動再起動なしで `subject_type` 補正が確実に走る保証（restart / verify ステップ）
- なお調査中に判明した「staging verify が deploy 完了の約 2 秒後に走り、ウォームアップ前の旧コンテナに当たる」構造的問題は別途検討（本 PR の対象外）

## 関連

- 元 PR: #429（クローズ。本 PR が後継）
- 併発リグレッション修正: #430（ForwardedHeaders / issuer=http、マージ済み）

Refs #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)