### PR TITLE
fix: 起動時のDB一過性未応答でシーダーが全スキップされる問題を修正 (#415)

### DIFF
--- a/IdentityProvider.Test/Data/DbInitializerTests.cs
+++ b/IdentityProvider.Test/Data/DbInitializerTests.cs
@@ -176,6 +176,92 @@ namespace IdentityProvider.Test.Data
             Assert.False(wasExecuted);
         }
 
+        [Fact]
+        public async Task InitializeAsync_WhenDatabaseAvailableAfterRetries_ShouldExecuteSeeders()
+        {
+            // Arrange: 2 回失敗した後に接続確立する
+            var wasExecuted = false;
+            var seeder = new TestSeeder("Migration1", 100, () => wasExecuted = true);
+
+            var seeders = new List<IDbSeeder> { seeder };
+            var initializer = new TestableDbInitializer(
+                seeders,
+                _mockLogger.Object,
+                _mockLoggerFactory.Object,
+                new HashSet<string> { "Migration1" },
+                canConnectResults: new[] { false, false, true });
+
+            var configuration = new ConfigurationBuilder().Build();
+
+            // Act
+            await initializer.InitializeAsync(_context, configuration);
+
+            // Assert: リトライ後にシーダーが実行され、2 回待機している
+            Assert.True(wasExecuted);
+            Assert.Equal(2, initializer.DelayCount);
+        }
+
+        [Fact]
+        public async Task InitializeAsync_WhenDatabaseNeverAvailable_ShouldRetryUpToMaxAttempts()
+        {
+            // Arrange: 常に接続失敗。MaxAttempts=3 に設定
+            var wasExecuted = false;
+            var seeder = new TestSeeder("Migration1", 100, () => wasExecuted = true);
+
+            var seeders = new List<IDbSeeder> { seeder };
+            var initializer = new TestableDbInitializer(
+                seeders,
+                _mockLogger.Object,
+                _mockLoggerFactory.Object,
+                new HashSet<string> { "Migration1" },
+                canConnect: false);
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["DbInitializer:ConnectionRetry:MaxAttempts"] = "3",
+                    ["DbInitializer:ConnectionRetry:DelaySeconds"] = "0",
+                })
+                .Build();
+
+            // Act
+            await initializer.InitializeAsync(_context, configuration);
+
+            // Assert: 全リトライ後もスキップ。試行 3 回のうち待機は 2 回
+            Assert.False(wasExecuted);
+            Assert.Equal(2, initializer.DelayCount);
+        }
+
+        [Fact]
+        public async Task InitializeAsync_WhenDatabaseNotReady_ShouldLogRetryWarning()
+        {
+            // Arrange: 1 回失敗後に接続確立
+            var seeder = new TestSeeder("Migration1", 100, () => { });
+
+            var seeders = new List<IDbSeeder> { seeder };
+            var initializer = new TestableDbInitializer(
+                seeders,
+                _mockLogger.Object,
+                _mockLoggerFactory.Object,
+                new HashSet<string> { "Migration1" },
+                canConnectResults: new[] { false, true });
+
+            var configuration = new ConfigurationBuilder().Build();
+
+            // Act
+            await initializer.InitializeAsync(_context, configuration);
+
+            // Assert: リトライ待機時に Warning ログが出る（AppServiceConsoleLogs で観測可能）
+            _mockLogger.Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Database not ready")),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+        }
+
         #endregion
 
         #region Error Handling Tests
@@ -285,21 +371,49 @@ namespace IdentityProvider.Test.Data
         private class TestableDbInitializer : DbInitializer
         {
             private readonly HashSet<string> _appliedMigrations;
-            private readonly bool _canConnect;
+            // CanConnectAsync の逐次結果。先頭から消費し、尽きたら最後の値を維持する。
+            private readonly Queue<bool> _canConnectResults;
+            private bool _lastCanConnect;
+
+            public int DelayCount { get; private set; }
 
             public TestableDbInitializer(
                 IEnumerable<IDbSeeder> seeders,
                 ILogger<DbInitializer> logger,
                 ILoggerFactory loggerFactory,
                 HashSet<string> appliedMigrations,
-                bool canConnect = true) : base(seeders, logger, loggerFactory)
+                bool canConnect = true)
+                : this(seeders, logger, loggerFactory, appliedMigrations, new[] { canConnect })
+            {
+            }
+
+            public TestableDbInitializer(
+                IEnumerable<IDbSeeder> seeders,
+                ILogger<DbInitializer> logger,
+                ILoggerFactory loggerFactory,
+                HashSet<string> appliedMigrations,
+                IEnumerable<bool> canConnectResults) : base(seeders, logger, loggerFactory)
             {
                 _appliedMigrations = appliedMigrations;
-                _canConnect = canConnect;
+                _canConnectResults = new Queue<bool>(canConnectResults);
+                _lastCanConnect = _canConnectResults.Count > 0 ? _canConnectResults.Peek() : true;
             }
 
             protected override Task<bool> CanConnectAsync(EcAuthDbContext context)
-                => Task.FromResult(_canConnect);
+            {
+                if (_canConnectResults.Count > 0)
+                {
+                    _lastCanConnect = _canConnectResults.Dequeue();
+                }
+                return Task.FromResult(_lastCanConnect);
+            }
+
+            // 実時間の待機を回避しつつ、リトライ回数を検証できるようにする
+            protected override Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken = default)
+            {
+                DelayCount++;
+                return Task.CompletedTask;
+            }
 
             protected override Task<HashSet<string>> GetAppliedMigrationsAsync(EcAuthDbContext context)
                 => Task.FromResult(_appliedMigrations);

