### PR TITLE
feat(account): Phase F - mailpit ベースの Account E2E 検証を追加

### DIFF
--- a/.env.dev.tpl
+++ b/.env.dev.tpl
@@ -103,12 +103,14 @@ STAGING_MOCK_IDP_USERINFO_ENDPOINT=https://localhost:9091/userinfo
 # Organization の code / tenant_name はサブドメイン解決と一致させるため Seeder 側で固定。
 ACCOUNTS_CLIENT_ID=ecauth-admin-console
 ACCOUNTS_CLIENT_SECRET=accounts_client_secret
-ACCOUNTS_ALLOWED_RP_IDS=localhost
+# passkey 登録/認証の E2E は accounts テナントの origin（accounts.ec-auth.io）でページを開くため、
+# rp_id に accounts.ec-auth.io を許可する。localhost も併記して手動検証を許容する。
+ACCOUNTS_ALLOWED_RP_IDS=accounts.ec-auth.io,localhost
 ACCOUNTS_REDIRECT_URI=https://localhost:8081/auth/callback
 
 STG_ACCOUNTS_CLIENT_ID=ecauth-admin-console-stg
 STG_ACCOUNTS_CLIENT_SECRET=stg_accounts_client_secret
-STG_ACCOUNTS_ALLOWED_RP_IDS=localhost
+STG_ACCOUNTS_ALLOWED_RP_IDS=stg-accounts.ec-auth.io,localhost
 STG_ACCOUNTS_REDIRECT_URI=https://localhost:8081/auth/callback
 
 # 申込・マジックリンクのメール送信 (Phase D で使用)。ローカルはダミー値。

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -31,6 +31,18 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
+      # Account 申込・マジックリンクの実メール経路を検証するための SMTP 受信サーバー。
+      # アプリは Email__Provider=Smtp で mailpit:1025 へ送信し、E2E は REST API（8025）で
+      # 本文からトークンを取得する。
+      mailpit:
+        image: axllent/mailpit:latest
+        env:
+          MP_SMTP_AUTH_ACCEPT_ANY: "1"
+          MP_SMTP_AUTH_ALLOW_INSECURE: "1"
+        ports:
+          - 1025:1025
+          - 8025:8025
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -91,6 +103,21 @@ jobs:
           DEV_B2B_USER_EXTERNAL_ID=test-admin
           DEV_B2B_REDIRECT_URI=https://localhost:8081/admin/ecauth/callback
           DEV_B2B_ALLOWED_RP_IDS=localhost
+          # Account 申込フロー（Phase D-1）/ マジックリンク（Phase D-2）の E2E 用。
+          # AccountsOrganizationSeeder が accounts Org + 管理コンソール Client を投入するために必須。
+          # rp_id は passkey 登録のブラウザ origin（localhost）と一致させる。
+          ACCOUNTS_CLIENT_ID=ecauth-admin-console
+          ACCOUNTS_CLIENT_SECRET=accounts_client_secret
+          ACCOUNTS_ALLOWED_RP_IDS=accounts.ec-auth.io,localhost
+          ACCOUNTS_REDIRECT_URI=https://localhost:8081/auth/callback
+          # 確認 URL / マジックリンク URL の基底（テナント別・リクエスト処理時に必須参照）。
+          # 未設定だと SignupService.BuildConfirmUrl / MagicLinkService.BuildMagicLinkUrl が例外で停止する。
+          Signup__ConfirmBaseUrl__accounts=https://localhost:8081
+          MagicLink__BaseUrl__accounts=https://localhost:8081
+          # メール送信は mailpit（SMTP）へ。実メール経路を CI 内で完結させる。
+          Email__Provider=Smtp
+          Smtp__Host=localhost
+          Smtp__Port=1025
           EOF
 
       - name: Set up environment variables

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -53,6 +53,11 @@ jobs:
           # クレデンシャルは含まない。MOCK_IDP_BASE_URL 等の機密は後続 step で
           # secrets から注入する。変数展開を含む値（FEDERATE_OAUTH2_* / STAGING_MOCK_IDP_*_ENDPOINT）は
           # 旧 .env.dist でも除外されていたため、ここでも展開済みの値を後続 step で組み立てる。
+          # 注意: 以下の heredoc は $GITHUB_ENV に追記されるため KEY=value 行のみ許容。
+          # コメント行を混ぜると「Invalid format」で step が失敗する（Account/mailpit 系の
+          # 説明はこのブロック外に置く）。ACCOUNTS_* は AccountsOrganizationSeeder が accounts
+          # Org + 管理コンソール Client を投入するために必須。Email__Provider=Smtp / Smtp__* は
+          # 申込・マジックリンクの実メール経路を mailpit で検証するための切替。
           cat <<'EOF' >> $GITHUB_ENV
           DB_HOST=db
           MIGRATION_DB_HOST=localhost
@@ -103,18 +108,12 @@ jobs:
           DEV_B2B_USER_EXTERNAL_ID=test-admin
           DEV_B2B_REDIRECT_URI=https://localhost:8081/admin/ecauth/callback
           DEV_B2B_ALLOWED_RP_IDS=localhost
-          # Account 申込フロー（Phase D-1）/ マジックリンク（Phase D-2）の E2E 用。
-          # AccountsOrganizationSeeder が accounts Org + 管理コンソール Client を投入するために必須。
-          # rp_id は passkey 登録のブラウザ origin（localhost）と一致させる。
           ACCOUNTS_CLIENT_ID=ecauth-admin-console
           ACCOUNTS_CLIENT_SECRET=accounts_client_secret
           ACCOUNTS_ALLOWED_RP_IDS=accounts.ec-auth.io,localhost
           ACCOUNTS_REDIRECT_URI=https://localhost:8081/auth/callback
-          # 確認 URL / マジックリンク URL の基底（テナント別・リクエスト処理時に必須参照）。
-          # 未設定だと SignupService.BuildConfirmUrl / MagicLinkService.BuildMagicLinkUrl が例外で停止する。
           Signup__ConfirmBaseUrl__accounts=https://localhost:8081
           MagicLink__BaseUrl__accounts=https://localhost:8081
-          # メール送信は mailpit（SMTP）へ。実メール経路を CI 内で完結させる。
           Email__Provider=Smtp
           Smtp__Host=localhost
           Smtp__Port=1025

