### PR TITLE
fix: backfill 実行時にランナー IP を SQL ファイアウォールへ一時許可

### DIFF
--- a/.github/scripts/sql-firewall.sh
+++ b/.github/scripts/sql-firewall.sh
@@ -27,9 +27,15 @@ SQL_SERVER="${SQL_HOST%%.database.windows.net}"
 RULE_NAME="gh-backfill-${RUN_ID}"
 
 # リソースグループはサーバー名でサーバーサイド解決する。
-RESOURCE_GROUP=$(az resource list --name "${SQL_SERVER}" --resource-type "Microsoft.Sql/servers" --query "[0].resourceGroup" -o tsv)
+# az の一過性失敗で set -e により即死しないよう || true を付ける。
+RESOURCE_GROUP=$(az resource list --name "${SQL_SERVER}" --resource-type "Microsoft.Sql/servers" --query "[0].resourceGroup" -o tsv 2>/dev/null || true)
 if [ -z "${RESOURCE_GROUP}" ]; then
   echo "SQL Server が見つかりません: ${SQL_SERVER}" >&2
+  # remove は always() のクリーンアップで走るため、RG 未解決でもワークフローを
+  # 失敗扱いにしない（best-effort）。add は許可できないと backfill も失敗するため fail-fast。
+  if [ "${ACTION}" = "remove" ]; then
+    exit 0
+  fi
   exit 1
 fi
 

--- a/.github/scripts/sql-firewall.sh
+++ b/.github/scripts/sql-firewall.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+# backfill 実行のため、GitHub ランナーの IP を Azure SQL Server のファイアウォールに
+# 一時許可 / 解除する。azure/sql-action が内部で行うのと同じことを、.NET アプリ
+# （ConsoleApp backfill）から直接接続するために明示的に行う。
+#
+# 使い方:
+#   sql-firewall.sh add      ランナー IP を一時許可
+#   sql-firewall.sh remove   一時許可を解除（常に実行する。失敗しても無視）
+#
+# 必須環境変数:
+#   SQL_HOST  Azure SQL の FQDN（例: ecauth-staging-sql-xxxx.database.windows.net）
+#   RUN_ID    実行ごとに一意なルール名を作るための ID（github.run_id）
+# 前提: 事前に azure/login 済みで、identity が SQL Server のファイアウォール管理権限を持つこと。
+
+set -euo pipefail
+
+ACTION="${1:?add または remove を指定してください}"
+
+if [ -z "${SQL_HOST:-}" ] || [ -z "${RUN_ID:-}" ]; then
+  echo "SQL_HOST / RUN_ID が未設定です" >&2
+  exit 1
+fi
+
+# FQDN からサーバーのリソース名を取り出す（.database.windows.net を除去）。
+SQL_SERVER="${SQL_HOST%%.database.windows.net}"
+RULE_NAME="gh-backfill-${RUN_ID}"
+
+# リソースグループはサーバー名でサーバーサイド解決する。
+RESOURCE_GROUP=$(az resource list --name "${SQL_SERVER}" --resource-type "Microsoft.Sql/servers" --query "[0].resourceGroup" -o tsv)
+if [ -z "${RESOURCE_GROUP}" ]; then
+  echo "SQL Server が見つかりません: ${SQL_SERVER}" >&2
+  exit 1
+fi
+
+case "${ACTION}" in
+  add)
+    RUNNER_IP=$(curl -fsS https://api.ipify.org)
+    if [ -z "${RUNNER_IP}" ]; then
+      echo "ランナー IP を取得できませんでした" >&2
+      exit 1
+    fi
+    az sql server firewall-rule create \
+      -g "${RESOURCE_GROUP}" -s "${SQL_SERVER}" -n "${RULE_NAME}" \
+      --start-ip-address "${RUNNER_IP}" --end-ip-address "${RUNNER_IP}" --output none
+    echo "一時ファイアウォールルールを追加しました: ${RULE_NAME}"
+    ;;
+  remove)
+    # クリーンアップは冪等・ベストエフォート（存在しなくてもエラーにしない）。
+    az sql server firewall-rule delete \
+      -g "${RESOURCE_GROUP}" -s "${SQL_SERVER}" -n "${RULE_NAME}" --output none || true
+    echo "一時ファイアウォールルールを削除しました: ${RULE_NAME}"
+    ;;
+  *)
+    echo "不明なアクション: ${ACTION}（add または remove）" >&2
+    exit 1
+    ;;
+esac

--- a/.github/workflows/backfill-client-secrets.yml
+++ b/.github/workflows/backfill-client-secrets.yml
@@ -31,6 +31,8 @@ concurrency:
 
 env:
   DOTNET_VERSION: '10.0.x'
