### PR TITLE
feat: client_secret 平文行を Key Vault 暗号化へ移行する backfill を追加

### DIFF
--- a/.github/scripts/resolve-kv-key-id.sh
+++ b/.github/scripts/resolve-kv-key-id.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# 対象 App Service の app_settings から client_secret 暗号化用の Key Vault 鍵 URI を取得する。
+# Terraform が管理する app_settings（単一ソース）を再利用し、本番 Key Vault の URL を
+# リポジトリに焼き込まないための間接取得。
+#
+# 必須環境変数:
+#   APP_NAME  対象 Web App 名（例: ecauth-staging-xxxx）
+# 出力:
+#   $GITHUB_OUTPUT に key_id=<Key Vault 鍵 URI>
+#
+# 前提: 事前に azure/login 済みで az CLI がサブスクリプションにアクセスできること。
+
+set -euo pipefail
+
+if [ -z "${APP_NAME:-}" ]; then
+  echo "APP_NAME が未設定です" >&2
+  exit 1
+fi
+
+APP_ID=$(az webapp list --query "[?name=='${APP_NAME}'].id | [0]" -o tsv)
+if [ -z "${APP_ID}" ]; then
+  echo "Web App が見つかりません: ${APP_NAME}" >&2
+  exit 1
+fi
+
+KEY_ID=$(az webapp config appsettings list --ids "${APP_ID}" \
+  --query "[?name=='ClientSecretProtection__KeyVaultKeyId'].value | [0]" -o tsv)
+if [ -z "${KEY_ID}" ]; then
+  echo "ClientSecretProtection__KeyVaultKeyId が ${APP_NAME} の app_settings に設定されていません" >&2
+  echo "（インフラ側の鍵配線が完了しているか確認してください）" >&2
+  exit 1
+fi
+
+# 非秘密だが、本番 Key Vault の URL をログに残さないためマスクする。
+echo "::add-mask::${KEY_ID}"
+echo "key_id=${KEY_ID}" >> "${GITHUB_OUTPUT}"
+echo "Resolved Key Vault key id for ${APP_NAME} (masked)."

--- a/.github/workflows/backfill-client-secrets.yml
+++ b/.github/workflows/backfill-client-secrets.yml
@@ -47,6 +47,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # 後続は Azure ログイン + 1Password + 明示的な NuGet トークンで認証するため、
+          # checkout が永続化する GitHub トークンは不要。残存による漏洩リスクを避ける。
+          persist-credentials: false
 
       - name: Load secrets from 1Password
         uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
@@ -117,6 +121,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # 後続は Azure ログイン + 1Password + 明示的な NuGet トークンで認証するため、
+          # checkout が永続化する GitHub トークンは不要。残存による漏洩リスクを避ける。
+          persist-credentials: false
 
       - name: Load secrets from 1Password
         uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1