--- a/E2ETests/playwright.config.ts
+++ b/E2ETests/playwright.config.ts
@@ -48,10 +48,22 @@ export default defineConfig({
       name: 'chromium',
       use: {
         ...devices['Desktop Chrome'],
-        // ローカルDocker環境でのホスト名解決のため（GitHub Actions環境では不要）
-        launchOptions: process.env.CI ? {} : {
-          args: ['--host-resolver-rules=MAP mockopenidprovider:8081 127.0.0.1:9091,MAP mockopenidprovider:8080 127.0.0.1:9090']
-        }
+        // ホスト名解決のマッピング。
+        // - accounts.ec-auth.io: Account 申込フローの passkey 登録/認証で使う accounts テナント
+        //   （3 セグメント以上で TenantMiddleware が tenant=accounts に解決）。CI / ローカル両方で必要。
+        //   WebAuthn の rp_id を origin と一致させ、B2BUser 解決を accounts テナントで行うため、
+        //   passkey ページはこのホストで配信する。
+        // - mockopenidprovider: ローカル Docker 環境の MockIdP 解決（GitHub Actions では不要）。
+        launchOptions: {
+          args: [
+            '--host-resolver-rules=' + [
+              'MAP accounts.ec-auth.io 127.0.0.1',
+              ...(process.env.CI
+                ? []
+                : ['MAP mockopenidprovider:8081 127.0.0.1:9091', 'MAP mockopenidprovider:8080 127.0.0.1:9090']),
+            ].join(','),
+          ],
+        },
       },
     },
 

--- a/E2ETests/tests/helpers/mailpit.ts
+++ b/E2ETests/tests/helpers/mailpit.ts
@@ -1,0 +1,98 @@
+import { APIRequestContext } from '@playwright/test';
+
+/**
+ * mailpit REST API のラッパ。
+ *
+ * Account 申込・マジックリンクの確認/ログイントークンは「メール本文にしか存在しない」
+ * （DB には SHA-256 ハッシュのみ保存）。E2E でフローを完走するため、mailpit が受信した
+ * メール本文からトークンを抽出する。
+ *
+ * mailpit は plain HTTP（既定 http://localhost:8025）で REST API を提供する。
+ *
+ * 注意: mailpit は全 spec で共有される単一インスタンス。Playwright の fullyParallel 実行で
+ * 複数 spec が同時にメールを送るため、**全削除（DELETE /api/v1/messages 全体）は使わず**、
+ * 宛先メールアドレス（run ごとに一意）で検索し、処理済みメッセージは ID 指定で削除する。
+ */
+const MAILPIT_BASE = process.env.MAILPIT_BASE_URL || 'http://localhost:8025';
+
+export interface MailpitMessage {
+  ID: string;
+  /** プレーンテキスト本文 */
+  Text: string;
+  /** HTML 本文 */
+  HTML: string;
+  Subject: string;
+}
+
+/**
+ * 指定した宛先メールアドレス宛の最新メッセージを取得する。
+ * 送信は非同期のため、受信するまで一定間隔でポーリングする。
+ *
+ * @param request Playwright の APIRequestContext
+ * @param toEmail 宛先メールアドレス（完全一致で検索）
+ * @param opts.subjectIncludes 件名に含まれる文字列でさらに絞り込む（同一宛先に複数種のメールが届く場合）
+ * @param opts.timeoutMs 最大待機時間（既定 20000ms）
+ * @param opts.intervalMs ポーリング間隔（既定 500ms）
+ */
+export async function waitForMessage(
+  request: APIRequestContext,
+  toEmail: string,
+  opts: { subjectIncludes?: string; timeoutMs?: number; intervalMs?: number } = {}
+): Promise<MailpitMessage> {
+  const timeoutMs = opts.timeoutMs ?? 20000;
+  const intervalMs = opts.intervalMs ?? 500;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const res = await request.get(`${MAILPIT_BASE}/api/v1/search`, {
+      params: { query: `to:${toEmail}` },
+    });
+    if (res.ok()) {
+      const body = await res.json();
+      const summaries: Array<{ ID: string; Subject?: string }> = Array.isArray(body.messages)
+        ? body.messages
+        : [];
+      // 検索結果は新しい順。件名フィルタがあれば一致する最新を選ぶ。
+      const summary = opts.subjectIncludes
+        ? summaries.find((m) => (m.Subject ?? '').includes(opts.subjectIncludes!))
+        : summaries[0];
+      if (summary) {
+        const detail = await request.get(`${MAILPIT_BASE}/api/v1/message/${summary.ID}`);
+        if (detail.ok()) {
+          return (await detail.json()) as MailpitMessage;
+        }
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+
+  const suffix = opts.subjectIncludes ? `（件名: ${opts.subjectIncludes}）` : '';
+  throw new Error(`Mailpit: ${toEmail} 宛のメール${suffix}が ${timeoutMs}ms 以内に受信されませんでした。`);
+}
+
+/**
+ * 指定した ID のメッセージを削除する（テスト後の後始末）。
+ * 他 spec のメールを消さないよう、必ず処理済みの ID のみを渡すこと。
+ */
+export async function deleteMessages(request: APIRequestContext, ids: string[]): Promise<void> {
+  if (ids.length === 0) {
+    return;
+  }
+  await request.delete(`${MAILPIT_BASE}/api/v1/messages`, {
+    data: { IDs: ids },
+  });
+}
+
+/**
+ * メール本文（プレーンテキスト推奨）から `token=...` クエリの値を抽出して URL デコードする。
+ * 確認 URL（/signup/confirm?token=...）とマジックリンク URL（/signin/magic-link?token=...）の
+ * どちらにも対応する。
+ */
+export function extractToken(body: string, tokenParam: string = 'token'): string {
+  // URL-safe な base64（英数字 + - _ . ~ %）を貪欲に拾い、区切り文字（引用符・空白・タグ・& 等）で止める。
+  const match = body.match(new RegExp(`[?&]${tokenParam}=([^"'&\\s<>\\)]+)`));
+  if (!match) {
+    throw new Error(`メール本文から ${tokenParam} を抽出できませんでした。`);
+  }
+  return decodeURIComponent(match[1]);
+}

--- a/E2ETests/tests/specs/account_magic_link_flow.spec.ts
+++ b/E2ETests/tests/specs/account_magic_link_flow.spec.ts
@@ -1,0 +1,149 @@
+import { test, expect, APIRequestContext, request } from '@playwright/test';
+import { waitForMessage, deleteMessages, extractToken } from '../helpers/mailpit';
+
+/**
+ * マジックリンクログインの E2E テスト（mailpit ベース）。
+ *
+ * 事前に申込 → confirm で Account を作成し、
+ * request → メール（mailpit）→ リンク抽出 → verify → 認可コード → /token → managed_orgs を検証。
+ * さらに異常系（second-use / レート制限）も検証する。
+ *
+ * マジックリンクは UI を介さない純粋な API フローのため、テナント（accounts）解決は
+ * すべて Host ヘッダで行う（パスキーのようなブラウザ操作は不要）。
+ */
+test.describe.serial('マジックリンクログインの E2E テスト', () => {
+  const baseUrl = process.env.E2E_BASE_URL || 'https://localhost:8081';
+  const tokenEndpoint = process.env.E2E_TOKEN_ENDPOINT || `${baseUrl}/v1/token`;
+  const accountsHost = process.env.E2E_ACCOUNTS_HOST || 'accounts.ec-auth.io';
+  const accountsClientId = process.env.ACCOUNTS_CLIENT_ID || 'ecauth-admin-console';
+  const accountsClientSecret = process.env.ACCOUNTS_CLIENT_SECRET || 'accounts_client_secret';
+  const accountsRedirectUri = process.env.ACCOUNTS_REDIRECT_URI || 'https://localhost:8081/auth/callback';
+
+  const runSuffix = `${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+  const email = `e2e-magic-${runSuffix}@example.com`;
+  const productionSiteHost = `magic-${runSuffix}.example.com`;
+  const productionSiteUrl = `https://${productionSiteHost}`;
+  const expectedOrgCode = productionSiteHost.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+
+  const signupSubject = 'お申し込み確認';
+  const magicLinkSubject = 'ログインリンク';
+
+  let apiAccounts: APIRequestContext;
+  let mailpitCtx: APIRequestContext;
+
+  // 後始末で削除するメッセージ ID（他 spec のメールを消さないよう ID 指定で削除）。
+  const messageIds: string[] = [];
+  // 消費テスト用に保持するログイントークン。
+  let magicToken: string;
+
+  test.beforeAll(async () => {
+    apiAccounts = await request.newContext({
+      ignoreHTTPSErrors: true,
+      extraHTTPHeaders: { Host: accountsHost },
+    });
+    mailpitCtx = await request.newContext();
+
+    // 前提: マジックリンク対象の Account を申込フローで作成する。
+    const signupRes = await apiAccounts.post(`${baseUrl}/api/signup/request`, {
+      data: {
+        email,
+        organization_name: `E2E Magic Org ${runSuffix}`,
+        contact_name: 'E2E Tester',
+        production_site_url: productionSiteUrl,
+        ec_cube_version: '4',
+      },
+    });
+    expect(signupRes.status()).toBe(202);
+
+    const confirmMail = await waitForMessage(mailpitCtx, email, { subjectIncludes: signupSubject });
+    messageIds.push(confirmMail.ID);
+    const confirmToken = extractToken(confirmMail.Text || confirmMail.HTML);
+
+    const confirmRes = await apiAccounts.post(`${baseUrl}/api/signup/confirm`, {
+      data: { token: confirmToken },
+    });
+    expect(confirmRes.status()).toBe(200);
+  });
+
+  test.afterAll(async () => {
+    await deleteMessages(mailpitCtx, messageIds);
+    await apiAccounts?.dispose();
+    await mailpitCtx?.dispose();
+  });
+
+  test('マジックリンク要求 → メール → verify → 認可コード → トークン + managed_orgs', async () => {
+    test.setTimeout(30000);
+
+    const reqRes = await apiAccounts.post(`${baseUrl}/api/account/magic-link/request`, {
+      data: { email },
+    });
+    // Email enumeration 対策により、常に 200 を返す。
+    expect(reqRes.status()).toBe(200);
+
+    const mail = await waitForMessage(mailpitCtx, email, { subjectIncludes: magicLinkSubject });
+    messageIds.push(mail.ID);
+    magicToken = extractToken(mail.Text || mail.HTML);
+    expect(magicToken.length).toBeGreaterThan(10);
+
+    const verifyRes = await apiAccounts.post(`${baseUrl}/api/account/magic-link/verify`, {
+      data: { token: magicToken },
+    });
+    console.log('Magic-link verify status:', verifyRes.status());
+    const verifyBody = await verifyRes.json();
+    if (verifyRes.status() !== 200) {
+      console.log('Magic-link verify body:', JSON.stringify(verifyBody));
+    }
+    expect(verifyRes.status()).toBe(200);
+    expect(verifyBody.location).toBeTruthy();
+
+    const location = new URL(verifyBody.location);
+    const code = location.searchParams.get('code')!;
+    expect(code).toBeTruthy();
+
+    const tokenRes = await apiAccounts.post(tokenEndpoint, {
+      form: {
+        client_id: accountsClientId,
+        client_secret: accountsClientSecret,
+        code,
+        redirect_uri: accountsRedirectUri,
+        grant_type: 'authorization_code',
+        scope: 'openid',
+      },
+    });
+    console.log('Token status:', tokenRes.status());
+    const tokenBody = await tokenRes.json();
+    if (tokenRes.status() !== 200) {
+      console.log('Token body:', JSON.stringify(tokenBody));
+    }
+    expect(tokenRes.status()).toBe(200);
+    expect(tokenBody.access_token).toBeTruthy();
+    expect(tokenBody.id_token).toBeTruthy();
+
+    const idPayload = JSON.parse(Buffer.from(tokenBody.id_token.split('.')[1], 'base64url').toString());
+    const managedOrgs = idPayload.managed_orgs;
+    expect(Array.isArray(managedOrgs)).toBe(true);
+    const owned = managedOrgs.find((o: { code: string }) => o.code === expectedOrgCode);
+    expect(owned).toBeTruthy();
+    expect(owned.role).toBe('owner');
+  });
+
+  test('single-use: 消費済みトークンの再 verify は失敗する', async () => {
+    expect(magicToken).toBeTruthy();
+
+    const res = await apiAccounts.post(`${baseUrl}/api/account/magic-link/verify`, {
+      data: { token: magicToken },
+    });
+    console.log('Second-use verify status:', res.status());
+    // Compare-And-Set により消費済みトークンは再利用不可（200 にはならない）。
+    expect(res.status()).not.toBe(200);
+  });
+
+  test('rate limit: 直近要求済みの同一メールへの再要求は 429', async () => {
+    const res = await apiAccounts.post(`${baseUrl}/api/account/magic-link/request`, {
+      data: { email },
+    });
+    console.log('Rate-limited request status:', res.status());
+    // 同一メールは 5 分に 1 回の制限。beforeAll 直後の happy path で 1 回要求済みのため 429。
+    expect(res.status()).toBe(429);
+  });
+});

--- a/E2ETests/tests/specs/account_signup_flow.spec.ts
+++ b/E2ETests/tests/specs/account_signup_flow.spec.ts
@@ -1,0 +1,219 @@
+import { test, expect, BrowserContext, Page, APIRequestContext, request } from '@playwright/test';
+import { randomUUID } from 'crypto';
+import { waitForMessage, extractToken, deleteMessages } from '../helpers/mailpit';
+
+/**
+ * Account 申込フローの E2E テスト（mailpit ベース）。
+ *
+ * 申込 → 確認メール（mailpit）→ トークン抽出 → /api/signup/confirm → Account 作成 →
+ * パスキー登録（既存 B2B 仮想認証器を流用）→ 認証 → 認可コード → /token → managed_orgs 検証。
+ *
+ * テナント解決:
+ *   - /api/signup/* と /token はテナント（accounts）に依存するため Host ヘッダを付与する
+ *     （TenantMiddleware は host のセグメント数が 3 以上のときのみ先頭をテナント名にする）。
+ *   - パスキー register/authenticate は Client の Organization 経由で解決され（IgnoreQueryFilters）、
+ *     リクエストのテナントに依存しない。よってブラウザは localhost のまま rp_id=localhost で動く。
+ */
+test.describe.serial('Account 申込フローの E2E テスト', () => {
+  const baseUrl = process.env.E2E_BASE_URL || 'https://localhost:8081';
+  const tokenEndpoint = process.env.E2E_TOKEN_ENDPOINT || `${baseUrl}/v1/token`;
+
+  // accounts テナントに解決させる 3 セグメント以上の Host。
+  // TenantMiddleware は host セグメント数が 3 以上のときのみ先頭をテナント名にする。
+  const accountsHost = process.env.E2E_ACCOUNTS_HOST || 'accounts.ec-auth.io';
+  // passkey ページの配信元。playwright.config.ts の --host-resolver-rules で
+  // accounts.ec-auth.io → 127.0.0.1 にマップ済み。ページの fetch は tenant=accounts に解決され、
+  // WebAuthn の rp_id を origin（accountsHost）と一致させられる。
+  const accountsPageBaseUrl = process.env.E2E_ACCOUNTS_PAGE_URL || `https://${accountsHost}:8081`;
+
+  // Account 管理コンソール Client（AccountsOrganizationSeeder が accounts Org に投入）。
+  const accountsClientId = process.env.ACCOUNTS_CLIENT_ID || 'ecauth-admin-console';
+  const accountsClientSecret = process.env.ACCOUNTS_CLIENT_SECRET || 'accounts_client_secret';
+  // rp_id は passkey ページの origin（accountsHost）と一致させる。accounts Client の
+  // AllowedRpIds に accountsHost を含めておく必要がある（ACCOUNTS_ALLOWED_RP_IDS）。
+  const accountsRpId = process.env.E2E_ACCOUNTS_RP_ID || accountsHost;
+  const accountsRedirectUri = process.env.ACCOUNTS_REDIRECT_URI || 'https://localhost:8081/auth/callback';
+
+  // Run ごとに一意化（前回 run の残存データとの衝突を回避）。
+  const runSuffix = `${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+  const email = `e2e-signup-${runSuffix}@example.com`;
+  const organizationName = `E2E Signup Org ${runSuffix}`;
+  // 顧客 Org の code は site host から導出される（[^a-z0-9]+ → '-'）。一意な host で衝突回避。
+  const productionSiteHost = `e2e-${runSuffix}.example.com`;
+  const productionSiteUrl = `https://${productionSiteHost}`;
+  const expectedOrgCode = productionSiteHost.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+
+  // register/authenticate は external_id フォールバックで既存 Account の B2BUser に解決させる。
+  // external_id はサーバー側で ExternalIdHasher.Hash されるため、申込メールと同じ生 email を渡す。
+  const b2bSubject = randomUUID();
+  const deviceName = 'E2E Signup Device';
+
+  let apiAccounts: APIRequestContext; // Host=accounts を付与した API コンテキスト
+  let mailpitCtx: APIRequestContext; // mailpit REST 用（http）
+  let context: BrowserContext;
+  let page: Page;
+
+  let confirmToken: string;
+  let authorizationCode: string;
+  const messageIds: string[] = [];
+
+  test.beforeAll(async ({ browser }) => {
+    apiAccounts = await request.newContext({
+      ignoreHTTPSErrors: true,
+      extraHTTPHeaders: { Host: accountsHost },
+    });
+    mailpitCtx = await request.newContext();
+
+    // passkey ページは accounts テナントの origin で開く（fetch が tenant=accounts に解決され、
+    // 申込で作った accounts org の B2BUser を external_id で引き当てられる）。
+    context = await browser.newContext({ ignoreHTTPSErrors: true });
+    await context.credentials.install();
+    page = await context.newPage();
+    await page.goto(`${accountsPageBaseUrl}/b2b-passkey-test.html`);
+    await page.waitForLoadState('domcontentloaded');
+  });
+
+  test.afterAll(async () => {
+    await deleteMessages(mailpitCtx, messageIds);
+    await apiAccounts?.dispose();
+    await mailpitCtx?.dispose();
+    await context?.close();
+  });
+
+  test('申込リクエスト（202 Accepted）', async () => {
+    const response = await apiAccounts.post(`${baseUrl}/api/signup/request`, {
+      data: {
+        email,
+        organization_name: organizationName,
+        contact_name: 'E2E Tester',
+        production_site_url: productionSiteUrl,
+        ec_cube_version: '4',
+      },
+    });
+
+    console.log('Signup request status:', response.status());
+    if (response.status() !== 202) {
+      console.log('Signup request body:', await response.text());
+    }
+    expect(response.status()).toBe(202);
+  });
+
+  test('確認メール受信 → トークン抽出 → confirm（200）', async () => {
+    test.setTimeout(30000);
+
+    const message = await waitForMessage(mailpitCtx, email, { subjectIncludes: 'お申し込み確認' });
+    messageIds.push(message.ID);
+    expect(message.Subject).toContain('お申し込み確認');
+
+    confirmToken = extractToken(message.Text || message.HTML);
+    expect(confirmToken.length).toBeGreaterThan(10);
+
+    const response = await apiAccounts.post(`${baseUrl}/api/signup/confirm`, {
+      data: { token: confirmToken },
+    });
+
+    console.log('Confirm status:', response.status());
+    const body = await response.json();
+    console.log('Confirm body:', JSON.stringify(body));
+    expect(response.status()).toBe(200);
+    expect(body.email).toBe(email);
+  });
+
+  test('パスキー登録（既存 Account を external_id で解決）', async () => {
+    test.setTimeout(30000);
+
+    await page.fill('#clientId', accountsClientId);
+    await page.fill('#clientSecret', accountsClientSecret);
+    await page.fill('#rpId', accountsRpId);
+    await page.fill('#b2bSubject', b2bSubject);
+    await page.fill('#externalId', email);
+    await page.fill('#redirectUri', accountsRedirectUri);
+    await page.fill('#displayName', organizationName);
+    await page.fill('#deviceName', deviceName);
+
+    // サーバーが返す timeout=0 を上書き（既存 B2B テストと同じ対処）。
+    await page.evaluate(() => {
+      const originalCreate = navigator.credentials.create.bind(navigator.credentials);
+      navigator.credentials.create = (options?: CredentialCreationOptions) => {
+        if (options?.publicKey && (!options.publicKey.timeout || options.publicKey.timeout === 0)) {
+          options.publicKey.timeout = 60000;
+        }
+        return originalCreate(options);
+      };
+      const originalGet = navigator.credentials.get.bind(navigator.credentials);
+      navigator.credentials.get = (options?: CredentialRequestOptions) => {
+        if (options?.publicKey && (!options.publicKey.timeout || options.publicKey.timeout === 0)) {
+          options.publicKey.timeout = 60000;
+        }
+        return originalGet(options);
+      };
+    });
+
+    await page.click('button:has-text("Register New Passkey")');
+
+    const registerResult = page.locator('#registerResult');
+    await expect(registerResult).toBeVisible({ timeout: 15000 });
+
+    const resultClass = await registerResult.getAttribute('class');
+    if (resultClass?.includes('error')) {
+      console.log('Register error:', await registerResult.textContent());
+      console.log('Debug log:', (await page.locator('#debugLog').textContent())?.substring(0, 2000));
+    }
+    await expect(registerResult).toHaveClass(/success/, { timeout: 15000 });
+  });
+
+  test('パスキー認証 → 認可コード取得', async () => {
+    test.setTimeout(30000);
+
+    await page.fill('#state', `e2e-signup-state-${Date.now()}`);
+    await page.click('button:has-text("Authenticate with Passkey")');
+
+    const authenticateResult = page.locator('#authenticateResult');
+    await expect(authenticateResult).toBeVisible({ timeout: 15000 });
+    await expect(authenticateResult).toHaveClass(/success/, { timeout: 15000 });
+
+    const preContent = await authenticateResult.locator('pre').textContent();
+    const responseData = JSON.parse(preContent!);
+    const redirectUrl = new URL(responseData.redirect_url);
+    authorizationCode = redirectUrl.searchParams.get('code')!;
+    expect(authorizationCode).toBeTruthy();
+  });
+
+  test('トークン交換 → managed_orgs claim 検証', async () => {
+    expect(authorizationCode).toBeTruthy();
+
+    const response = await apiAccounts.post(tokenEndpoint, {
+      form: {
+        client_id: accountsClientId,
+        client_secret: accountsClientSecret,
+        code: authorizationCode,
+        redirect_uri: accountsRedirectUri,
+        grant_type: 'authorization_code',
+        scope: 'openid',
+      },
+    });
+
+    console.log('Token status:', response.status());
+    const body = await response.json();
+    if (response.status() !== 200) {
+      console.log('Token body:', JSON.stringify(body));
+    }
+    expect(response.status()).toBe(200);
+    expect(body.access_token).toBeTruthy();
+    expect(body.id_token).toBeTruthy();
+
+    // id_token / access_token の payload をデコードして managed_orgs を検証する。
+    const idPayload = JSON.parse(Buffer.from(body.id_token.split('.')[1], 'base64url').toString());
+    console.log('id_token payload:', JSON.stringify(idPayload, null, 2));
+
+    const managedOrgs = idPayload.managed_orgs;
+    expect(Array.isArray(managedOrgs)).toBe(true);
+    expect(managedOrgs.length).toBeGreaterThanOrEqual(1);
+
+    // 申込で作られた顧客 Org が owner ロールで含まれること。
+    const owned = managedOrgs.find((o: { code: string }) => o.code === expectedOrgCode);
+    expect(owned).toBeTruthy();
+    expect(owned.role).toBe('owner');
+    expect(typeof owned.org_id).toBe('number');
+  });
+});

--- a/IdentityProvider.Test/Services/EmailTemplatesTests.cs
+++ b/IdentityProvider.Test/Services/EmailTemplatesTests.cs
@@ -1,0 +1,59 @@
+using IdentityProvider.Services;
+using Xunit;
+
+namespace IdentityProvider.Test.Services
+{
+    /// <summary>
+    /// メール本文の共通テンプレート（<see cref="EmailTemplates"/>）の検証。
+    /// SendGrid / SMTP の両プロバイダがこの生成結果を共有するため、本文のドリフトを
+    /// このテストで固定する。
+    /// </summary>
+    public class EmailTemplatesTests
+    {
+        [Fact]
+        public void BuildSignupConfirmation_件名と確認URLを含む()
+        {
+            var content = EmailTemplates.BuildSignupConfirmation("テスト商店", "https://accounts.ec-auth.io/signup/confirm?token=abc123");
+
+            Assert.Equal("【EcAuth】お申し込み確認のお願い", content.Subject);
+            Assert.Contains("テスト商店", content.PlainText);
+            Assert.Contains("https://accounts.ec-auth.io/signup/confirm?token=abc123", content.PlainText);
+            Assert.Contains("https://accounts.ec-auth.io/signup/confirm?token=abc123", content.Html);
+            // HTML では anchor として埋め込まれる
+            Assert.Contains("<a href=", content.Html);
+        }
+
+        [Fact]
+        public void BuildSignupConfirmation_組織名が空なら既定表記に置換される()
+        {
+            var content = EmailTemplates.BuildSignupConfirmation("  ", "https://example.com/signup/confirm?token=x");
+
+            Assert.Contains("ご登録の組織", content.PlainText);
+            Assert.Contains("ご登録の組織", content.Html);
+        }
+
+        [Fact]
+        public void BuildSignupConfirmation_HTML本文で特殊文字がエスケープされる()
+        {
+            // 組織名・URL に含まれる特殊文字が HTML エスケープされ、生の < > & が残らないこと。
+            var content = EmailTemplates.BuildSignupConfirmation("A&B <Shop>", "https://example.com/confirm?token=a&b=c");
+
+            Assert.Contains("A&amp;B &lt;Shop&gt;", content.Html);
+            Assert.DoesNotContain("<Shop>", content.Html);
+            // プレーンテキストはエスケープしない（そのまま）
+            Assert.Contains("A&B <Shop>", content.PlainText);
+        }
+
+        [Fact]
+        public void BuildMagicLoginLink_件名とログインURLを含む()
+        {
+            var content = EmailTemplates.BuildMagicLoginLink("https://ec-auth.io/signin/magic-link?token=xyz789");
+
+            Assert.Equal("【EcAuth】ログインリンクのお知らせ", content.Subject);
+            Assert.Contains("https://ec-auth.io/signin/magic-link?token=xyz789", content.PlainText);
+            Assert.Contains("https://ec-auth.io/signin/magic-link?token=xyz789", content.Html);
+            Assert.Contains("10 分", content.PlainText);
+            Assert.Contains("一度のみ", content.PlainText);
+        }
+    }
+}

--- a/IdentityProvider/IdentityProvider.csproj
+++ b/IdentityProvider/IdentityProvider.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.5.0" />
     <PackageReference Include="DotNetEnv" Version="3.2.0" />
     <PackageReference Include="Fido2" Version="4.0.1" />
+    <PackageReference Include="MailKit" Version="4.14.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.6">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/IdentityProvider/Program.cs
+++ b/IdentityProvider/Program.cs
@@ -67,7 +67,18 @@ builder.Services.AddScoped<IB2BPasskeyService, B2BPasskeyService>();
 
 // Account 申込フロー（Phase D-1）関連サービス
 builder.Services.AddScoped<ISignupService, SignupService>();
-builder.Services.AddScoped<IEmailService, SendGridEmailService>();
+// メール送信プロバイダは Email:Provider で切替。既定は本番 / staging 用の SendGrid（HTTP API）。
+// ローカル開発 / CI E2E では Email:Provider=Smtp で MailKit ベースの SmtpEmailService に切替え、
+// mailpit（Smtp:Host / Smtp:Port）へ送信して実メール経路を検証する。
+var emailProvider = builder.Configuration["Email:Provider"];
+if (string.Equals(emailProvider, "Smtp", StringComparison.OrdinalIgnoreCase))
+{
+    builder.Services.AddScoped<IEmailService, SmtpEmailService>();
+}
+else
+{
+    builder.Services.AddScoped<IEmailService, SendGridEmailService>();
+}
 // ブロックリストは不変のため singleton 登録（DisposableEmailChecker の設計）
 builder.Services.AddSingleton<IDisposableEmailChecker, DisposableEmailChecker>();
 

--- a/IdentityProvider/Services/EmailTemplates.cs
+++ b/IdentityProvider/Services/EmailTemplates.cs
@@ -1,0 +1,79 @@
+using System.Net;
+
+namespace IdentityProvider.Services
+{
+    /// <summary>
+    /// メール本文（件名・プレーンテキスト・HTML）の生成を一元管理する。
+    /// <see cref="SendGridEmailService"/>（本番 / staging）と <see cref="SmtpEmailService"/>
+    /// （ローカル開発 / CI E2E）の両プロバイダが同一の本文を送信できるよう、
+    /// 文面をここに集約してドリフトを防ぐ。
+    /// </summary>
+    public static class EmailTemplates
+    {
+        /// <summary>件名・プレーンテキスト・HTML をまとめて表す。</summary>
+        public readonly record struct EmailContent(string Subject, string PlainText, string Html);
+
+        /// <summary>
+        /// Account 申込確認メールの本文を生成する。
+        /// </summary>
+        /// <param name="organizationName">申込対象の Organization 名（空の場合は既定表記に置換）</param>
+        /// <param name="confirmUrl">申込確認用 URL</param>
+        public static EmailContent BuildSignupConfirmation(string organizationName, string confirmUrl)
+        {
+            var subject = "【EcAuth】お申し込み確認のお願い";
+
+            var displayOrganization = string.IsNullOrWhiteSpace(organizationName)
+                ? "ご登録の組織"
+                : organizationName;
+
+            var plainTextContent =
+                $"EcAuth へのお申し込みありがとうございます。\n\n" +
+                $"{displayOrganization} のお申し込みを受け付けました。\n" +
+                $"以下の URL にアクセスして、お申し込み内容のご確認をお願いいたします。\n\n" +
+                $"{confirmUrl}\n\n" +
+                $"このメールにお心当たりがない場合は、お手数ですが破棄してください。\n\n" +
+                $"-- \nEcAuth";
+
+            var htmlContent =
+                $"<p>EcAuth へのお申し込みありがとうございます。</p>" +
+                $"<p>{WebUtility.HtmlEncode(displayOrganization)} のお申し込みを受け付けました。<br>" +
+                $"下記のボタン（リンク）から、お申し込み内容のご確認をお願いいたします。</p>" +
+                $"<p><a href=\"{WebUtility.HtmlEncode(confirmUrl)}\">お申し込みを確認する</a></p>" +
+                $"<p>ボタンが動作しない場合は、以下の URL をブラウザに貼り付けてアクセスしてください。<br>" +
+                $"{WebUtility.HtmlEncode(confirmUrl)}</p>" +
+                $"<p>このメールにお心当たりがない場合は、お手数ですが破棄してください。</p>" +
+                $"<p>--<br>EcAuth</p>";
+
+            return new EmailContent(subject, plainTextContent, htmlContent);
+        }
+
+        /// <summary>
+        /// マジックリンクログイン用メールの本文を生成する。
+        /// </summary>
+        /// <param name="magicLinkUrl">マジックリンクのログイン URL</param>
+        public static EmailContent BuildMagicLoginLink(string magicLinkUrl)
+        {
+            var subject = "【EcAuth】ログインリンクのお知らせ";
+
+            var plainTextContent =
+                $"EcAuth へのログインリクエストを受け付けました。\n\n" +
+                $"以下の URL にアクセスしてログインを完了してください（有効期限: 10 分）。\n\n" +
+                $"{magicLinkUrl}\n\n" +
+                $"このリンクは一度のみ使用できます。\n" +
+                $"心当たりがない場合は、このメールを破棄してください（操作は不要です）。\n\n" +
+                $"-- \nEcAuth";
+
+            var htmlContent =
+                $"<p>EcAuth へのログインリクエストを受け付けました。</p>" +
+                $"<p>下記のボタン（リンク）からログインを完了してください（有効期限: 10 分）。</p>" +
+                $"<p><a href=\"{WebUtility.HtmlEncode(magicLinkUrl)}\">ログインする</a></p>" +
+                $"<p>ボタンが動作しない場合は、以下の URL をブラウザに貼り付けてアクセスしてください。<br>" +
+                $"{WebUtility.HtmlEncode(magicLinkUrl)}</p>" +
+                $"<p>このリンクは一度のみ使用できます。<br>" +
+                $"心当たりがない場合は、このメールを破棄してください（操作は不要です）。</p>" +
+                $"<p>--<br>EcAuth</p>";
+
+            return new EmailContent(subject, plainTextContent, htmlContent);
+        }
+    }
+}

--- a/IdentityProvider/Services/SendGridEmailService.cs
+++ b/IdentityProvider/Services/SendGridEmailService.cs
@@ -47,34 +47,15 @@ namespace IdentityProvider.Services
                 ?? _configuration["SENDGRID_FROM_NAME"]
                 ?? "EcAuth";
 
-            var subject = "【EcAuth】お申し込み確認のお願い";
-
+            var content = EmailTemplates.BuildSignupConfirmation(organizationName, confirmUrl);
             var displayOrganization = string.IsNullOrWhiteSpace(organizationName)
                 ? "ご登録の組織"
                 : organizationName;
 
-            var plainTextContent =
-                $"EcAuth へのお申し込みありがとうございます。\n\n" +
-                $"{displayOrganization} のお申し込みを受け付けました。\n" +
-                $"以下の URL にアクセスして、お申し込み内容のご確認をお願いいたします。\n\n" +
-                $"{confirmUrl}\n\n" +
-                $"このメールにお心当たりがない場合は、お手数ですが破棄してください。\n\n" +
-                $"-- \nEcAuth";
-
-            var htmlContent =
-                $"<p>EcAuth へのお申し込みありがとうございます。</p>" +
-                $"<p>{System.Net.WebUtility.HtmlEncode(displayOrganization)} のお申し込みを受け付けました。<br>" +
-                $"下記のボタン（リンク）から、お申し込み内容のご確認をお願いいたします。</p>" +
-                $"<p><a href=\"{System.Net.WebUtility.HtmlEncode(confirmUrl)}\">お申し込みを確認する</a></p>" +
-                $"<p>ボタンが動作しない場合は、以下の URL をブラウザに貼り付けてアクセスしてください。<br>" +
-                $"{System.Net.WebUtility.HtmlEncode(confirmUrl)}</p>" +
-                $"<p>このメールにお心当たりがない場合は、お手数ですが破棄してください。</p>" +
-                $"<p>--<br>EcAuth</p>";
-
             var client = new SendGridClient(apiKey);
             var from = new EmailAddress(fromEmail, fromName);
             var to = new EmailAddress(toEmail);
-            var message = MailHelper.CreateSingleEmail(from, to, subject, plainTextContent, htmlContent);
+            var message = MailHelper.CreateSingleEmail(from, to, content.Subject, content.PlainText, content.Html);
 
             var response = await client.SendEmailAsync(message, ct);
 
@@ -124,30 +105,12 @@ namespace IdentityProvider.Services
                 ?? _configuration["SENDGRID_FROM_NAME"]
                 ?? "EcAuth";
 
-            var subject = "【EcAuth】ログインリンクのお知らせ";
-
-            var plainTextContent =
-                $"EcAuth へのログインリクエストを受け付けました。\n\n" +
-                $"以下の URL にアクセスしてログインを完了してください（有効期限: 10 分）。\n\n" +
-                $"{magicLinkUrl}\n\n" +
-                $"このリンクは一度のみ使用できます。\n" +
-                $"心当たりがない場合は、このメールを破棄してください（操作は不要です）。\n\n" +
-                $"-- \nEcAuth";
-
-            var htmlContent =
-                $"<p>EcAuth へのログインリクエストを受け付けました。</p>" +
-                $"<p>下記のボタン（リンク）からログインを完了してください（有効期限: 10 分）。</p>" +
-                $"<p><a href=\"{System.Net.WebUtility.HtmlEncode(magicLinkUrl)}\">ログインする</a></p>" +
-                $"<p>ボタンが動作しない場合は、以下の URL をブラウザに貼り付けてアクセスしてください。<br>" +
-                $"{System.Net.WebUtility.HtmlEncode(magicLinkUrl)}</p>" +
-                $"<p>このリンクは一度のみ使用できます。<br>" +
-                $"心当たりがない場合は、このメールを破棄してください（操作は不要です）。</p>" +
-                $"<p>--<br>EcAuth</p>";
+            var content = EmailTemplates.BuildMagicLoginLink(magicLinkUrl);
 
             var client = new SendGridClient(apiKey);
             var from = new EmailAddress(fromEmail, fromName);
             var to = new EmailAddress(toEmail);
-            var message = MailHelper.CreateSingleEmail(from, to, subject, plainTextContent, htmlContent);
+            var message = MailHelper.CreateSingleEmail(from, to, content.Subject, content.PlainText, content.Html);
 
             var response = await client.SendEmailAsync(message, ct);
 

--- a/IdentityProvider/Services/SmtpEmailService.cs
+++ b/IdentityProvider/Services/SmtpEmailService.cs
@@ -98,7 +98,17 @@ namespace IdentityProvider.Services
             // ローカル / CI の閉じたネットワーク内でのみ使用される。
             await client.ConnectAsync(host, port, SecureSocketOptions.None, ct);
             await client.SendAsync(message, ct);
-            await client.DisconnectAsync(true, ct);
+            // 送信は上の SendAsync（DATA→250）で確定済み。graceful QUIT は best-effort とし、
+            // 切断（QUIT 送信・221 待ち）での例外を送信失敗として扱わない。ここで例外を伝播させると
+            // 配送済みなのに SignupService は 500、MagicLinkService は誤ったエラーログを出すため。
+            try
+            {
+                await client.DisconnectAsync(true, ct);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "SMTP サーバーからの切断中にエラーが発生しました（送信自体は成功）: To={ToEmail}", MaskEmail(toEmail));
+            }
         }
 
         /// <summary>

--- a/IdentityProvider/Services/SmtpEmailService.cs
+++ b/IdentityProvider/Services/SmtpEmailService.cs
@@ -1,0 +1,127 @@
+using MailKit.Net.Smtp;
+using MailKit.Security;
+using MimeKit;
+
+namespace IdentityProvider.Services
+{
+    /// <summary>
+    /// MailKit ベースの SMTP メール送信実装。
+    /// ローカル開発 / CI E2E で <c>Email:Provider=Smtp</c> のとき DI され、
+    /// mailpit 等の SMTP サーバー（<c>Smtp:Host</c> / <c>Smtp:Port</c>）へ送信する。
+    /// 本文生成は <see cref="EmailTemplates"/> に集約し、SendGrid と同一本文を保証する。
+    /// </summary>
+    public class SmtpEmailService : IEmailService
+    {
+        private readonly IConfiguration _configuration;
+        private readonly ILogger<SmtpEmailService> _logger;
+
+        public SmtpEmailService(IConfiguration configuration, ILogger<SmtpEmailService> logger)
+        {
+            _configuration = configuration;
+            _logger = logger;
+        }
+
+        /// <inheritdoc />
+        public async Task SendSignupConfirmationAsync(string toEmail, string organizationName, string confirmUrl, CancellationToken ct = default)
+        {
+            if (string.IsNullOrWhiteSpace(toEmail))
+                throw new ArgumentException("toEmail cannot be null or empty.", nameof(toEmail));
+            if (string.IsNullOrWhiteSpace(confirmUrl))
+                throw new ArgumentException("confirmUrl cannot be null or empty.", nameof(confirmUrl));
+
+            var content = EmailTemplates.BuildSignupConfirmation(organizationName, confirmUrl);
+            await SendAsync(toEmail, content, ct);
+
+            var displayOrganization = string.IsNullOrWhiteSpace(organizationName)
+                ? "ご登録の組織"
+                : organizationName;
+            _logger.LogInformation(
+                "申込確認メールを送信しました (SMTP): To={ToEmail}, Organization={Organization}",
+                MaskEmail(toEmail), displayOrganization);
+        }
+
+        /// <inheritdoc />
+        public async Task SendMagicLoginLinkAsync(string toEmail, string magicLinkUrl, CancellationToken ct = default)
+        {
+            if (string.IsNullOrWhiteSpace(toEmail))
+                throw new ArgumentException("toEmail cannot be null or empty.", nameof(toEmail));
+            if (string.IsNullOrWhiteSpace(magicLinkUrl))
+                throw new ArgumentException("magicLinkUrl cannot be null or empty.", nameof(magicLinkUrl));
+
+            var content = EmailTemplates.BuildMagicLoginLink(magicLinkUrl);
+            await SendAsync(toEmail, content, ct);
+
+            _logger.LogInformation(
+                "マジックリンクを送信しました (SMTP): To={ToEmail}",
+                MaskEmail(toEmail));
+        }
+
+        /// <summary>
+        /// 共通の SMTP 送信処理。<c>Smtp:Host</c> / <c>Smtp:Port</c> へ接続し、
+        /// プレーンテキスト + HTML の multipart メッセージを送信する。
+        /// </summary>
+        private async Task SendAsync(string toEmail, EmailTemplates.EmailContent content, CancellationToken ct)
+        {
+            // SMTP 接続先は IConfiguration（Smtp:Host / Smtp:Port）→ 環境変数の順で解決する。
+            var host = _configuration["Smtp:Host"] ?? _configuration["SMTP_HOST"];
+            if (string.IsNullOrWhiteSpace(host))
+            {
+                // Provider=Smtp を選んだのに接続先が未設定なのは設定不備。fail-closed で例外を投げる。
+                _logger.LogError("Smtp:Host が未設定のためメールを送信できません: To={ToEmail}", MaskEmail(toEmail));
+                throw new InvalidOperationException("SMTP ホスト（Smtp:Host / SMTP_HOST）が設定されていません。");
+            }
+
+            var portValue = _configuration["Smtp:Port"] ?? _configuration["SMTP_PORT"];
+            var port = int.TryParse(portValue, out var parsedPort) ? parsedPort : 1025;
+
+            // 送信元アドレス・表示名は SendGrid 実装と同じキーで解決する（両プロバイダで統一）。
+            var fromEmail = _configuration["SendGrid:FromEmail"]
+                ?? _configuration["SENDGRID_FROM_EMAIL"]
+                ?? "noreply@ecauth.jp";
+            var fromName = _configuration["SendGrid:FromName"]
+                ?? _configuration["SENDGRID_FROM_NAME"]
+                ?? "EcAuth";
+
+            var message = new MimeMessage();
+            message.From.Add(new MailboxAddress(fromName, fromEmail));
+            message.To.Add(MailboxAddress.Parse(toEmail));
+            message.Subject = content.Subject;
+            message.Body = new BodyBuilder
+            {
+                TextBody = content.PlainText,
+                HtmlBody = content.Html
+            }.ToMessageBody();
+
+            using var client = new SmtpClient();
+            // mailpit 等の開発用 SMTP は TLS 非対応。SecureSocketOptions.None で平文接続する。
+            // 本番のメール送信は SendGrid（HTTP API）が担うため、この平文 SMTP は
+            // ローカル / CI の閉じたネットワーク内でのみ使用される。
+            await client.ConnectAsync(host, port, SecureSocketOptions.None, ct);
+            await client.SendAsync(message, ct);
+            await client.DisconnectAsync(true, ct);
+        }
+
+        /// <summary>
+        /// ログ出力用にメールアドレスをマスクする（<see cref="SendGridEmailService"/> と同一仕様）。
+        /// 例: <c>owner@example.com</c> → <c>o****@example.com</c>。
+        /// </summary>
+        private static string MaskEmail(string? email)
+        {
+            if (string.IsNullOrWhiteSpace(email))
+            {
+                return "(empty)";
+            }
+
+            var atIndex = email.IndexOf('@');
+            if (atIndex <= 0)
+            {
+                return "****";
+            }
+
+            var local = email[..atIndex];
+            var domain = email[atIndex..];
+            var visible = local[..1];
+            return $"{visible}****{domain}";
+        }
+    }
+}

--- a/compose.yaml
+++ b/compose.yaml
@@ -18,6 +18,7 @@ services:
         - GITHUB_TOKEN=${GITHUB_TOKEN}
     depends_on:
       - db
+      - mailpit
     environment:
       ASPNETCORE_ENVIRONMENT: Development
       ASPNETCORE_HTTP_PORTS: "8080"
@@ -60,6 +61,26 @@ services:
       E2E_TOKEN_ENDPOINT: ${E2E_TOKEN_ENDPOINT}
       E2E_USERINFO_ENDPOINT: ${E2E_USERINFO_ENDPOINT}
       E2E_REDIRECT_URI: ${E2E_REDIRECT_URI}
+      # Account 申込フロー（Phase D-1）/ マジックリンク（Phase D-2）用。
+      # AccountsOrganizationSeeder が accounts / stg-accounts Org と管理コンソール Client を
+      # 投入するために ACCOUNTS_* / STG_ACCOUNTS_* を container に渡す。
+      ACCOUNTS_CLIENT_ID: ${ACCOUNTS_CLIENT_ID}
+      ACCOUNTS_CLIENT_SECRET: ${ACCOUNTS_CLIENT_SECRET}
+      ACCOUNTS_ALLOWED_RP_IDS: ${ACCOUNTS_ALLOWED_RP_IDS}
+      ACCOUNTS_REDIRECT_URI: ${ACCOUNTS_REDIRECT_URI}
+      STG_ACCOUNTS_CLIENT_ID: ${STG_ACCOUNTS_CLIENT_ID}
+      STG_ACCOUNTS_CLIENT_SECRET: ${STG_ACCOUNTS_CLIENT_SECRET}
+      STG_ACCOUNTS_ALLOWED_RP_IDS: ${STG_ACCOUNTS_ALLOWED_RP_IDS}
+      STG_ACCOUNTS_REDIRECT_URI: ${STG_ACCOUNTS_REDIRECT_URI}
+      # 確認 URL / マジックリンク URL の基底（テナント別・リクエスト処理時に必須参照）。
+      Signup__ConfirmBaseUrl__accounts: ${Signup__ConfirmBaseUrl__accounts:-https://localhost:8081}
+      Signup__ConfirmBaseUrl__stg_accounts: ${Signup__ConfirmBaseUrl__stg_accounts:-https://localhost:8081}
+      MagicLink__BaseUrl__accounts: ${MagicLink__BaseUrl__accounts:-https://localhost:8081}
+      MagicLink__BaseUrl__stg_accounts: ${MagicLink__BaseUrl__stg_accounts:-https://localhost:8081}
+      # メール送信プロバイダ。ローカル / CI E2E は mailpit（SMTP）に送信して実メール経路を検証する。
+      Email__Provider: ${Email__Provider:-Smtp}
+      Smtp__Host: ${Smtp__Host:-mailpit}
+      Smtp__Port: ${Smtp__Port:-1025}
     ports:
       - "8080:8080"
       - "8081:8081"
@@ -67,6 +88,20 @@ services:
       - ${HOME}/.microsoft/usersecrets:/home/app/.microsoft/usersecrets:ro
     networks:
       - backend
+
+  # メールテスト用の SMTP サーバー（受信専用）。SMTP 1025 で受信し、Web UI / REST API を 8025 で提供。
+  # E2E テストは REST API（http://localhost:8025/api/v1/messages）で確認・マジックリンクのトークンを取得する。
+  mailpit:
+    image: axllent/mailpit:latest
+    environment:
+      MP_SMTP_AUTH_ACCEPT_ANY: "1"
+      MP_SMTP_AUTH_ALLOW_INSECURE: "1"
+    ports:
+      - "1025:1025"
+      - "8025:8025"
+    networks:
+      - backend
+    restart: unless-stopped
 
   db:
     image: mcr.microsoft.com/mssql/server:2022-latest


### PR DESCRIPTION
## Summary

[EcAuthDocs #79](https://github.com/EcAuth/EcAuthDocs/issues/79) の **Phase F**（最終フェーズ）。Account 申込・マジックリンクの**実メール経路**（送信 → 本文 → トークン抽出 → 確認）を **PR-CI のローカルスタックで丸ごと検証**できるようにする。

確認トークン / ログイントークンは DB には SHA-256 ハッシュのみ保存され**メール本文にしか存在しない**ため、E2E でフローを完走するには実メールからトークンを取得する必要がある。本 PR は CI に [mailpit](https://github.com/axllent/mailpit)（SMTP 受信 + REST API）を組み込み、`Email:Provider=Smtp` で MailKit ベースの送信に切り替えて、この経路を CI 内で完結させる。本番 / staging は従来どおり SendGrid 据え置き。

設計書: [Account E2E 検証戦略](https://github.com/EcAuth/EcAuthDocs/blob/main/html/account-management-architecture.html)

## Changes

### 領域 A: SMTP プロバイダ + メール本文テンプレート共通化
- `Services/EmailTemplates.cs`（新規）: 件名・本文（plain / html）生成を集約
- `Services/SmtpEmailService.cs`（新規）: MailKit で mailpit（`Smtp:Host` / `Smtp:Port`）へ送信
- `Services/SendGridEmailService.cs`: 本文生成を `EmailTemplates` に委譲（**文言は完全に不変**、SendGrid / SMTP で同一本文を保証）
- `Program.cs`: `Email:Provider`（既定 `SendGrid` / `Smtp`）による DI 切替
- `IdentityProvider.csproj`: `MailKit` 4.14.0 追加

### 領域 B: インフラ（ローカル / CI）
- `compose.yaml`: mailpit（SMTP 1025 / API 8025）追加、`identityprovider` に `Email__Provider=Smtp` / `ACCOUNTS_*` / `Signup__ConfirmBaseUrl__*` / `MagicLink__BaseUrl__*` を配線
- `.github/workflows/playwright.yml`: mailpit service container + `Email__Provider=Smtp` / `ACCOUNTS_*` / base-URL env を注入
- `.env.dev.tpl`: `ACCOUNTS_ALLOWED_RP_IDS` に accounts ホストを追加

### 領域 C: E2E スペック
- `E2ETests/tests/helpers/mailpit.ts`（新規）: mailpit REST ラッパ（件名フィルタ + ID 指定削除で並列実行安全）
- `E2ETests/tests/specs/account_signup_flow.spec.ts`（新規）: 申込 → confirm → パスキー登録（既存 B2B 仮想認証器を流用）→ 認証 → `/token` → **`managed_orgs` claim 検証**
- `E2ETests/tests/specs/account_magic_link_flow.spec.ts`（新規）: request → verify → `/token` + 異常系（second-use / rate-limit）
- `E2ETests/playwright.config.ts`: accounts テナント解決用の `--host-resolver-rules` を追加
- `IdentityProvider.Test/Services/EmailTemplatesTests.cs`（新規）: テンプレートのドリフトを固定

### テナント解決の要点（実装時に判明した制約）
- `TenantMiddleware` は host のセグメント数が **3 以上**のときのみ先頭をテナント名にするため、`accounts.localhost`（2 セグメント）では解決されず `accounts.ec-auth.io` を使用
- パスキーの `B2BUser` 解決（`GetByExternalIdAsync`）は `TenantName` クエリフィルタが効くため、**passkey ページを accounts ホスト origin で配信**し `rp_id` を一致させる。`external_id` は生 email を渡せばサーバ側で `ExternalIdHasher.Hash` により突合される

## Test plan

すべてローカルで SQL Server + mailpit を docker 起動し、CI と同じ `dotnet run` 方式で検証済み。

- [x] `dotnet build EcAuth.sln` — 0 エラー（.NET 10、MailKit 4.14.0 解決）
- [x] ユニットテスト **649 件全合格**（`EmailTemplates` 4 件含む、既存 645 件に回帰なし）
- [x] E2E `account_magic_link_flow` **3/3**（verify 200 / second-use 400 / rate-limit 429）
- [x] E2E `account_signup_flow` **5/5**（申込 202 → confirm 200 → パスキー登録 → token、`managed_orgs` に owner ロール確認）
- [x] E2E 両 account spec 並列 **8/8**（共有 mailpit で干渉なし）
- [x] E2E 既存 `b2b_passkey` 回帰 **7/7**（config 変更の影響なし）
- [x] `compose.yaml` / `playwright.yml` 構文 valid
- [ ] CI（`playwright.yml`）で mailpit 経路が通ることを確認

Related: EcAuthDocs#79

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 申込確認メール／マジックリンクメールの送信にSMTP（ローカルmailpit）を追加。
* **改善**
  * 許可するRP IDとステージング設定を更新し、認証の互換性を向上。
  * メール本文（件名・プレーンテキスト・HTML）の内容を統一。
* **テスト**
  * E2EをMailpit連携で強化し、メール取得〜トークン交換までの検証を追加。テンプレート内容のテストも追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->