--- a/IdentityProvider.Test/Data/DbInitializerTests.cs
+++ b/IdentityProvider.Test/Data/DbInitializerTests.cs
@@ -189,7 +189,7 @@ namespace IdentityProvider.Test.Data
                 _mockLogger.Object,
                 _mockLoggerFactory.Object,
                 new HashSet<string> { "Migration1" },
-                canConnectResults: new[] { false, false, true });
+                canConnectResults: new bool?[] { false, false, true });
 
             var configuration = new ConfigurationBuilder().Build();
 
@@ -244,7 +244,7 @@ namespace IdentityProvider.Test.Data
                 _mockLogger.Object,
                 _mockLoggerFactory.Object,
                 new HashSet<string> { "Migration1" },
-                canConnectResults: new[] { false, true });
+                canConnectResults: new bool?[] { false, true });
 
             var configuration = new ConfigurationBuilder().Build();
 
@@ -260,6 +260,38 @@ namespace IdentityProvider.Test.Data
                     It.IsAny<Exception>(),
                     It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
                 Times.Once);
+        }
+
+        [Fact]
+        public async Task InitializeAsync_WhenProbeTimesOut_ShouldTreatAsNotConnectedAndRetry()
+        {
+            // Arrange: 1 回目は無応答（プローブタイムアウト）、2 回目で接続確立。
+            // null は渡されたトークンがキャンセルされるまでハングする挙動を模擬する。
+            var wasExecuted = false;
+            var seeder = new TestSeeder("Migration1", 100, () => wasExecuted = true);
+
+            var seeders = new List<IDbSeeder> { seeder };
+            var initializer = new TestableDbInitializer(
+                seeders,
+                _mockLogger.Object,
+                _mockLoggerFactory.Object,
+                new HashSet<string> { "Migration1" },
+                canConnectResults: new bool?[] { null, true });
+
+            // プローブタイムアウトを最小値（1 秒）にしてテストを高速化
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["DbInitializer:ConnectionRetry:ProbeTimeoutSeconds"] = "1",
+                })
+                .Build();
+
+            // Act
+            await initializer.InitializeAsync(_context, configuration);
+
+            // Assert: プローブタイムアウトは例外を伝播させず未接続扱いにし、リトライ後に成功する
+            Assert.True(wasExecuted);
+            Assert.Equal(1, initializer.DelayCount);
         }
 
         #endregion
@@ -372,7 +404,9 @@ namespace IdentityProvider.Test.Data
         {
             private readonly HashSet<string> _appliedMigrations;
             // CanConnectAsync の逐次結果。先頭から消費し、尽きたら最後の値を維持する。
-            private readonly Queue<bool> _canConnectResults;
+            // null はプローブタイムアウト（無応答）を模擬し、渡されたトークンが
+            // キャンセルされるまでハングして OperationCanceledException を投げる。
+            private readonly Queue<bool?> _canConnectResults;
             private bool _lastCanConnect;
 
             public int DelayCount { get; private set; }
@@ -383,7 +417,7 @@ namespace IdentityProvider.Test.Data
                 ILoggerFactory loggerFactory,
                 HashSet<string> appliedMigrations,
                 bool canConnect = true)
-                : this(seeders, logger, loggerFactory, appliedMigrations, new[] { canConnect })
+                : this(seeders, logger, loggerFactory, appliedMigrations, new bool?[] { canConnect })
             {
             }
 
@@ -392,20 +426,28 @@ namespace IdentityProvider.Test.Data
                 ILogger<DbInitializer> logger,
                 ILoggerFactory loggerFactory,
                 HashSet<string> appliedMigrations,
