### PR TITLE
feat: client_secret を Key Vault で暗号化保存する

### DIFF
--- a/.env.staging.tpl
+++ b/.env.staging.tpl
@@ -66,3 +66,11 @@ STAGING_B2B_ALLOWED_RP_IDS=op://EcAuth/ecauth-staging-app/b2b_allowed_rp_ids
 # SendGrid (Staging) - Phase D-1 申込 API / D-2 マジックリンクで使用
 # =============================================================================
 SENDGRID_API_KEY=op://EcAuth/ecauth-staging-app/sendgrid_api_key
+
+# =============================================================================
+# client_secret 保存時暗号化（EcAuthDocs#106）
+# =============================================================================
+# Key Vault 鍵の URI（非秘密）。アプリ実行時＋起動シーダーが参照する。
+# Azure ランタイムへの配線は ecauth-infrastructure の app_settings（staging main.tf）で実施済み。
+# ここはローカルから staging を動かす場合用。未設定なら平文フォールバックする（保険）。
+ClientSecretProtection__KeyVaultKeyId=https://ecauth-staging-kv.vault.azure.net/keys/client-secret-protection

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,13 +62,13 @@ cd E2ETests && pnpm install && pnpm exec playwright test
 
 | エンドポイント | ステップ |
 |---|---|
-| `/token` | `client_lookup` / `auth_code_lookup` / `auth_code_mark_used` / `user_lookup` / `token_generate` |
+| `/token` | `client_lookup` / `client_secret_verify` / `auth_code_lookup` / `auth_code_mark_used` / `user_lookup` / `token_generate` |
 | `/userinfo` | `auth_header_parse` / `access_token_validate` / `user_lookup` |
 | `/api/external-userinfo` | `auth_header_parse` / `access_token_validate` / `external_userinfo_fetch` |
 | `register/verify` | `client_authenticate` / `service_call`（内訳: `challenge_lookup` / `fido2_make_credential` / `credential_persist` / `challenge_consume`） |
 | `authenticate/verify` | `client_authenticate` / `service_call`（内訳: `challenge_lookup` / `credential_lookup` / `fido2_make_assertion` / `signcount_persist` / `challenge_consume`） |
 | `/api/signup/request` | `validate` / `persist` / `send_email` |
-| `/api/signup/confirm` | `token_lookup` / `confirm` |
+| `/api/signup/confirm` | `token_lookup` / `confirm`（内訳: `client_secret_protect`） |
 | `/api/signup/status` | `status_lookup` |
 | `/api/account/magic-link/request` | `rate_limit` / `account_lookup` / `persist` / `send_email` |
 | `/api/account/magic-link/verify` | `token_lookup` / `token_consume` |

--- a/ConsoleApp/EcAuthConsoleApp.csproj
+++ b/ConsoleApp/EcAuthConsoleApp.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
 

--- a/IdentityProvider.Test/Controllers/B2BPasskeyControllerIntegrationTests.cs
+++ b/IdentityProvider.Test/Controllers/B2BPasskeyControllerIntegrationTests.cs
@@ -4,6 +4,7 @@ using IdentityProvider.Controllers;
 using IdentityProvider.Models;
 using IdentityProvider.Services;
 using IdentityProvider.Test.TestHelpers;
+using IdpUtilities.Security;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.WebUtilities;
@@ -81,7 +82,8 @@ namespace IdentityProvider.Test.Controllers
                 _tokenService,
                 _b2bUserService,
                 _context,