--- a/.github/workflows/backfill-client-secrets.yml
+++ b/.github/workflows/backfill-client-secrets.yml
@@ -1,0 +1,174 @@
+name: Backfill client_secret encryption
+
+# 既存の平文 client.client_secret を Key Vault 暗号化（kv1:）へ移行する一回限りの手動ジョブ（EcAuthDocs#106）。
+# 暗号化はローカル処理（公開鍵取得）で行われるため、実行アイデンティティに必要な鍵権限は Get のみ。
+# CI の ecauth-workload-identity は Terraform アクセスポリシー経由で対象鍵に Get を持つ（crypto_key_names 設定済み環境）。
+#
+# 前提: 対象環境に暗号化対応版（ISecretProtector 導入済み）がデプロイ済みであること。
+#       未対応版が稼働していると kv1: 値をリテラル比較して認証が壊れる。
+# 既定は dry-run（対象の列挙のみ・KV 呼び出しと DB 書き込みなし）。実行は dry_run=false を明示する。
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Target environment'
+        required: true
+        type: choice
+        options:
+          - staging
+          - production
+        default: staging
+      dry_run:
+        description: 'Dry run (list targets only; no KV calls, no DB writes)'
+        required: false
+        type: boolean
+        default: true
+
+concurrency:
+  group: backfill-client-secrets-${{ inputs.environment }}
+  cancel-in-progress: false
+
+env:
+  DOTNET_VERSION: '10.0.x'
+
+jobs:
+  backfill-staging:
+    if: inputs.environment == 'staging'
+    runs-on: ubuntu-latest
+    environment:
+      name: staging
+
+    permissions:
+      contents: read
+      packages: read
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Load secrets from 1Password
+        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_NONPROD }}
+          SQL_HOST: op://EcAuth/ecauth-staging-sql/hostname
+          SQL_DATABASE: op://EcAuth/ecauth-staging-sql/database
+          SQL_USERNAME: op://EcAuth/ecauth-staging-sql/username
+          SQL_PASSWORD: op://EcAuth/ecauth-staging-sql/password
+          WEB_APP_SUFFIX: op://EcAuth/ecauth-staging-app/web_app_suffix
+          AZURE_CLIENT_ID: op://EcAuth/ecauth-workload-identity/AZURE_CLIENT_ID
+          AZURE_TENANT_ID: op://EcAuth/ecauth-workload-identity/AZURE_TENANT_ID
+          AZURE_SUBSCRIPTION_ID: op://EcAuth/ecauth-workload-identity/AZURE_SUBSCRIPTION_ID
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Add GitHub Packages source with credentials
+        run: |
+          dotnet nuget remove source github || true
+          dotnet nuget add source https://nuget.pkg.github.com/EcAuth/index.json \
+            --name github \
+            --username ${{ github.actor }} \
+            --password ${{ secrets.ORG_PAT || secrets.PACKAGES_READ_TOKEN }} \
+            --store-password-in-clear-text
+
+      - name: Build ConsoleApp
+        run: dotnet build ConsoleApp/EcAuthConsoleApp.csproj --configuration Release
+
+      - name: Login to Azure
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        with:
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Resolve Key Vault key id from app settings
+        id: kv
+        env:
+          APP_NAME: ecauth-staging-${{ env.WEB_APP_SUFFIX }}
+        run: ./.github/scripts/resolve-kv-key-id.sh
+
+      - name: Run backfill
+        env:
+          ClientSecretProtection__KeyVaultKeyId: ${{ steps.kv.outputs.key_id }}
+        run: |
+          CONNECTION_STRING="Server=tcp:${SQL_HOST},1433;Initial Catalog=${SQL_DATABASE};User ID=${SQL_USERNAME};Password=${SQL_PASSWORD};Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+          echo "::add-mask::${CONNECTION_STRING}"
+          export ConnectionStrings__EcAuthDbContext="${CONNECTION_STRING}"
+          dotnet run --project ConsoleApp/EcAuthConsoleApp.csproj --configuration Release --no-build -- \
+            backfill-client-secrets ${{ (inputs.dry_run && '--dry-run') || '' }}
+
+  backfill-production:
+    if: inputs.environment == 'production'
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+
+    permissions:
+      contents: read
+      packages: read
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Load secrets from 1Password
+        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_PROD }}
+          SQL_HOST: op://EcAuth/ecauth-prod-sql/hostname
+          SQL_DATABASE: op://EcAuth/ecauth-prod-sql/database
+          SQL_USERNAME: op://EcAuth/ecauth-prod-sql/username
+          SQL_PASSWORD: op://EcAuth/ecauth-prod-sql/password
+          WEB_APP_SUFFIX: op://EcAuth/ecauth-prod-app/web_app_suffix
+          AZURE_CLIENT_ID: op://EcAuth/ecauth-workload-identity/AZURE_CLIENT_ID
+          AZURE_TENANT_ID: op://EcAuth/ecauth-workload-identity/AZURE_TENANT_ID
+          AZURE_SUBSCRIPTION_ID: op://EcAuth/ecauth-workload-identity/AZURE_SUBSCRIPTION_ID
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Add GitHub Packages source with credentials
+        run: |
+          dotnet nuget remove source github || true
+          dotnet nuget add source https://nuget.pkg.github.com/EcAuth/index.json \
+            --name github \
+            --username ${{ github.actor }} \
+            --password ${{ secrets.ORG_PAT || secrets.PACKAGES_READ_TOKEN }} \
+            --store-password-in-clear-text
+
+      - name: Build ConsoleApp
+        run: dotnet build ConsoleApp/EcAuthConsoleApp.csproj --configuration Release
+
+      - name: Login to Azure
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        with:
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Resolve Key Vault key id from app settings
+        id: kv
+        env:
+          APP_NAME: ecauth-prod-${{ env.WEB_APP_SUFFIX }}
+        run: ./.github/scripts/resolve-kv-key-id.sh
+
+      - name: Run backfill
+        env:
+          ClientSecretProtection__KeyVaultKeyId: ${{ steps.kv.outputs.key_id }}
+        run: |
+          CONNECTION_STRING="Server=tcp:${SQL_HOST},1433;Initial Catalog=${SQL_DATABASE};User ID=${SQL_USERNAME};Password=${SQL_PASSWORD};Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+          echo "::add-mask::${CONNECTION_STRING}"
+          export ConnectionStrings__EcAuthDbContext="${CONNECTION_STRING}"
+          dotnet run --project ConsoleApp/EcAuthConsoleApp.csproj --configuration Release --no-build -- \
+            backfill-client-secrets ${{ (inputs.dry_run && '--dry-run') || '' }}

