### PR TITLE
fix: backfill の dotnet run に --no-launch-profile を付与（接続先 127.0.0.1 問題）

### DIFF
--- a/.github/workflows/backfill-client-secrets.yml
+++ b/.github/workflows/backfill-client-secrets.yml
@@ -111,7 +111,10 @@ jobs:
           CONNECTION_STRING="Server=tcp:${SQL_HOST},1433;Initial Catalog=${SQL_DATABASE};User ID=${SQL_USERNAME};Password=${SQL_PASSWORD};Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
           echo "::add-mask::${CONNECTION_STRING}"
           export ConnectionStrings__EcAuthDbContext="${CONNECTION_STRING}"
-          dotnet run --project ConsoleApp/EcAuthConsoleApp.csproj --configuration Release --no-build -- \
+          # --no-launch-profile: launchSettings.json の environmentVariables（ローカル開発用の
+          # ConnectionStrings__EcAuthDbContext=Server=127.0.0.1;...）が、上で export した本物の
+          # 接続文字列を上書きするのを防ぐ。
+          dotnet run --project ConsoleApp/EcAuthConsoleApp.csproj --configuration Release --no-build --no-launch-profile -- \
             backfill-client-secrets ${{ (inputs.dry_run && '--dry-run') || '' }}
 
       - name: Remove runner IP from SQL firewall
@@ -194,7 +197,10 @@ jobs:
           CONNECTION_STRING="Server=tcp:${SQL_HOST},1433;Initial Catalog=${SQL_DATABASE};User ID=${SQL_USERNAME};Password=${SQL_PASSWORD};Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
           echo "::add-mask::${CONNECTION_STRING}"
           export ConnectionStrings__EcAuthDbContext="${CONNECTION_STRING}"
-          dotnet run --project ConsoleApp/EcAuthConsoleApp.csproj --configuration Release --no-build -- \
+          # --no-launch-profile: launchSettings.json の environmentVariables（ローカル開発用の
+          # ConnectionStrings__EcAuthDbContext=Server=127.0.0.1;...）が、上で export した本物の
+          # 接続文字列を上書きするのを防ぐ。
+          dotnet run --project ConsoleApp/EcAuthConsoleApp.csproj --configuration Release --no-build --no-launch-profile -- \
             backfill-client-secrets ${{ (inputs.dry_run && '--dry-run') || '' }}
 
       - name: Remove runner IP from SQL firewall


### PR DESCRIPTION
## 概要

backfill の staging dry-run（run 29172465337）で `Run backfill` が SQL 接続失敗し続けた**真因の修正**。

## 根本原因

ログ最上部に決定的な手がかりがあった:

```
fail: Microsoft.EntityFrameworkCore.Database.Connection[20004]
      An error occurred using the connection to database '***' on server '127.0.0.1'.
```

接続先が **`127.0.0.1`（localhost）** になっていた。`dotnet run` は既定で `launchSettings.json` の `environmentVariables` を適用し、そこに定義されたローカル開発用の

```
ConnectionStrings__EcAuthDbContext=Server=127.0.0.1;Database=EcAuthDb;...
```

が、ステップで `export` した本物の接続文字列（Azure SQL）を**上書き**していた。このため 3 回とも Azure SQL に到達せず localhost 宛で失敗していた（`TCP Provider, error 35`）。

> #449（`-g/-n`）・#450（SQL ファイアウォール一時許可）はいずれも正しい対処だが、接続先が 127.0.0.1 だったため実接続では活きていなかった。本修正で接続先が Azure SQL になり、#450 のファイアウォール許可が初めて実接続で機能する。

## 修正

両 job の `dotnet run` に **`--no-launch-profile`** を付与し、`launchSettings.json` の上書きを止める。`AddEnvironmentVariables()` が拾う `export` 済みの接続文字列が使われる。

## 検証

- YAML パース … OK
- マージ後、staging を `dry_run=true` で再実行し、`Run backfill` が Azure SQL へ接続して対象 client_id を列挙することを確認する。

Refs: EcAuthDocs#106, EcAuth#448, EcAuth#449, EcAuth#450

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ステージングおよび本番環境でのクライアントシークレットのバックフィル処理を改善しました。
  * 実行時にローカル開発環境向けの設定が優先される問題を防止し、指定した接続先へ確実に処理できるようになりました。
  * これにより、環境ごとのデータ処理の安全性と信頼性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->