-                _mockControllerLogger.Object);
+                _mockControllerLogger.Object,
+                new PlaintextSecretProtector());
 
             _controller.ControllerContext = new ControllerContext
             {
@@ -97,7 +99,8 @@ namespace IdentityProvider.Test.Controllers
                 _mockTokenService.Object,
                 _b2bUserService,
                 _context,
-                _mockControllerLogger.Object);
+                _mockControllerLogger.Object,
+                new PlaintextSecretProtector());
 
             _controllerWithMockToken.ControllerContext = new ControllerContext
             {

--- a/IdentityProvider.Test/Controllers/B2BPasskeyControllerTests.cs
+++ b/IdentityProvider.Test/Controllers/B2BPasskeyControllerTests.cs
@@ -4,6 +4,7 @@ using IdentityProvider.Controllers;
 using IdentityProvider.Exceptions;
 using IdentityProvider.Models;
 using IdentityProvider.Services;
+using IdpUtilities.Security;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -48,7 +49,8 @@ namespace IdentityProvider.Test.Controllers
                 _mockTokenService.Object,
                 _mockB2BUserService.Object,
                 _context,
-                _mockLogger.Object);
+                _mockLogger.Object,
+                new PlaintextSecretProtector());
 
             _controller.ControllerContext = new ControllerContext
             {

--- a/IdentityProvider.Test/Controllers/TokenControllerTests.cs
+++ b/IdentityProvider.Test/Controllers/TokenControllerTests.cs
@@ -1,6 +1,7 @@
 using IdentityProvider.Controllers;
 using IdentityProvider.Models;
 using IdentityProvider.Services;
+using IdpUtilities.Security;
 using IdentityProvider.Test.TestHelpers;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -43,7 +44,8 @@ namespace IdentityProvider.Test.Controllers
                 _mockB2BUserService.Object,
                 _mockAccountService.Object,
                 _mockLogger.Object,
-                _mockConfiguration.Object);
+                _mockConfiguration.Object,
+                new PlaintextSecretProtector());
         }
 
         [Fact]

--- a/IdentityProvider.Test/Data/Seeders/AccountsOrganizationSeederTests.cs
+++ b/IdentityProvider.Test/Data/Seeders/AccountsOrganizationSeederTests.cs
@@ -1,6 +1,7 @@
 using IdentityProvider.Data.Seeders;
 using IdentityProvider.Models;
 using IdentityProvider.Test.TestHelpers;
+using IdpUtilities.Security;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -31,7 +32,7 @@ namespace IdentityProvider.Test.Data.Seeders
         public AccountsOrganizationSeederTests()
         {
             _context = TestDbContextHelper.CreateInMemoryContext();
-            _seeder = new AccountsOrganizationSeeder();
+            _seeder = new AccountsOrganizationSeeder(new PlaintextSecretProtector());
             _mockLogger = new Mock<ILogger>();
         }
 

--- a/IdentityProvider.Test/Data/Seeders/OrganizationClientSeederTests.cs
+++ b/IdentityProvider.Test/Data/Seeders/OrganizationClientSeederTests.cs
@@ -1,6 +1,7 @@
 using IdentityProvider.Data.Seeders;
 using IdentityProvider.Models;
 using IdentityProvider.Test.TestHelpers;
+using IdpUtilities.Security;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -35,7 +36,7 @@ namespace IdentityProvider.Test.Data.Seeders
         public OrganizationClientSeederTests()
         {
             _context = TestDbContextHelper.CreateInMemoryContext();
-            _seeder = new OrganizationClientSeeder();
+            _seeder = new OrganizationClientSeeder(new PlaintextSecretProtector());
             _mockLogger = new Mock<ILogger>();
         }
 

--- a/IdentityProvider.Test/IdentityProvider.Test.csproj
+++ b/IdentityProvider.Test/IdentityProvider.Test.csproj
@@ -15,7 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/IdentityProvider.Test/Services/SignupServiceTests.cs
+++ b/IdentityProvider.Test/Services/SignupServiceTests.cs
@@ -4,6 +4,7 @@ using IdentityProvider.Exceptions;
 using IdentityProvider.Models;
 using IdentityProvider.Services;
 using IdentityProvider.Test.TestHelpers;
+using IdpUtilities.Security;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -102,7 +103,8 @@ namespace IdentityProvider.Test.Services
                 emailServiceMock.Object,
                 disposableCheckerMock.Object,
                 CreateConfiguration(withConfirmBaseUrl),
-                _logger);
+                _logger,
+                new PlaintextSecretProtector());
         }
 
         /// <summary>
@@ -220,7 +222,8 @@ namespace IdentityProvider.Test.Services
             disposableMock.Setup(x => x.IsDisposable(It.IsAny<string>())).Returns(false);
 
             var service = new SignupService(
-                context, tenantService, emailMock.Object, disposableMock.Object, config, _logger);
+                context, tenantService, emailMock.Object, disposableMock.Object, config, _logger,
+                new PlaintextSecretProtector());
 
             await service.RequestAsync(ValidInput());
 