-                IEnumerable<bool> canConnectResults) : base(seeders, logger, loggerFactory)
+                IEnumerable<bool?> canConnectResults) : base(seeders, logger, loggerFactory)
             {
                 _appliedMigrations = appliedMigrations;
-                _canConnectResults = new Queue<bool>(canConnectResults);
-                _lastCanConnect = _canConnectResults.Count > 0 ? _canConnectResults.Peek() : true;
+                _canConnectResults = new Queue<bool?>(canConnectResults);
+                _lastCanConnect = false;
             }
 
-            protected override Task<bool> CanConnectAsync(EcAuthDbContext context)
+            protected override async Task<bool> CanConnectAsync(
+                EcAuthDbContext context, CancellationToken cancellationToken = default)
             {
-                if (_canConnectResults.Count > 0)
+                bool? result = _canConnectResults.Count > 0
+                    ? _canConnectResults.Dequeue()
+                    : _lastCanConnect;
+
+                if (result is null)
                 {
-                    _lastCanConnect = _canConnectResults.Dequeue();
+                    // 無応答を模擬: プローブタイムアウト（トークン）で打ち切られるまで待つ
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
                 }
-                return Task.FromResult(_lastCanConnect);
+
+                _lastCanConnect = result ?? false;
+                return _lastCanConnect;
             }
 
             // 実時間の待機を回避しつつ、リトライ回数を検証できるようにする

--- a/IdentityProvider/Data/DbInitializer.cs
+++ b/IdentityProvider/Data/DbInitializer.cs
@@ -12,11 +12,22 @@ public class DbInitializer
     // DB 接続確立待ちのリトライ既定値。
     // デプロイ起動の一瞬だけ DB が未応答だと CanConnectAsync が false を返し、
     // 全シーダー（OrganizationClientSeeder の B2C→B2B 補正含む）がスキップされる事象への対策。
-    // App Service の warmup プローブは起動完了まで約 70 秒待つため、その猶予内でリトライする。
-    // 既定は最大 12 回・間隔 5 秒 = 最大約 55 秒待機。非秘密のチューニング定数のため
-    // 配線（Terraform / CI / .env）には入れず、必要時のみ appsettings/env で上書きする。
-    private const int DefaultMaxConnectionAttempts = 12;
-    private const int DefaultConnectionRetryDelaySeconds = 5;
+    //
+    // 重要: 各 CanConnectAsync は接続確立を待つため、DB が routable だが無応答
+    // （SYN drop 等）の場合、接続文字列の Connect Timeout（既定 15 秒）まで
+    // ブロックしうる。試行回数だけで待機上限を管理すると DB 恒久障害時に
+    // app.Run() 前で数分ブロックし、App Service の起動制限超過でコンテナ再起動
+    // ループを招く（可用性優先の設計「本番はシード失敗でも起動継続」と矛盾）。
+    // → 1 試行あたりの最大ブロック時間を ProbeTimeout（CancellationToken）で縛り、
+    //   最悪起動遅延を「試行あたりのブロック時間」に依らず有界にする。
+    //
+    // 既定: 最大 5 回・間隔 3 秒・各プローブ 3 秒上限 = 最悪 5×3 + 4×3 = 27 秒。
+    // App Service の起動制限内に収めつつ、約 15 秒の一過性未応答窓をカバーする。
+    // 非秘密のチューニング定数のため配線（Terraform / CI / .env）には入れず、
+    // 必要時のみ appsettings/env で上書きする。
+    private const int DefaultMaxConnectionAttempts = 5;
+    private const int DefaultConnectionRetryDelaySeconds = 3;
+    private const int DefaultConnectionProbeTimeoutSeconds = 3;
 
     private readonly IEnumerable<IDbSeeder> _seeders;
     private readonly ILogger<DbInitializer> _logger;
@@ -36,8 +47,13 @@ public class DbInitializer
     /// データベースに接続可能かどうかを確認します。
     /// テスト時にオーバーライドして接続状態を制御できます。
     /// </summary>
-    protected virtual async Task<bool> CanConnectAsync(EcAuthDbContext context)
-        => await context.Database.CanConnectAsync();
+    /// <param name="cancellationToken">
+    /// プローブのタイムアウト用トークン。routable だが無応答の DB で
+    /// 接続確立を無制限に待たないよう、呼び出し側が期限を設定する。
+    /// </param>
+    protected virtual async Task<bool> CanConnectAsync(
+        EcAuthDbContext context, CancellationToken cancellationToken = default)
+        => await context.Database.CanConnectAsync(cancellationToken);
 
     /// <summary>
     /// リトライ間の待機を行います。