--- a/ConsoleApp/Commands/BackfillClientSecretsCommand.cs
+++ b/ConsoleApp/Commands/BackfillClientSecretsCommand.cs
@@ -1,0 +1,98 @@
+using ConsoleAppFramework;
+using IdentityProvider.Models;
+using IdpUtilities.Security;
+using Microsoft.EntityFrameworkCore;
+
+namespace EcAuthConsoleApp.Commands
+{
+    /// <summary>
+    /// 平文のまま保存されている <c>client.client_secret</c> を Key Vault 暗号化（<c>kv1:</c> エンベロープ）へ
+    /// 移行する一回限りの backfill コマンド（EcAuthDocs#106）。
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// 暗号化導入前にシードされた既存クライアントの <c>client_secret</c> は平文のまま残る
+    /// （冪等シーダーは既存行を skip するため）。認証はレガシー平文経路で従来どおり動くが、暗号化の
+    /// 恩恵は受けられない。本コマンドで既存の平文行を <c>ProtectAsync</c> により <c>kv1:</c> 化する。
+    /// </para>
+    /// <para>
+    /// <b>冪等</b>: 既に <c>kv1:</c> の行は skip する。何度実行しても安全。
+    /// </para>
+    /// <para>
+    /// <b>実行前提</b>: 暗号化を検証できるのは暗号化対応アプリ（ISecretProtector 導入済み）が稼働する環境
+    /// だけなので、対象環境が暗号化対応版をデプロイ済みであること。<c>ClientSecretProtection__KeyVaultKeyId</c>
+    /// が設定され、実行アイデンティティが対象鍵に <c>Get</c> 権限を持つこと（暗号化はローカル処理のため
+    /// <c>Get</c> で足りる）。
+    /// </para>
+    /// </remarks>
+    [RegisterCommands]
+    internal class BackfillClientSecretsCommand
+    {
+        private const string KeyVaultSchemePrefix = "kv1:";
+
+        private readonly EcAuthDbContext _db;
+        private readonly ISecretProtector _secretProtector;
+
+        public BackfillClientSecretsCommand(EcAuthDbContext db, ISecretProtector secretProtector)
+        {
+            _db = db;
+            _secretProtector = secretProtector;
+        }
+
+        /// <summary>
+        /// 平文の client.client_secret を Key Vault 暗号化（kv1:）へ移行する。
+        /// </summary>
+        /// <param name="dryRun">-d, 実際には保存せず対象件数のみ表示する。</param>
+        public async Task BackfillClientSecrets(bool dryRun = false, CancellationToken cancellationToken = default)
+        {
+            // Client 自体はテナントフィルタを持たないが、将来フィルタが追加されても全テナントを
+            // 対象化できるよう防御的に IgnoreQueryFilters() を付ける。
+            var clients = await _db.Clients
+                .IgnoreQueryFilters()
+                .ToListAsync(cancellationToken);
+
+            var total = clients.Count;
+            var migrated = 0;
+            var alreadyEncrypted = 0;
+            var empty = 0;
+
+            foreach (var client in clients)
+            {
+                if (string.IsNullOrEmpty(client.ClientSecret))
+                {
+                    empty++;
+                    continue;
+                }
+
+                // kv1: プレフィックスの有無で暗号化済みか判定する。SecretEnvelope は IdpUtilities 内 internal の
+                // ため、ここでは公開されたエンベロープ規約（プレフィックス = 暗号化済み / 無印 = レガシー平文）で判定する。
+                if (client.ClientSecret.StartsWith(KeyVaultSchemePrefix, StringComparison.Ordinal))
+                {
+                    alreadyEncrypted++;
+                    continue;
+                }
+
+                if (dryRun)
+                {
+                    // 値そのものは出力しない（client_id のみ）。
+                    Console.WriteLine($"[dry-run] would encrypt: client_id={client.ClientId}");
+                    migrated++;
+                    continue;
+                }
+
+                client.ClientSecret = await _secretProtector.ProtectAsync(client.ClientSecret, cancellationToken);
+                migrated++;
+                Console.WriteLine($"encrypted: client_id={client.ClientId}");
+            }
+
+            if (!dryRun && migrated > 0)
+            {
+                await _db.SaveChangesAsync(cancellationToken);
+            }
+
+            Console.WriteLine(
+                $"Backfill {(dryRun ? "(dry-run) " : string.Empty)}completed: " +
+                $"total={total}, migrated={migrated}, already_encrypted={alreadyEncrypted}, empty={empty}");
+        }
+    }
+}