--- a/IdentityProvider/Controllers/B2BPasskeyController.cs
+++ b/IdentityProvider/Controllers/B2BPasskeyController.cs
@@ -3,6 +3,7 @@ using IdentityProvider.Exceptions;
 using IdentityProvider.Models;
 using IdentityProvider.Services;
 using IdentityProvider.Telemetry;
+using IdpUtilities.Security;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -27,6 +28,7 @@ namespace IdentityProvider.Controllers
         private readonly IB2BUserService _b2bUserService;
         private readonly EcAuthDbContext _context;
         private readonly ILogger<B2BPasskeyController> _logger;
+        private readonly ISecretProtector _secretProtector;
 
         public B2BPasskeyController(
             IB2BPasskeyService passkeyService,
@@ -34,7 +36,8 @@ namespace IdentityProvider.Controllers
             ITokenService tokenService,
             IB2BUserService b2bUserService,
             EcAuthDbContext context,
-            ILogger<B2BPasskeyController> logger)
+            ILogger<B2BPasskeyController> logger,
+            ISecretProtector secretProtector)
         {
             _passkeyService = passkeyService;
             _authorizationCodeService = authorizationCodeService;
@@ -42,6 +45,7 @@ namespace IdentityProvider.Controllers
             _b2bUserService = b2bUserService;
             _context = context;
             _logger = logger;
+            _secretProtector = secretProtector;
         }
 
         #region Request/Response DTOs
@@ -679,11 +683,9 @@ namespace IdentityProvider.Controllers
                 return null;
             }
 
-            // タイミング攻撃対策: 定時間比較
-            var secretBytes = System.Text.Encoding.UTF8.GetBytes(clientSecret);
-            var storedSecretBytes = System.Text.Encoding.UTF8.GetBytes(client.ClientSecret);
-
-            if (System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(secretBytes, storedSecretBytes))
+            // 保存値は Key Vault 暗号化エンベロープ（レガシーは平文）。ISecretProtector が
+            // 復号(+キャッシュ)して定数時間比較を行う（タイミング攻撃対策）。
+            if (await _secretProtector.VerifyAsync(clientSecret, client.ClientSecret))
             {
                 return client;
             }

--- a/IdentityProvider/Controllers/TokenController.cs
+++ b/IdentityProvider/Controllers/TokenController.cs
@@ -2,6 +2,7 @@ using IdentityProvider.Models;
 using IdentityProvider.Services;
 using IdentityProvider.Telemetry;
 using IdpUtilities;
+using IdpUtilities.Security;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -23,6 +24,7 @@ namespace IdentityProvider.Controllers
         private readonly IAccountService _accountService;
         private readonly ILogger<TokenController> _logger;
         private readonly IConfiguration _configuration;
+        private readonly ISecretProtector _secretProtector;
 
         public TokenController(
             EcAuthDbContext context,
@@ -32,7 +34,8 @@ namespace IdentityProvider.Controllers
             IB2BUserService b2bUserService,
             IAccountService accountService,
             ILogger<TokenController> logger,
-            IConfiguration configuration)
+            IConfiguration configuration,
+            ISecretProtector secretProtector)
         {
             _context = context;
             _environment = environment;
@@ -42,6 +45,7 @@ namespace IdentityProvider.Controllers
             _accountService = accountService;
             _logger = logger;
             _configuration = configuration;
+            _secretProtector = secretProtector;
         }
 
         /// <summary>
@@ -146,9 +150,11 @@ namespace IdentityProvider.Controllers
                 }
 
                 // 4. client_secretの検証（設定されている場合のみ）