@@ -57,6 +73,8 @@ public class DbInitializer
             "DbInitializer:ConnectionRetry:MaxAttempts", DefaultMaxConnectionAttempts);
         var delaySeconds = configuration.GetValue(
             "DbInitializer:ConnectionRetry:DelaySeconds", DefaultConnectionRetryDelaySeconds);
+        var probeTimeoutSeconds = configuration.GetValue(
+            "DbInitializer:ConnectionRetry:ProbeTimeoutSeconds", DefaultConnectionProbeTimeoutSeconds);
 
         // 不正値（0 以下）でも最低 1 回は試行する
         if (maxAttempts < 1)
@@ -67,10 +85,15 @@ public class DbInitializer
         {
             delaySeconds = 0;
         }
+        // プローブタイムアウトは正の値を要求（0 以下だと即キャンセル扱いになるため）
+        if (probeTimeoutSeconds < 1)
+        {
+            probeTimeoutSeconds = 1;
+        }
 
         for (var attempt = 1; attempt <= maxAttempts; attempt++)
         {
-            if (await CanConnectAsync(context))
+            if (await TryConnectAsync(context, TimeSpan.FromSeconds(probeTimeoutSeconds)))
             {
                 return true;
             }
@@ -87,6 +110,25 @@ public class DbInitializer
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// プローブタイムアウト付きで DB 接続可否を判定します。
+    /// routable だが無応答の DB で接続確立が Connect Timeout（既定 15 秒）まで
+    /// ブロックするのを防ぐため、指定時間で打ち切って false 扱いにします。
+    /// </summary>
+    private async Task<bool> TryConnectAsync(EcAuthDbContext context, TimeSpan probeTimeout)
+    {
+        using var cts = new CancellationTokenSource(probeTimeout);
+        try
+        {
+            return await CanConnectAsync(context, cts.Token);
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested)
+        {
+            // プローブがタイムアウト。未接続として扱いリトライへ。
+            return false;
+        }
     }
 
     /// <summary>

--- a/IdentityProvider/Data/DbInitializer.cs
+++ b/IdentityProvider/Data/DbInitializer.cs
@@ -9,6 +9,15 @@ namespace IdentityProvider.Data;
 /// </summary>
 public class DbInitializer
 {
+    // DB 接続確立待ちのリトライ既定値。
+    // デプロイ起動の一瞬だけ DB が未応答だと CanConnectAsync が false を返し、
+    // 全シーダー（OrganizationClientSeeder の B2C→B2B 補正含む）がスキップされる事象への対策。
+    // App Service の warmup プローブは起動完了まで約 70 秒待つため、その猶予内でリトライする。
+    // 既定は最大 12 回・間隔 5 秒 = 最大約 55 秒待機。非秘密のチューニング定数のため
+    // 配線（Terraform / CI / .env）には入れず、必要時のみ appsettings/env で上書きする。
+    private const int DefaultMaxConnectionAttempts = 12;
+    private const int DefaultConnectionRetryDelaySeconds = 5;
+
     private readonly IEnumerable<IDbSeeder> _seeders;
     private readonly ILogger<DbInitializer> _logger;
     private readonly ILoggerFactory _loggerFactory;
@@ -31,6 +40,56 @@ public class DbInitializer
         => await context.Database.CanConnectAsync();
 
     /// <summary>
+    /// リトライ間の待機を行います。
+    /// テスト時にオーバーライドして実時間の待機を回避できます。
+    /// </summary>
+    protected virtual Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken = default)
+        => Task.Delay(delay, cancellationToken);
+
+    /// <summary>
+    /// DB 接続が確立できるまでリトライ付きで待機します。
+    /// デプロイ起動直後の一過性の DB 未応答でシーダーが丸ごとスキップされるのを防ぎます。
+    /// </summary>
+    /// <returns>接続が確立できた場合は true、全リトライ後も確立できなかった場合は false</returns>
+    private async Task<bool> WaitForDatabaseAsync(EcAuthDbContext context, IConfiguration configuration)
+    {
+        var maxAttempts = configuration.GetValue(
+            "DbInitializer:ConnectionRetry:MaxAttempts", DefaultMaxConnectionAttempts);
+        var delaySeconds = configuration.GetValue(
+            "DbInitializer:ConnectionRetry:DelaySeconds", DefaultConnectionRetryDelaySeconds);
+
+        // 不正値（0 以下）でも最低 1 回は試行する
+        if (maxAttempts < 1)
+        {
+            maxAttempts = 1;
+        }
+        if (delaySeconds < 0)
+        {
+            delaySeconds = 0;
+        }
+
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            if (await CanConnectAsync(context))
+            {
+                return true;
+            }
+
+            if (attempt < maxAttempts)
+            {
+                _logger.LogWarning(
+                    "DbInitializer: Database not ready (attempt {Attempt}/{MaxAttempts}), retrying in {Delay}s",
+                    attempt,
+                    maxAttempts,
+                    delaySeconds);
+                await DelayAsync(TimeSpan.FromSeconds(delaySeconds));
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// 適用済みマイグレーションの一覧を取得します。
     /// テスト時にオーバーライドしてマイグレーション状態を制御できます。
     /// </summary>
@@ -47,8 +106,8 @@ public class DbInitializer
         EcAuthDbContext context,
         IConfiguration configuration)
     {
-        // データベース接続確認
-        if (!await CanConnectAsync(context))
+        // データベース接続確認（一過性の未応答に耐えるためリトライ付きで待機）
+        if (!await WaitForDatabaseAsync(context, configuration))
         {
             _logger.LogWarning("DbInitializer: Database is not available. Skipping seed.");
             return;


### PR DESCRIPTION
## 概要

本番デプロイ起動直後の**一瞬だけ DB が未応答**だと、`DbInitializer.InitializeAsync` 冒頭の `CanConnectAsync` が `false` を返し、**全シーダー（`OrganizationClientSeeder` の B2C→B2B 補正含む）が丸ごとスキップ**される事象があった。手動で `az webapp restart` するまで補正が反映されず、B2B パスキーのトークン交換が 400 になっていた（#415）。

実機ログ（`AppServiceConsoleLogs`）で根本原因が確定済み:

```
2026-06-28T01:21:33Z warn: DbInitializer: Database is not available. Skipping seed.
2026-06-28T01:21:43Z       Application started. Press Ctrl+C to shut down.
```

→ 起動の一瞬だけ DB 未応答 → 全スキップ → 直後に DB 復帰（`/healthz` は healthy）。手動再起動時は DB が温まっており `CanConnectAsync=true` で補正が走っていた。

詳細: https://github.com/EcAuth/EcAuth/issues/415#issuecomment-4823846184

## 変更内容

`CanConnectAsync` の単発判定を、リトライ/バックオフ待機を行う `WaitForDatabaseAsync` に置換する。

- **既定値はコード内 `const`**（`MaxAttempts=12` / `DelaySeconds=5` = 最大約 55 秒待機）。App Service の warmup 猶予（約 70 秒）内に収まる。
- `DbInitializer:ConnectionRetry:MaxAttempts` / `DelaySeconds` で任意上書き可（未設定なら既定値、不正値は安全側に補正）。
- リトライ試行を **Warning ログ**で出力 → `AppServiceConsoleLogs` で観測可能。
- 全リトライ後も接続不可なら**従来どおり** Warning + return（握り潰さない挙動を維持）。
- テスト容易性のため `DelayAsync` シームを追加。

### 配線について

リトライ設定は**非秘密のチューニング定数でコード既定値を持つ**ため、Terraform / CI (`staging.yml` / `production.yml`) / `.env.*.tpl` の配線には**入れていません**（`EcAuth/CLAUDE.md` の配線ルールに基づく設計判断。レビュー bot が「4 箇所に追加せよ」と指摘する可能性がありますが、安全な既定値を持つため不要です）。

## テスト計画

- [x] `dotnet build IdentityProvider.Test.csproj` → 0 エラー
- [x] `DbInitializerTests` → 12/12 合格（リトライ成功・全失敗スキップ・Warning ログの新規 3 ケース含む）
- [x] 全ユニットテスト → 644/644 合格（リグレッションなし）
- [ ] staging デプロイ後、手動再起動なしで `subject_type` 補正が走ること（受け入れ条件）
- [ ] B2B パスキー E2E（`verify`）がデプロイ直後に green

## 関連

- Closes #415（受け入れ条件「手動再起動なしで補正が確実に走る」に対応）
- 旧 PR #429（CLOSED）は別アプローチ（ForceFlush、#432 で revert 済み）。本 PR はブランチを切り直した新規実装。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * データベース初期化時に、接続できるまで一定回数リトライして待機するようになりました。
  * 接続が一時的に失敗しても、準備完了後に初期化処理が続行されます。

* **バグ修正**
  * データベース未準備時に初期化が早期終了してシード処理が実行されない問題を改善しました。
  * リトライ中は警告ログが出力されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->