+  # SQL ファイアウォールの一時ルール名に使う（実行ごとに一意）。sql-firewall.sh が参照。
+  RUN_ID: ${{ github.run_id }}
 
 jobs:
   backfill-staging:
@@ -97,6 +99,11 @@ jobs:
           APP_NAME: ecauth-staging-${{ env.WEB_APP_SUFFIX }}
         run: ./.github/scripts/resolve-kv-key-id.sh
 
+      # backfill は .NET アプリから DB へ直接接続するため、azure/sql-action と同様に
+      # ランナー IP を SQL ファイアウォールへ一時許可する（完了時に必ず解除）。
+      - name: Allow runner IP on SQL firewall
+        run: ./.github/scripts/sql-firewall.sh add
+
       - name: Run backfill
         env:
           ClientSecretProtection__KeyVaultKeyId: ${{ steps.kv.outputs.key_id }}
@@ -106,6 +113,10 @@ jobs:
           export ConnectionStrings__EcAuthDbContext="${CONNECTION_STRING}"
           dotnet run --project ConsoleApp/EcAuthConsoleApp.csproj --configuration Release --no-build -- \
             backfill-client-secrets ${{ (inputs.dry_run && '--dry-run') || '' }}
+
+      - name: Remove runner IP from SQL firewall
+        if: always()
+        run: ./.github/scripts/sql-firewall.sh remove
 
   backfill-production:
     if: inputs.environment == 'production'
@@ -171,6 +182,11 @@ jobs:
           APP_NAME: ecauth-prod-${{ env.WEB_APP_SUFFIX }}
         run: ./.github/scripts/resolve-kv-key-id.sh
 
+      # backfill は .NET アプリから DB へ直接接続するため、azure/sql-action と同様に
+      # ランナー IP を SQL ファイアウォールへ一時許可する（完了時に必ず解除）。
+      - name: Allow runner IP on SQL firewall
+        run: ./.github/scripts/sql-firewall.sh add
+
       - name: Run backfill
         env:
           ClientSecretProtection__KeyVaultKeyId: ${{ steps.kv.outputs.key_id }}
@@ -180,3 +196,7 @@ jobs:
           export ConnectionStrings__EcAuthDbContext="${CONNECTION_STRING}"
           dotnet run --project ConsoleApp/EcAuthConsoleApp.csproj --configuration Release --no-build -- \
             backfill-client-secrets ${{ (inputs.dry_run && '--dry-run') || '' }}
+
+      - name: Remove runner IP from SQL firewall
+        if: always()
+        run: ./.github/scripts/sql-firewall.sh remove


### PR DESCRIPTION
## 概要

backfill ワークフローの staging dry-run（run 29171989779）で `Run backfill` が Azure SQL 接続失敗で落ちたための修正。

`Resolve Key Vault key id`（[#449](https://github.com/EcAuth/EcAuth/pull/449) で修正）は通過するようになったが、次の `Run backfill` で以下が発生:

```
Microsoft.Data.SqlClient.SqlException: A network-related or instance-specific error occurred
while establishing a connection to SQL Server ... (provider: TCP Provider, error: 35)
```

## 原因

**ランナー IP が Azure SQL のファイアウォールで未許可**のため。`staging.yml` の migrate は `azure/sql-action` が `azure/login` の identity を使ってランナー IP を一時許可/解除しているが、backfill は **.NET アプリ（ConsoleApp）から直接接続**するためその機構が働かない。

（接続文字列は migrate と同一で正しく、`az login`・鍵取得・DB 認証情報取得は成功済み。純粋にネットワーク到達性の問題。）

## 修正

- **`.github/scripts/sql-firewall.sh`**（新規）: `add`/`remove` でランナー IP を SQL ファイアウォールへ一時許可・解除。サーバー名は `SQL_HOST` から導出、リソースグループは `az resource list`（サーバーサイドフィルタ）で解決、ルール名は `run_id` で一意化。
- **`backfill-client-secrets.yml`**: 両 job で `Run backfill` の前に `add`、後に `remove`（`if: always()`）を追加。`RUN_ID` を top-level env に追加。

## 権限について

`azure/sql-action`（staging migrate で稼働中）は**同じ identity（`ecauth-workload-identity`）で**ファイアウォールルールを add/remove している。migrate が成功している以上、この identity は既に SQL ファイアウォール管理権限を持つことが確定しており、**別途権限付与は不要**。

## 検証

- `bash -n` / YAML パース … OK
- マージ後、staging を `dry_run=true` で再実行し `Run backfill`（対象 client_id 列挙）まで通ることを確認する。

Refs: EcAuthDocs#106, EcAuth#448, EcAuth#449

🤖 Generated with [Claude Code](https://claude.com/claude-code)