--- a/ConsoleApp/Commands/BackfillClientSecretsCommand.cs
+++ b/ConsoleApp/Commands/BackfillClientSecretsCommand.cs
@@ -45,8 +45,11 @@ namespace EcAuthConsoleApp.Commands
         /// <param name="dryRun">-d, 実際には保存せず対象件数のみ表示する。</param>
         public async Task BackfillClientSecrets(bool dryRun = false, CancellationToken cancellationToken = default)
         {
-            // Client 自体はテナントフィルタを持たないが、将来フィルタが追加されても全テナントを
-            // 対象化できるよう防御的に IgnoreQueryFilters() を付ける。
+            // これは全テナント横断の管理バッチ（平文 client_secret を漏れなく暗号化する）であり、
+            // IgnoreQueryFilters() でテナント分離を意図的にバイパスするのが正しい挙動。
+            // Client 自体は現在テナントフィルタを持たないため今日時点では冗長だが、将来 Client に
+            // フィルタが追加されると、ConsoleApp は TenantName=null のため対象行をサイレントに取りこぼし、
+            // 平文の secret が暗号化されずに残る（移行ツールとして最悪の失敗）。それを防ぐため全件を対象化する。
             var clients = await _db.Clients
                 .IgnoreQueryFilters()
                 .ToListAsync(cancellationToken);

--- a/ConsoleApp/Program.cs
+++ b/ConsoleApp/Program.cs
@@ -1,19 +1,39 @@
-﻿using ConsoleAppFramework;
+using ConsoleAppFramework;
 using IdentityProvider.Models;
+using IdentityProvider.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
 var configuration = new ConfigurationBuilder()
     .AddEnvironmentVariables()
     .Build();
+
 using var host = Host.CreateDefaultBuilder()
-    .ConfigureServices((hostContext, services) => {
+    .ConfigureServices((hostContext, services) =>
+    {
         services.AddDbContext<EcAuthDbContext>(options =>
-            options.UseSqlServer(configuration["ConnectionStrings:EcAuthDbContext"]))
-            .BuildServiceProvider();
+            options.UseSqlServer(configuration["ConnectionStrings:EcAuthDbContext"]));
+
+        // EcAuthDbContext のコンストラクタが ITenantService を要求する。Client エンティティ自体は
+        // テナントフィルタを持たないため、テナント未設定（TenantName = null）でも全クライアントを列挙できる。
+        services.AddSingleton<ITenantService, TenantService>();
+
+        // client_secret の保存時暗号化（EcAuthDocs#106）。backfill は「平文 → kv1: 暗号化」が目的のため、
+        // アプリ本体の平文フォールバック（保険）とは異なり Key Vault 必須とする。鍵 URI 未設定なら
+        // AddSecretProtection が InvalidOperationException を投げ、平文で no-op 実行される事故を防ぐ。
+        services.AddSecretProtection(options =>
+        {
+            options.UsePlaintext = false;
+            options.KeyVaultKeyId = configuration["ClientSecretProtection:KeyVaultKeyId"];
+        });
+
+        services.AddLogging(builder => builder.AddSimpleConsole());
     }).Build();
+
 ConsoleApp.ServiceProvider = host.Services;
 var app = ConsoleApp.Create();
-    
-app.Run(args);
+
+await app.RunAsync(args);


### PR DESCRIPTION
## 概要

`client_secret` 保存時暗号化（[EcAuthDocs#106](https://github.com/EcAuth/EcAuthDocs/issues/106)）の **backfill（既存平文行の移行）** です。[EcAuth#447](https://github.com/EcAuth/EcAuth/pull/447)（暗号化本体）の後続 PR。

暗号化導入前にシードされた既存クライアントの `client_secret` は**平文のまま残る**（冪等シーダーが既存行を skip するため）。認証はレガシー平文経路で従来どおり動くが暗号化の恩恵を受けられない。本 PR は既存の平文行を Key Vault 暗号化（`kv1:` エンベロープ）へ再暗号化する一回限りのコマンドと、それを実行する手動ワークフローを追加する。

## 変更内容

- **`ConsoleApp/Commands/BackfillClientSecretsCommand.cs`**（新規）
  - `backfill-client-secrets` コマンド。無印（平文）の `client_secret` のみ `ProtectAsync` で `kv1:` 化。
  - **冪等**: 既に `kv1:` の行は skip。何度実行しても安全。
  - `--dry-run`（`-d`）で対象を列挙するのみ（KV 呼び出し・DB 書き込みなし）。
  - `Client` はテナントフィルタ非対象だが、将来の追加に備え `IgnoreQueryFilters()` で全テナントを対象化。
  - 値そのものはログに出さず `client_id` のみ出力。
- **`ConsoleApp/Program.cs`**
  - DI に `ITenantService`（`EcAuthDbContext` の ctor が要求）と `AddSecretProtection` を配線。
  - backfill は暗号化が目的のため **Key Vault 必須**（`UsePlaintext=false`）。鍵 URI 未設定は明示エラーにし、平文 no-op 実行を防ぐ。
- **`.github/workflows/backfill-client-secrets.yml`**（新規, `workflow_dispatch`）
  - 入力: `environment`（staging / production）, `dry_run`（既定 **true**）。
  - CI の `ecauth-workload-identity` で Azure ログインして実行。
  - 鍵 URI は**対象 App Service の `app_settings` から取得**（Terraform 管理の単一ソースを再利用し、本番 KV URL をリポジトリに焼き込まない）。
- **`.github/scripts/resolve-kv-key-id.sh`**（新規）— 上記の鍵 URI 取得スクリプト。

## 権限設計（重要）

- 暗号化（`ProtectAsync`）は `CryptographyClient` が**公開鍵を取得してローカルで実行**するため、実行 identity に必要な鍵権限は **`Get` のみ**（`Encrypt` は不要）。
- staging KV の `terraform` アクセスポリシーは `object_id = data.azurerm_client_config.current.object_id`（= CI の `ecauth-workload-identity`）に `crypto_key_names` 指定時 `Get` を付与済み → **staging は追加のインフラ変更なしで実行可能**。
- production は PR[4]（`environments/production/main.tf` に `crypto_key_names` 追加）を apply した後に同様に `Get` が付く → **production backfill は PR[4] 適用後**。

## 実行順序（依存関係）

暗号化（`kv1:`）値を検証できるのは**暗号化対応版（`ISecretProtector` 導入済み）が稼働する環境だけ**。未対応版が動いていると `kv1:` をリテラル比較して認証が壊れる。したがって:

```
staging:   #447 マージ → staging(main) が暗号化対応 → 本 workflow を staging dry-run → 本実行 → 検証
production: PR[4] apply → production を #447 込みでデプロイ → 本 workflow を production dry-run → 本実行 → 検証
```

## 検証

- `dotnet build ConsoleApp/EcAuthConsoleApp.csproj -c Release` … **0 エラー**
- `--help` / `backfill-client-secrets --help` … コマンド・`--dry-run` 生成を確認
- ローカル SQL Server 未起動のため、**実 DB/実 identity での検証は staging の `dry_run=true` 実行**で行う（KV 呼び出し・書き込みなし）。

## ロールバック・安全性

- backfill は前進のみだが、`kv1:` 行も `UnprotectAsync` で平文へ戻せる（緊急時）。
- 未移行の平文行はレガシー経路で従来どおり動くため、**部分適用でも認証は壊れない**。
- production KV は `purge_protection=true`・soft-delete 90日で鍵消失から保護済み。

Refs: EcAuthDocs#106, EcAuth#447

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 既存の平文クライアントシークレットを、Azure Key Vaultによる暗号化形式へ一括移行できる手動ワークフローを追加しました。
  - staging／productionを選択して実行できます。
  - dry run（既定）では対象件数の確認のみ行い、データを変更しません。
  - 移行済み・空の値は自動的にスキップされます。
  - 完了時に対象数、移行数、スキップ数などの結果を表示します。

- **セキュリティ**
  - 秘密情報やKey VaultのキーURIをログ上でマスクします。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->