+                // 保存値は Key Vault 暗号化エンベロープ（レガシーは平文）。ISecretProtector が
+                // 復号(+キャッシュ)して定数時間比較を行う。
                 if (!string.IsNullOrEmpty(client.ClientSecret))
                 {
-                    if (string.IsNullOrEmpty(client_secret) || client.ClientSecret != client_secret)
+                    if (!await _secretProtector.VerifyAsync(client_secret, client.ClientSecret))
                     {
                         _logger.LogWarning("Invalid client_secret for client: {ClientId}", client_id);
                         return BadRequest(new

--- a/IdentityProvider/Controllers/TokenController.cs
+++ b/IdentityProvider/Controllers/TokenController.cs
@@ -151,10 +151,16 @@ namespace IdentityProvider.Controllers
 
                 // 4. client_secretの検証（設定されている場合のみ）
                 // 保存値は Key Vault 暗号化エンベロープ（レガシーは平文）。ISecretProtector が
-                // 復号(+キャッシュ)して定数時間比較を行う。
+                // 復号(+キャッシュ)して定数時間比較を行う。提示値が空なら復号せず即座に拒否する。
                 if (!string.IsNullOrEmpty(client.ClientSecret))
                 {
-                    if (!await _secretProtector.VerifyAsync(client_secret, client.ClientSecret))
+                    bool secretValid;
+                    using (TimingScope.Begin("client_secret_verify"))
+                    {
+                        secretValid = !string.IsNullOrEmpty(client_secret)
+                            && await _secretProtector.VerifyAsync(client_secret, client.ClientSecret);
+                    }
+                    if (!secretValid)
                     {
                         _logger.LogWarning("Invalid client_secret for client: {ClientId}", client_id);
                         return BadRequest(new

--- a/IdentityProvider/Data/Seeders/AccountsOrganizationSeeder.cs
+++ b/IdentityProvider/Data/Seeders/AccountsOrganizationSeeder.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography;
 using IdentityProvider.Models;
+using IdpUtilities.Security;
 using Microsoft.EntityFrameworkCore;
 
 namespace IdentityProvider.Data.Seeders;
@@ -18,6 +19,13 @@ namespace IdentityProvider.Data.Seeders;
 /// </summary>
 public class AccountsOrganizationSeeder : IDbSeeder
 {
+    private readonly ISecretProtector _secretProtector;
+
+    public AccountsOrganizationSeeder(ISecretProtector secretProtector)
+    {
+        _secretProtector = secretProtector;
+    }
+
     /// <inheritdoc />
     /// <remarks>
     /// Phase A で 4 マイグレーションが統合されたため、<c>AddSubjectTypeToClient</c> を含む
@@ -56,7 +64,7 @@ public class AccountsOrganizationSeeder : IDbSeeder
 
         foreach (var definition in Definitions)
         {
-            hasChanges |= await SeedDefinitionAsync(context, configuration, definition, logger);
+            hasChanges |= await SeedDefinitionAsync(context, configuration, definition, _secretProtector, logger);
         }
 
         if (hasChanges)
@@ -74,6 +82,7 @@ public class AccountsOrganizationSeeder : IDbSeeder
         EcAuthDbContext context,
         IConfiguration configuration,
         AccountOrgDefinition definition,
+        ISecretProtector secretProtector,
         ILogger logger)
     {
         var clientId = configuration[$"{definition.ConfigPrefix}_CLIENT_ID"];
@@ -98,7 +107,7 @@ public class AccountsOrganizationSeeder : IDbSeeder
 
         // 2. Client 作成（SubjectType.Account）
         var client = await SeedClientAsync(
-            context, definition, clientId, clientSecret, allowedRpIds, organization, logger);
+            context, definition, clientId, clientSecret, allowedRpIds, organization, secretProtector, logger);
         hasChanges |= client.created;
 
         if (client.entity == null)
@@ -154,6 +163,7 @@ public class AccountsOrganizationSeeder : IDbSeeder
         string? clientSecret,
         string? allowedRpIds,
         Organization organization,
+        ISecretProtector secretProtector,
         ILogger logger)
     {
         var existing = await context.Clients
@@ -177,7 +187,8 @@ public class AccountsOrganizationSeeder : IDbSeeder
         var client = new Client
         {
             ClientId = clientId,
-            ClientSecret = clientSecret,
+            // 保存前に client_secret を暗号化する（レガシー/dev は平文パススルー）。
+            ClientSecret = await secretProtector.ProtectAsync(clientSecret),
             AppName = definition.Name,
             OrganizationId = organization.Id,
             SubjectType = SubjectType.Account

--- a/IdentityProvider/Data/Seeders/OrganizationClientSeeder.cs
+++ b/IdentityProvider/Data/Seeders/OrganizationClientSeeder.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography;
 using IdentityProvider.Models;
+using IdpUtilities.Security;
 using Microsoft.EntityFrameworkCore;
 
 namespace IdentityProvider.Data.Seeders;
@@ -14,6 +15,13 @@ namespace IdentityProvider.Data.Seeders;
 /// </summary>
 public class OrganizationClientSeeder : IDbSeeder
 {
+    private readonly ISecretProtector _secretProtector;
+
+    public OrganizationClientSeeder(ISecretProtector secretProtector)
+    {
+        _secretProtector = secretProtector;
+    }
+
     /// <inheritdoc />
     public string RequiredMigration => "20260328225834_AddKidAndIsActiveToRsaKeyPair";
 
@@ -67,7 +75,7 @@ public class OrganizationClientSeeder : IDbSeeder
 
         // 2. Client 作成
         var client = await SeedClientAsync(
-            context, clientId, clientSecret, appName, organization, logger);
+            context, clientId, clientSecret, appName, organization, _secretProtector, logger);
         hasChanges |= client.created;
 
         if (client.entity == null)
@@ -137,6 +145,7 @@ public class OrganizationClientSeeder : IDbSeeder
         string? clientSecret,
         string? appName,
         Organization organization,
+        ISecretProtector secretProtector,
         ILogger logger)
     {
         var existing = await context.Clients
@@ -175,7 +184,8 @@ public class OrganizationClientSeeder : IDbSeeder
         var client = new Client
         {
             ClientId = clientId,
-            ClientSecret = clientSecret,
+            // 保存前に client_secret を暗号化する（レガシー/dev は平文パススルー）。
+            ClientSecret = await secretProtector.ProtectAsync(clientSecret),
             AppName = appName ?? clientId,
             OrganizationId = organization.Id,
             // EC-CUBE 管理画面用の B2B パスキー Client。Client.SubjectType の

--- a/IdentityProvider/IdentityProvider.csproj
+++ b/IdentityProvider/IdentityProvider.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="EcAuth.IdpUtilities" Version="2.0.0" />
+    <PackageReference Include="EcAuth.IdpUtilities" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/IdentityProvider/IdentityProvider.csproj
+++ b/IdentityProvider/IdentityProvider.csproj
@@ -16,12 +16,12 @@
     <PackageReference Include="Fido2" Version="4.0.1" />
     <PackageReference Include="MailKit" Version="4.14.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.6">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.6">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/IdentityProvider/Program.cs
+++ b/IdentityProvider/Program.cs
@@ -94,10 +94,25 @@ builder.Services.AddHostedService<MagicLinkCleanupService>();
 // client_secret 等の保存時暗号化（EcAuthDocs#106）。
 // Development はローカル例外として平文パススルー、それ以外は Key Vault の CryptographyClient で暗号化する。
 // KeyVaultKeyId は非秘密の鍵 URL のため app_settings（ClientSecretProtection__KeyVaultKeyId）で渡す。
+//
+// 通常のデプロイ順序は「インフラ（鍵配線）→ アプリ」を維持する。ただし保険として、非 Development でも
+// 鍵 URL が未設定の場合は例外で起動失敗させず PlaintextSecretProtector にフォールバックする。これにより
+// 万一インフラ配線より先にアプリがデプロイされても、client_secret は現状どおり平文で動作し（元々平文の
+// ため回帰なし）、鍵を設定した時点で暗号化へ自動的に切り替わる。フォールバック時は運用者が気づけるよう
+// 起動ログ（stdout → AppServiceConsoleLogs）に警告を出す。
+var clientSecretKeyVaultKeyId = builder.Configuration["ClientSecretProtection:KeyVaultKeyId"];
+var usePlaintextSecretProtector = builder.Environment.IsDevelopment()
+    || string.IsNullOrEmpty(clientSecretKeyVaultKeyId);
+if (usePlaintextSecretProtector && !builder.Environment.IsDevelopment())
+{
+    Console.Error.WriteLine(
+        "[WARN] ClientSecretProtection:KeyVaultKeyId が未設定のため PlaintextSecretProtector に" +
+        "フォールバックします。client_secret は暗号化されません（鍵配線後に暗号化が有効化されます）。");
+}
 builder.Services.AddSecretProtection(options =>
 {
-    options.UsePlaintext = builder.Environment.IsDevelopment();
-    options.KeyVaultKeyId = builder.Configuration["ClientSecretProtection:KeyVaultKeyId"];
+    options.UsePlaintext = usePlaintextSecretProtector;
+    options.KeyVaultKeyId = clientSecretKeyVaultKeyId;
 });
 
 // データベース初期化（シーダー）

--- a/IdentityProvider/Program.cs
+++ b/IdentityProvider/Program.cs
@@ -91,6 +91,15 @@ builder.Services.AddScoped<IMagicLinkService, MagicLinkService>();
 // 期限切れトークンの日次クリーンアップ（既定の保持期間 7 日）
 builder.Services.AddHostedService<MagicLinkCleanupService>();
 
+// client_secret 等の保存時暗号化（EcAuthDocs#106）。
+// Development はローカル例外として平文パススルー、それ以外は Key Vault の CryptographyClient で暗号化する。
+// KeyVaultKeyId は非秘密の鍵 URL のため app_settings（ClientSecretProtection__KeyVaultKeyId）で渡す。
+builder.Services.AddSecretProtection(options =>
+{
+    options.UsePlaintext = builder.Environment.IsDevelopment();
+    options.KeyVaultKeyId = builder.Configuration["ClientSecretProtection:KeyVaultKeyId"];
+});
+
 // データベース初期化（シーダー）
 builder.Services.AddScoped<IDbSeeder, OrganizationClientSeeder>();
 builder.Services.AddScoped<IDbSeeder, AccountsOrganizationSeeder>();

--- a/IdentityProvider/Services/SignupService.cs
+++ b/IdentityProvider/Services/SignupService.cs
@@ -243,7 +243,11 @@ namespace IdentityProvider.Services
 
                     var client = CreateClient(organization, site, signupRequest.OrganizationName);
                     // 保存前に client_secret を暗号化する（レガシー/dev は平文パススルー）。
-                    client.ClientSecret = await _secretProtector.ProtectAsync(client.ClientSecret, ct);
+                    // Key Vault 暗号化の所要時間を confirm 内の独立ステップとして計測する。
+                    using (TimingScope.Begin("client_secret_protect"))
+                    {
+                        client.ClientSecret = await _secretProtector.ProtectAsync(client.ClientSecret, ct);
+                    }
                     _context.Clients.Add(client);
 
                     _context.RsaKeyPairs.Add(CreateRsaKeyPair(organization.Id));

--- a/IdentityProvider/Services/SignupService.cs
+++ b/IdentityProvider/Services/SignupService.cs
@@ -3,6 +3,7 @@ using System.Text.RegularExpressions;
 using IdentityProvider.Exceptions;
 using IdentityProvider.Models;
 using IdentityProvider.Telemetry;
+using IdpUtilities.Security;
 using Microsoft.EntityFrameworkCore;
 
 namespace IdentityProvider.Services
@@ -33,6 +34,7 @@ namespace IdentityProvider.Services
         private readonly IDisposableEmailChecker _disposableEmailChecker;
         private readonly IConfiguration _configuration;
         private readonly ILogger<SignupService> _logger;
+        private readonly ISecretProtector _secretProtector;
 
         public SignupService(
             EcAuthDbContext context,
@@ -40,7 +42,8 @@ namespace IdentityProvider.Services
             IEmailService emailService,
             IDisposableEmailChecker disposableEmailChecker,
             IConfiguration configuration,
-            ILogger<SignupService> logger)
+            ILogger<SignupService> logger,
+            ISecretProtector secretProtector)
         {
             _context = context;
             _tenantService = tenantService;
@@ -48,6 +51,7 @@ namespace IdentityProvider.Services
             _disposableEmailChecker = disposableEmailChecker;
             _configuration = configuration;
             _logger = logger;
+            _secretProtector = secretProtector;
         }
 
         /// <inheritdoc />
@@ -238,6 +242,8 @@ namespace IdentityProvider.Services
                     await _context.SaveChangesAsync(ct);
 
                     var client = CreateClient(organization, site, signupRequest.OrganizationName);
+                    // 保存前に client_secret を暗号化する（レガシー/dev は平文パススルー）。
+                    client.ClientSecret = await _secretProtector.ProtectAsync(client.ClientSecret, ct);
                     _context.Clients.Add(client);
 
                     _context.RsaKeyPairs.Add(CreateRsaKeyPair(organization.Id));


### PR DESCRIPTION
## 概要

`client.client_secret` を保存時に暗号化します（[EcAuthDocs#106](https://github.com/EcAuth/EcAuthDocs/issues/106) の **PR[2]**）。[EcAuth.IdpUtilities#32](https://github.com/EcAuth/EcAuth.IdpUtilities/pull/32) で追加した `ISecretProtector`（Key Vault `CryptographyClient` ベース）を利用します。

> ⚠️ **依存**: この PR は `EcAuth.IdpUtilities` **2.1.0** を参照します。PR[1]（IdpUtilities#32）がマージ・`v2.1.0` タグ発行されるまで **CI の restore は失敗（赤）** します。ローカルでは 2.1.0 のローカルビルドを一時フィードにして検証済みです。

## 変更内容

- **`EcAuth.IdpUtilities` 2.0.0 → 2.1.0**（`IdentityProvider.csproj`）
- **`Program.cs`**: `AddSecretProtection` を環境別に登録
  - Development … `PlaintextSecretProtector`（ローカル例外・KV 非依存）
  - Staging/Production … `KeyVaultSecretProtector`（`ClientSecretProtection__KeyVaultKeyId` を参照）
- **書き込み（暗号化）**: Client 生成時に `ProtectAsync`
  - `OrganizationClientSeeder` / `AccountsOrganizationSeeder` / `SignupService`
- **検証（復号 + 定数時間比較）**: `VerifyAsync` に置換
  - `TokenController`（従来の `!=` 非定数時間比較も同時に解消）
  - `B2BPasskeyController.AuthenticateClientAsync`
- **後方互換**: プレフィックス無しの値はレガシー平文として検証。既存の平文行はそのまま認証でき、段階移行（lazy migration）が可能
- **スキーマ変更なし**: `client_secret` は `nvarchar(max)` のため暗号文を収容可能

## テスト・検証（ローカル、2.1.0 ローカルフィード）

- `dotnet test IdentityProvider.Test` … **全 649 件成功**（失敗 0）
- `dotnet build EcAuth.sln` … 成功
- `dotnet ef migrations has-pending-model-changes` … **No changes**（マイグレーション不要）

## マージ手順

1. 先に PR[1]（IdpUtilities#32）をマージ → `v2.1.0` タグで NuGet 発行
2. 本 PR の CI を再実行（restore が 2.1.0 を解決）→ グリーン確認
3. マージ

## 後続（別 PR）

- **PR[3]** `ecauth-infrastructure` staging: KV RSA 鍵 + Managed Identity `Key Vault Crypto User` ロール + `ClientSecretProtection__KeyVaultKeyId` app_settings
- **PR[4]** production 同様 + 本番デプロイ検証

Refs: EcAuthDocs#106, EcAuth.IdpUtilities#32

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **セキュリティ**
  - クライアントシークレットを保存時に保護し、認証（Token/B2Bパスキー）時の検証も保護済み前提に置き換えて強化しました。
  - サインアップおよび初期データ登録（シーダー）で作成されるシークレットも保護されます。
  - 本番はKey Vaultキー設定で保護、開発は平文モードでテストしやすく動作します（非開発かつ未設定時は警告を表示）。

- **改善**
  - シークレット保護設定の登録と挙動を統一しました。

- **テスト**
  - テストで平文保護版を明示利用するよう調整しました。

- **Chores**
  - 主要ライブラリ/依存関係を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## 追記: デプロイ順序とフォールバック（保険）

- **想定デプロイ順序は「PR[3]（インフラ: KV 鍵 + ロール + `ClientSecretProtection__KeyVaultKeyId` app_settings）を staging 適用 → 本 PR をマージ」** を維持します。
- **保険**: 非 Development でも鍵 URL が未設定の場合、本 PR は起動失敗させず `PlaintextSecretProtector` にフォールバックします（`Program.cs`）。
  - 万一インフラ配線より先に本 PR がデプロイされても staging/production は起動でき、`client_secret` は現状どおり平文で動作（元々平文のため回帰なし）。鍵設定後に暗号化へ自動切替。
  - フォールバック時は起動ログ（stdout → `AppServiceConsoleLogs`）に `[WARN] ...` を出力。
- 追加コミット: EF Core を 10.0.9 に追従（IdpUtilities 2.1.0 の推移依存 NU1605 対策）、DI フォールバック。
