### PR TITLE
docs: 起動ログの調査方法（AppServiceConsoleLogs）を追記 (#415)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,33 @@ using (TimingScope.Begin("my_step"))
 - `Activity.Current` が null（ローカル開発で Application Insights 未設定など）の場合は no-op
 - ネスト可、各スコープが独立して `step.{name}.elapsed_ms` タグを付与
 
+#### 起動時（`app.Run()` 前）のログは App Insights ではなく `AppServiceConsoleLogs` を見る
+
+**重要**: `DbInitializer` / 各 `Seeder`（`OrganizationClientSeeder` の B2C→B2B 補正など）の起動ログは
+**App Insights の `traces` / `AppTraces` には出ない**。App Insights（OpenTelemetry）のログ送信パイプラインは
+host start（`app.Run()` 内の `TelemetryHostedService.StartAsync`）で初めて起動するため、それより前に走る
+起動コードのログは exporter に届かない（`Microsoft.Hosting.Lifetime` の「Application started」が host start の境界）。
+
+これらの起動ログは **コンテナ stdout（既定の Console ロガー）→ Log Analytics の `AppServiceConsoleLogs`** に出る。
+本番 Web App の診断設定（`ecauth-prod-0e9f509a-diag`）が `AppServiceConsoleLogs` / `AppServiceAppLogs` /
+`AppServiceHTTPLogs` を ワークスペース `ecauth-prod-0e9f509a-insights-law`（ワークスペースベース App Insights の
+バック）へ送る配線を**既に持っている**。したがって起動診断はインフラ変更なしで観測できる。
+
+```kusto
+// 起動シーダー / DbInitializer の実行・補正ログ（Log Analytics ワークスペースに対して実行）
+AppServiceConsoleLogs
+| where TimeGenerated > ago(1d)
+| where ResultDescription has "DbInitializer"
+     or ResultDescription has "SubjectType を"   // B2C→B2B 補正ログ（補正が発火したときのみ出力）
+     or ResultDescription has "Seeder"
+| project TimeGenerated, ResultDescription
+| order by TimeGenerated asc
+```
+
+- 切り分けの原則: 起動・マイグレーション・シーダー等 `app.Run()` 前の診断は **`AppServiceConsoleLogs`**、
+  リクエスト処理時（host start 後）の診断は **`traces` / `AppTraces`**。「App Insights に出ない」と感じたら、
+  まず参照テーブルの取り違えを疑う（起動前ログを App Insights に押し込む `ForceFlush` 等の小細工は不要・無効）。
+
 ### マイグレーション設計ルール
 
 - `migrationBuilder.Sql()` でカラムを参照する UPDATE/INSERT 文を書く場合、`EXEC()` 動的 SQL でラップすること


### PR DESCRIPTION
## 概要

Issue #415 の付随問題（起動ログが App Insights に出ない＝参照テーブルの取り違え）の再発防止として、`CLAUDE.md` の Application Insights セクションにログ調査方法を追記する。

## 追記内容

- 起動時（`app.Run()` 前）の `DbInitializer` / `Seeder` ログは **App Insights `traces` には構造上出ない**（OpenTelemetry のログパイプラインは host start で起動するため）。
- これらは **コンテナ stdout → Log Analytics の `AppServiceConsoleLogs`** に出る。診断設定は既存。
- 起動診断は `AppServiceConsoleLogs`、リクエスト診断は `traces`/`AppTraces` という使い分けと、起動ログ用の KQL を明記。

## 関連

- Issue #415（調査結果は同 Issue のコメント参照）
- 無効だった ForceFlush の revert: #432

Refs #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 起動時ログの確認方法を追記し、`App Insights` ではなくコンソールログで見るべきタイミングを明確化しました。
  * 起動、マイグレーション、シード処理前後でのログの見分け方と、確認用のクエリ例を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->