### PR TITLE
test(e2e): ecauth-website のフロントを実 API に通す結合 E2E を追加する

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -151,6 +151,50 @@ jobs:
           MOCK_IDP_BASE_URL: ${{ secrets.MOCK_IDP_BASE_URL }}
           MOCK_IDP_ORG: ${{ env.MOCK_IDP_ORG }}
 
+      # --- ecauth-website（フロント）の配信 ---
+      # website_signup_flow.spec.ts が「フロント → 実 API」の結合を検証するために、
+      # ecauth-website を hugo server で https://ec-auth.io:1313 に配信する。
+      # 別リポジトリへのアクセス権が無い環境でも EcAuth 本体の E2E は回るよう、
+      # checkout 失敗は job を落とさず、その場合は当該 spec がスキップされる（警告を出す）。
+      - name: Checkout ecauth-website
+        id: checkout_website
+        continue-on-error: true
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: EcAuth/ecauth-website
+          path: ecauth-website
+          token: ${{ secrets.ORG_PAT || secrets.PACKAGES_READ_TOKEN || github.token }}
+
+      - name: Setup Hugo
+        if: steps.checkout_website.outcome == 'success'
+        uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f # v3.0.0
+        with:
+          hugo-version: 'latest'
+          extended: true
+
+      - name: Configure frontend wiring
+        if: steps.checkout_website.outcome == 'success'
+        run: |
+          # PKCE（crypto.subtle）は secure context 必須。ec-auth.io は localhost 扱いされないため
+          # フロントは HTTPS で配信する。証明書は自己署名で、Playwright 側が ignoreHTTPSErrors。
+          WEBSITE_BASE="https://ec-auth.io:1313"
+          echo "E2E_WEBSITE_BASE_URL=${WEBSITE_BASE}" >> $GITHUB_ENV
+          # フロントの配信元（PasskeyPageController のマイページ遷移先）
+          echo "Frontend__BaseUrl=${WEBSITE_BASE}" >> $GITHUB_ENV
+          # CORS は scheme+host+port の完全一致比較なのでポートまで含める
+          echo "Signup__AllowedOrigins__0=${WEBSITE_BASE}" >> $GITHUB_ENV
+          # 確認メール / マジックリンクの着地先をフロントに向ける
+          echo "Signup__ConfirmBaseUrl__accounts=${WEBSITE_BASE}" >> $GITHUB_ENV
+          echo "MagicLink__BaseUrl__accounts=${WEBSITE_BASE}" >> $GITHUB_ENV
+          # 管理コンソール Client の redirect_uri（Seeder が登録する値）をフロントの callback に揃える。
+          # account_signup_flow.spec.ts も同じ env を参照するため、両 spec で登録値が一致する。
+          echo "ACCOUNTS_REDIRECT_URI=${WEBSITE_BASE}/auth/callback" >> $GITHUB_ENV
+
+      - name: Warn when ecauth-website is unavailable
+        if: steps.checkout_website.outcome != 'success'
+        run: |
+          echo "::warning title=website E2E skipped::ecauth-website を checkout できなかったため、website_signup_flow.spec.ts はスキップされます（フロント × 実 API の結合は未検証）。"
+
       - name: Set up .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
@@ -219,6 +263,32 @@ jobs:
             exit 1
           fi
 
+      - name: Start ecauth-website (hugo)
+        if: steps.checkout_website.outcome == 'success'
+        working-directory: ecauth-website
+        env:
+          # hugo.toml の既定値を E2E 環境に上書きする（baseof.html が window.ECAUTH に注入）。
+          HUGO_PARAMS_APIBASEURL: https://accounts.ec-auth.io:8081
+          HUGO_PARAMS_AUTHREDIRECTURI: https://ec-auth.io:1313/auth/callback
+        run: |
+          hugo server --tlsAuto --bind 127.0.0.1 --port 1313 \
+            --baseURL https://ec-auth.io:1313/ --appendPort=false --disableFastRender \
+            > /tmp/hugo.log 2>&1 &
+          echo $! > /tmp/hugo.pid
+          for i in {1..30}; do
+            if curl -sk https://127.0.0.1:1313/signup/ > /dev/null 2>&1; then
+              echo "ecauth-website is ready"
+              break
+            fi
+            echo "Waiting for hugo... ($i/30)"
+            sleep 2
+          done
+          if ! curl -sk https://127.0.0.1:1313/signup/ > /dev/null 2>&1; then
+            echo "ERROR: hugo server failed to start"
+            cat /tmp/hugo.log || true
+            exit 1
+          fi
+
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
@@ -258,3 +328,5 @@ jobs:
           cat /tmp/identityprovider.log || echo "No logs available"
           echo "=== .NET exception logs ==="
           cat IdentityProvider/logs/*.log 2>/dev/null || echo "No exception logs found"
+          echo "=== ecauth-website (hugo) logs ==="
+          cat /tmp/hugo.log 2>/dev/null || echo "No hugo logs (website E2E not run)"

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -5,7 +5,19 @@ name: Playwright E2E Tests - IdentityProvider
 # main.yml に集約し、二重起動を避ける。
 on:
   workflow_call:
+    inputs:
+      website_ref:
+        description: 'ecauth-website の ref。空ならデフォルトブランチ（main）'
+        type: string
+        required: false
+        default: ''
   workflow_dispatch:
+    inputs:
+      website_ref:
+        description: 'ecauth-website の ref（例: feat/signup-form）。空ならデフォルトブランチ（main）'
+        type: string
+        required: false
+        default: ''
 
 jobs:
   test:
@@ -162,18 +174,39 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: EcAuth/ecauth-website
+          # 空文字ならデフォルトブランチ。申込／マイページが未マージの間は
+          # workflow_dispatch で website_ref にそのブランチを指定して検証する。
+          ref: ${{ inputs.website_ref }}
           path: ecauth-website
           token: ${{ secrets.ORG_PAT || secrets.PACKAGES_READ_TOKEN || github.token }}
 
-      - name: Setup Hugo
+      # checkout できても、その ref に申込／マイページのテンプレートが無ければ
+      # 結合 E2E は回せない（未マージのデフォルトブランチなど）。ここで判定しておかないと
+      # hugo は起動するが全ページ 404 になり、テストが不可解なタイムアウトで落ちる。
+      - name: Check ecauth-website has the app pages
+        id: website_ready
         if: steps.checkout_website.outcome == 'success'
+        run: |
+          missing=""
+          for f in layouts/_default/signup.html layouts/_default/mypage.html layouts/_default/auth-callback.html; do
+            [ -f "ecauth-website/$f" ] || missing="$missing $f"
+          done
+          if [ -n "$missing" ]; then
+            echo "ready=false" >> $GITHUB_OUTPUT
+            echo "::warning title=website E2E skipped::ecauth-website の ref に申込/マイページのテンプレートがありません（未マージ）:$missing"
+          else
+            echo "ready=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Setup Hugo
+        if: steps.website_ready.outputs.ready == 'true'
         uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f # v3.0.0
         with:
           hugo-version: 'latest'
           extended: true
 
       - name: Configure frontend wiring
-        if: steps.checkout_website.outcome == 'success'
+        if: steps.website_ready.outputs.ready == 'true'
         run: |
           # PKCE（crypto.subtle）は secure context 必須。ec-auth.io は localhost 扱いされないため
           # フロントは HTTPS で配信する。証明書は自己署名で、Playwright 側が ignoreHTTPSErrors。
@@ -264,7 +297,7 @@ jobs:
           fi
 
       - name: Start ecauth-website (hugo)
-        if: steps.checkout_website.outcome == 'success'
+        if: steps.website_ready.outputs.ready == 'true'
         working-directory: ecauth-website
         env:
           # hugo.toml の既定値を E2E 環境に上書きする（baseof.html が window.ECAUTH に注入）。
@@ -275,16 +308,25 @@ jobs:
             --baseURL https://ec-auth.io:1313/ --appendPort=false --disableFastRender \
             > /tmp/hugo.log 2>&1 &
           echo $! > /tmp/hugo.pid
+          # -f を付けて 2xx 以外を失敗にする。-f 無しだと 404 でも exit 0 になり、
+          # 「hugo は起動したが全ページ 404」を ready と誤判定してしまう。
           for i in {1..30}; do
-            if curl -sk https://127.0.0.1:1313/signup/ > /dev/null 2>&1; then
+            if curl -fsk https://127.0.0.1:1313/signup/ -o /dev/null; then
               echo "ecauth-website is ready"
               break
             fi
             echo "Waiting for hugo... ($i/30)"
             sleep 2
           done
-          if ! curl -sk https://127.0.0.1:1313/signup/ > /dev/null 2>&1; then
-            echo "ERROR: hugo server failed to start"
+          # E2E が実際に開くページが 200 で返ることまで確認する。
+          failed=""
+          for path in /signup/ /signup/confirm/ /signin/ /signin/magic-link/ /mypage/ /auth/callback/; do
+            code=$(curl -sk -o /dev/null -w '%{http_code}' "https://127.0.0.1:1313${path}")
+            echo "  ${path} -> ${code}"
+            [ "$code" = "200" ] || failed="$failed ${path}(${code})"
+          done
+          if [ -n "$failed" ]; then
+            echo "ERROR: ecauth-website のページが 200 を返しません:$failed"
             cat /tmp/hugo.log || true
             exit 1
           fi

--- a/E2ETests/playwright.config.ts
+++ b/E2ETests/playwright.config.ts
@@ -53,11 +53,16 @@ export default defineConfig({
         //   （3 セグメント以上で TenantMiddleware が tenant=accounts に解決）。CI / ローカル両方で必要。
         //   WebAuthn の rp_id を origin と一致させ、B2BUser 解決を accounts テナントで行うため、
         //   passkey ページはこのホストで配信する。
+        // - ec-auth.io: ecauth-website（Hugo）のフロント配信元。website_signup_flow spec が
+        //   本番と同じホスト名でフロントを開くために必要（MAP は完全一致なので accounts とは別に要る）。
+        //   crypto.subtle（PKCE）は secure context 必須で、ec-auth.io は localhost 扱いされないため、
+        //   フロントは hugo server --tlsAuto の HTTPS で配信する（証明書は ignoreHTTPSErrors で許容）。
         // - mockopenidprovider: ローカル Docker 環境の MockIdP 解決（GitHub Actions では不要）。
         launchOptions: {
           args: [
             '--host-resolver-rules=' + [
               'MAP accounts.ec-auth.io 127.0.0.1',
+              'MAP ec-auth.io 127.0.0.1',
               ...(process.env.CI
                 ? []
                 : ['MAP mockopenidprovider:8081 127.0.0.1:9091', 'MAP mockopenidprovider:8080 127.0.0.1:9090']),

--- a/E2ETests/tests/specs/account_signup_flow.spec.ts
+++ b/E2ETests/tests/specs/account_signup_flow.spec.ts
@@ -200,10 +200,15 @@ test.describe.serial('Account 申込フローの E2E テスト', () => {
     }
 
     // 認証成功でサーバーが生成した redirect_url へ遷移する。
-    // redirect_uri（/auth/callback）は IdP 側に実体が無く 404 になるが、
-    // ナビゲーション自体は完了するため URL から認可コードを取り出せる。
+    // 本 spec は認可コードを URL から取り出すだけで、redirect_uri の先に実体があるかは問わない。
+    //   - IdP 上に実体が無い場合（既定の https://localhost:8081/auth/callback）は 404 になる
+    //   - ecauth-website を配信している場合（CI が ACCOUNTS_REDIRECT_URI をフロントに向ける）は
+    //     Hugo が正規形へ 301 するため、パスに末尾スラッシュが付く（/auth/callback → /auth/callback/）
+    // どちらでもナビゲーションは完了するので、末尾スラッシュを任意として待つ。
+    // なお、この着地ページ（auth-callback.js）は sessionStorage に state / verifier が無いと
+    // トークン交換せずエラー表示で留まるため、URL は書き換わらない。
     const escapedRedirectUri = accountsRedirectUri.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    await page.waitForURL(new RegExp(escapedRedirectUri + '\\?code='), { timeout: 15000 });
+    await page.waitForURL(new RegExp(escapedRedirectUri + '/?\\?code='), { timeout: 15000 });
 
     const url = new URL(page.url());
     authorizationCode = url.searchParams.get('code')!;

--- a/E2ETests/tests/specs/website_signup_flow.spec.ts
+++ b/E2ETests/tests/specs/website_signup_flow.spec.ts
@@ -1,0 +1,288 @@
+import { test, expect, BrowserContext, Page, APIRequestContext, request } from '@playwright/test';
+import { waitForMessage, extractToken, deleteMessages } from '../helpers/mailpit';
+
+/**
+ * ecauth-website（ec-auth.io）のフロントを実バックエンドに通すフル結合 E2E。
+ *
+ * ecauth-website リポジトリ側の E2E（e2e/tests/*.spec.ts）は API を page.route() で
+ * スタブするため高速に回るが、**実 API との契約齟齬・実 CORS・実 WebAuthn** は検出できない。
+ * 本 spec がその層を担当する:
+ *
+ *   確認メール URL がフロントを指すか（Signup:ConfirmBaseUrl の配線）
+ *     → /signup/confirm/ で確定（クロスオリジン CORS）
+ *     → accounts の /passkey/register で実パスキー登録（登録トークンをフラグメントで受け渡し）
+ *     → Frontend:BaseUrl 経由でマイページへ復帰
+ *     → /mypage/ から PKCE で認可開始 → accounts で実パスキー認証 → 認可コード
+ *     → /auth/callback が /v1/token でトークン交換（public client・PKCE）
+ *     → /v1/account/clients で Client 一覧、secret の reveal / 再生成
+ *     → リカバリ（マジックリンク）でも同じマイページに着地する
+ *
+ * 前提（CI では playwright.yml が用意する）:
+ *   - IdentityProvider が https://localhost:8081 で稼働し、accounts.ec-auth.io に解決すること
+ *   - ecauth-website を hugo server --tlsAuto で E2E_WEBSITE_BASE_URL に配信していること
+ *   - サーバ側が以下を website のオリジンに向けて配線していること
+ *       Signup__AllowedOrigins__0 / Frontend__BaseUrl /
+ *       Signup__ConfirmBaseUrl__accounts / MagicLink__BaseUrl__accounts / ACCOUNTS_REDIRECT_URI
+ *
+ * ホスト名解決は playwright.config.ts の --host-resolver-rules が
+ * ec-auth.io / accounts.ec-auth.io をいずれも 127.0.0.1 に向ける。
+ */
+
+/** フロントの配信元。未設定ならこの spec 全体をスキップする（他リポジトリの成果物に依存するため）。 */
+const WEBSITE_BASE = process.env.E2E_WEBSITE_BASE_URL;
+
+test.describe.serial('ecauth-website フロント × EcAuth 実バックエンドの結合 E2E', () => {
+  test.skip(
+    !WEBSITE_BASE,
+    'E2E_WEBSITE_BASE_URL が未設定のためスキップ（ecauth-website を hugo server で配信し、'
+      + 'サーバ側の Frontend__BaseUrl / Signup__AllowedOrigins をそのオリジンに合わせて起動すること）'
+  );
+
+  const websiteBase = (WEBSITE_BASE ?? '').replace(/\/$/, '');
+  const accountsHost = process.env.E2E_ACCOUNTS_HOST || 'accounts.ec-auth.io';
+  const accountsPageBaseUrl = process.env.E2E_ACCOUNTS_PAGE_URL || `https://${accountsHost}:8081`;
+
+  // run ごとに一意化（前回 run の残存データとの衝突を回避）。
+  const runSuffix = `${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+  const email = `e2e-website-${runSuffix}@example.com`;
+  const productionSiteHost = `web-${runSuffix}.example.com`;
+  const expectedOrgCode = productionSiteHost.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+
+  let mailpitCtx: APIRequestContext;
+  let context: BrowserContext;
+  let page: Page;
+
+  let confirmToken: string;
+  const messageIds: string[] = [];
+
+  test.beforeAll(async ({ browser }) => {
+    // 本 spec は全経路をブラウザ（フロント）から通すため、API 直叩き用のコンテキストは持たない。
+    // mailpit だけは REST でメール本文を読む必要がある。
+    mailpitCtx = await request.newContext();
+
+    context = await browser.newContext({ ignoreHTTPSErrors: true });
+    await context.credentials.install();
+
+    // サーバーが返す timeout=0 を上書きする（既存 B2B / Account spec と同じ対処）。
+    // ページ遷移をまたぐため addInitScript で全ページに適用する。
+    await context.addInitScript(() => {
+      const originalCreate = navigator.credentials.create.bind(navigator.credentials);
+      navigator.credentials.create = (options?: CredentialCreationOptions) => {
+        if (options?.publicKey && (!options.publicKey.timeout || options.publicKey.timeout === 0)) {
+          options.publicKey.timeout = 60000;
+        }
+        return originalCreate(options);
+      };
+      const originalGet = navigator.credentials.get.bind(navigator.credentials);
+      navigator.credentials.get = (options?: CredentialRequestOptions) => {
+        if (options?.publicKey && (!options.publicKey.timeout || options.publicKey.timeout === 0)) {
+          options.publicKey.timeout = 60000;
+        }
+        return originalGet(options);
+      };
+    });
+
+    page = await context.newPage();
+    // 失敗時の切り分けのため、フロント JS の例外とコンソールエラーを拾う。
+    page.on('pageerror', (e) => console.log('[pageerror]', e.message));
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        console.log('[console.error]', msg.text());
+      }
+    });
+  });
+
+  test.afterAll(async () => {
+    await deleteMessages(mailpitCtx, messageIds);
+    await mailpitCtx?.dispose();
+    await context?.close();
+  });
+
+  test('申込フォーム（/signup/）から実 API に申し込め、確認メールの URL がフロントを指す', async () => {
+    test.setTimeout(30000);
+
+    await page.goto(`${websiteBase}/signup/`);
+    await page.fill('#email', email);
+    await page.fill('#org', `E2E Website Org ${runSuffix}`);
+    await page.fill('#contact', 'E2E Tester');
+    await page.fill('#prod', `https://${productionSiteHost}`);
+    await page.locator('input[name="ec_cube_version"][value="4"]').check();
+    await page.click('#submit-btn');
+
+    // クロスオリジン（ec-auth.io → accounts.ec-auth.io）の CORS もここで通る。
+    const status = page.locator('#status');
+    await expect(status).toHaveClass(/ok/, { timeout: 15000 });
+    await expect(status).toContainText('確認メールを送信しました');
+
+    const message = await waitForMessage(mailpitCtx, email, { subjectIncludes: 'お申し込み確認' });
+    messageIds.push(message.ID);
+
+    // Signup:ConfirmBaseUrl がフロントに向いていること（バックエンド→フロントの URL 契約）。
+    const body = message.Text || message.HTML;
+    expect(body).toContain(`${websiteBase}/signup/confirm?token=`);
+
+    confirmToken = extractToken(body);
+    expect(confirmToken.length).toBeGreaterThan(10);
+  });
+
+  test('確認ページ（/signup/confirm/）が実 API で申込を確定し、パスキー登録へ誘導する', async () => {
+    test.setTimeout(30000);
+
+    // バックエンドはスラッシュ無しの URL を発行する。静的配信側が
+    // クエリを保持したまま /signup/confirm/ へリダイレクトすること自体も検証対象。
+    await page.goto(`${websiteBase}/signup/confirm?token=${encodeURIComponent(confirmToken)}`);
+    await expect(page).toHaveURL(/\/signup\/confirm\/\?token=/);
+
+    await page.click('#confirm-btn');
+
+    const status = page.locator('#status');
+    await expect(status).toHaveClass(/ok/, { timeout: 15000 });
+    await expect(status).toContainText(email);
+    await expect(page.locator('#next-step')).toBeVisible();
+  });
+
+  test('accounts（/passkey/register）で実パスキーを登録し、マイページへ復帰する', async () => {
+    test.setTimeout(30000);
+
+    await page.click('#passkey-btn');
+    await page.waitForURL(new RegExp('/passkey/register'), { timeout: 15000 });
+
+    // 登録トークンはフラグメントで渡っている（クエリには載らない）。
+    const registerUrl = new URL(page.url());
+    expect(registerUrl.origin).toBe(accountsPageBaseUrl);
+    expect(registerUrl.search).not.toContain('token=');
+    expect(new URLSearchParams(registerUrl.hash.replace(/^#/, '')).get('token')).toBeTruthy();
+
+    await page.click('#reg-btn');
+
+    const status = page.locator('#status');
+    await expect(status).toBeVisible({ timeout: 15000 });
+    const statusClass = await status.getAttribute('class');
+    if (statusClass?.includes('err')) {
+      console.log('Register error:', await status.textContent());
+    }
+
+    // Frontend:BaseUrl の配線どおり、フロントのマイページへ戻る。
+    await page.waitForURL(`${websiteBase}/mypage/`, { timeout: 15000 });
+    // 登録直後はまだアクセストークンが無いため、ログイン導線が出る。
+    await expect(page.locator('#login-view')).toBeVisible();
+  });
+
+  test('マイページから PKCE で認可を開始し、パスキー認証 → トークン交換まで通る', async () => {
+    test.setTimeout(45000);
+
+    await page.click('#login-btn');
+    await page.waitForURL(new RegExp('/passkey/authenticate'), { timeout: 15000 });
+
+    // マイページが組み立てた認可リクエスト（PKCE 必須）。
+    const authorizeUrl = new URL(page.url());
+    expect(authorizeUrl.origin).toBe(accountsPageBaseUrl);
+    expect(authorizeUrl.searchParams.get('code_challenge_method')).toBe('S256');
+    expect(authorizeUrl.searchParams.get('code_challenge')).toBeTruthy();
+    expect(authorizeUrl.searchParams.get('state')).toBeTruthy();
+    expect(authorizeUrl.searchParams.get('redirect_uri')).toBe(`${websiteBase}/auth/callback`);
+
+    await page.click('#auth-btn');
+
+    const status = page.locator('#status');
+    await expect(status).toBeVisible({ timeout: 15000 });
+    const statusClass = await status.getAttribute('class');
+    if (statusClass?.includes('err')) {
+      console.log('Authenticate error:', await status.textContent());
+    }
+
+    // 認可コードは /auth/callback（フロント）へ返り、auth-callback.js が /v1/token で交換して
+    // マイページへ遷移する。中間の callback で止まらずマイページまで到達することを見る。
+    await page.waitForURL(`${websiteBase}/mypage/`, { timeout: 20000 });
+    await expect(page.locator('#app-view')).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('#login-view')).toBeHidden();
+  });
+
+  test('マイページが実 API から Client 一覧を取得して表示する', async () => {
+    test.setTimeout(30000);
+
+    // 申込で作られた顧客 Org の Client が出ること（組織コードはサイト host から導出される）。
+    const item = page.locator('.client-item').filter({ hasText: expectedOrgCode });
+    await expect(item).toHaveCount(1, { timeout: 15000 });
+
+    const idRow = item.locator('.secret-row').filter({ hasText: 'Client ID' });
+    await expect(idRow.locator('code')).not.toBeEmpty();
+
+    // 一覧では secret を返さないため、既定はマスク表示。
+    const secretRow = item.locator('.secret-row').filter({ hasText: 'Client Secret' });
+    await expect(secretRow.locator('code')).toHaveText('•'.repeat(16));
+  });
+
+  test('client_secret を reveal し、再生成すると値が変わる', async () => {
+    test.setTimeout(30000);
+
+    const item = page.locator('.client-item').filter({ hasText: expectedOrgCode });
+    const secretRow = item.locator('.secret-row').filter({ hasText: 'Client Secret' });
+
+    await secretRow.getByRole('button', { name: '表示' }).click();
+    await expect(secretRow.getByRole('button', { name: '隠す' })).toBeVisible({ timeout: 15000 });
+
+    const revealed = (await secretRow.locator('code').textContent())?.trim() ?? '';
+    // 暗号化保存された secret が復号されて返ること（マスクでも空でもない）。
+    expect(revealed.length).toBeGreaterThan(10);
+    expect(revealed).not.toBe('•'.repeat(16));
+
+    page.once('dialog', (dialog) => dialog.accept());
+    await secretRow.getByRole('button', { name: '再生成' }).click();
+
+    await expect(page.locator('#list-status')).toHaveClass(/ok/, { timeout: 15000 });
+    const regenerated = (await secretRow.locator('code').textContent())?.trim() ?? '';
+    expect(regenerated.length).toBeGreaterThan(10);
+    expect(regenerated).not.toBe(revealed);
+  });
+
+  test('リカバリ: /signin/ からマジックリンクを要求し、マイページに着地する', async () => {
+    test.setTimeout(45000);
+
+    // パスキーで得たトークンを捨て、未ログイン状態から始める。
+    await page.goto(`${websiteBase}/mypage/`);
+    await page.click('#logout-link');
+    await expect(page.locator('#login-view')).toBeVisible();
+
+    await page.goto(`${websiteBase}/signin/`);
+    await page.fill('#email', email);
+    await page.click('#submit-btn');
+    await expect(page.locator('#status')).toHaveClass(/ok/, { timeout: 15000 });
+
+    const mail = await waitForMessage(mailpitCtx, email, { subjectIncludes: 'ログインリンク' });
+    messageIds.push(mail.ID);
+
+    // MagicLink:BaseUrl がフロントに向いていること。
+    const body = mail.Text || mail.HTML;
+    expect(body).toContain(`${websiteBase}/signin/magic-link?token=`);
+    const magicToken = extractToken(body);
+
+    await page.goto(`${websiteBase}/signin/magic-link?token=${encodeURIComponent(magicToken)}`);
+    await expect(page).toHaveURL(/\/signin\/magic-link\/\?token=/);
+    await page.click('#login-btn');
+
+    // verify は認可コードではなくトークンを直接返すため /auth/callback を経由しない。
+    await page.waitForURL(`${websiteBase}/mypage/`, { timeout: 20000 });
+    await expect(page.locator('#app-view')).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('.client-item').filter({ hasText: expectedOrgCode })).toHaveCount(1);
+  });
+
+  test('申込フォームのサーバ側バリデーションがフロントに正しく伝わる', async () => {
+    test.setTimeout(30000);
+
+    // 確認済みのドメインで再申込すると organization_already_exists になる
+    // （request 段階の EnsureOrganizationCodesAvailableAsync は 422 を返す）。
+    // サーバの field 指定に応じてフロントが該当入力欄を invalid にすることまで見る。
+    await page.goto(`${websiteBase}/signup/`);
+    await page.fill('#email', `e2e-website-dup-${runSuffix}@example.com`);
+    await page.fill('#org', `E2E Dup Org ${runSuffix}`);
+    await page.fill('#contact', 'E2E Tester');
+    await page.fill('#prod', `https://${productionSiteHost}`);
+    await page.click('#submit-btn');
+
+    const status = page.locator('#status');
+    await expect(status).toHaveClass(/err/, { timeout: 15000 });
+    await expect(status).toContainText('このドメインは既に EcAuth に登録されています');
+    await expect(page.locator('#f-prod')).toHaveClass(/invalid/);
+  });
+});

--- a/compose.yaml
+++ b/compose.yaml
@@ -76,6 +76,15 @@ services:
       STG_ACCOUNTS_CLIENT_SECRET: ${STG_ACCOUNTS_CLIENT_SECRET}
       STG_ACCOUNTS_ALLOWED_RP_IDS: ${STG_ACCOUNTS_ALLOWED_RP_IDS}
       STG_ACCOUNTS_REDIRECT_URI: ${STG_ACCOUNTS_REDIRECT_URI}
+      # フロント（ecauth-website / ec-auth.io）の配信元。PasskeyPageController が
+      # パスキー登録・認証後のマイページ遷移先に使う。既定は本番 URL。
+      # website 結合 E2E ではフロントの実配信元（例 https://ec-auth.io:1313）に差し替える。
+      Frontend__BaseUrl: ${Frontend__BaseUrl:-https://ec-auth.io}
+      # 申込 / マジックリンク / Account / token API の CORS 許可オリジン。
+      # WithOrigins は scheme+host+port の完全一致で比較するため、ポート付きでフロントを
+      # 配信する結合 E2E ではそのポートまで含めて指定する必要がある（未設定なら
+      # Program.cs のフォールバック https://ec-auth.io / https://www.ec-auth.io が使われる）。
+      Signup__AllowedOrigins__0: ${Signup__AllowedOrigins__0:-}
       # 確認 URL / マジックリンク URL の基底（テナント別・リクエスト処理時に必須参照）。
       Signup__ConfirmBaseUrl__accounts: ${Signup__ConfirmBaseUrl__accounts:-https://localhost:8081}
       Signup__ConfirmBaseUrl__stg_accounts: ${Signup__ConfirmBaseUrl__stg_accounts:-https://localhost:8081}


### PR DESCRIPTION
## 概要

[ecauth-website#15](https://github.com/EcAuth/ecauth-website/pull/15)（申込フォーム・マイページのフロント）に E2E が無かったため、2 層構成の E2E を用意した。本 PR はそのうち **フル結合層**（EcAuth 側）を追加する。

| 層 | 置き場所 | 検証範囲 |
|---|---|---|
| フロント単体 | ecauth-website `e2e/`（別 PR） | API は `page.route()` でスタブ。backend 不要で高速（65 tests） |
| **フル結合（本 PR）** | `E2ETests/.../website_signup_flow.spec.ts` | **実 API・実 CORS・実 WebAuthn・実メール**。スタブでは原理的に検出できない契約齟齬を拾う |

## 通す経路

申込フォーム → 確認メール（mailpit）→ 確認ページ → accounts での実パスキー登録 → マイページ復帰 → PKCE で認可開始 → 実パスキー認証 → `/v1/token` でトークン交換 → `/v1/account/clients` 表示 → `client_secret` の reveal / 再生成 → マジックリンク（リカバリ）着地

すべてブラウザから一気通貫で通す（API 直叩きは行わず、mailpit の REST だけ使う）。

## 変更内容

- `E2ETests/tests/specs/website_signup_flow.spec.ts`（新規・8 tests）
- `E2ETests/playwright.config.ts` — `--host-resolver-rules` に `ec-auth.io` を追加
- `.github/workflows/playwright.yml` — ecauth-website の checkout ＋ `hugo server --tlsAuto` ＋ 環境変数の配線
- `compose.yaml` — `Frontend__BaseUrl` / `Signup__AllowedOrigins__0` をローカル開発でも差し替え可能に
- `E2ETests/tests/specs/account_signup_flow.spec.ts` — `waitForURL` を末尾スラッシュ許容に修正

## 実装上のポイント

- **PKCE と secure context**: `crypto.subtle` は secure context 必須で、`ec-auth.io` は localhost 扱いされない。そのためフロントは `hugo server --tlsAuto` の HTTPS で配信する（証明書は `ignoreHTTPSErrors` で許容）。
- **CORS はポートまで一致させる**: `WithOrigins` は scheme+host+port の完全一致比較のため、`Signup__AllowedOrigins__0` にポート付きで指定する必要がある。
- **`ACCOUNTS_REDIRECT_URI`**: Seeder は `redirect_uri` を 1 つだけ登録するため、フロントの `/auth/callback` に揃える。結果として本番と同じ配線になる。
- **`account_signup_flow.spec.ts` の修正理由**: 上記により redirect_uri がフロントを指すと、静的配信側が正規形へ 301 して `/auth/callback` が `/auth/callback/` になり、従来の正規表現が外れていた。
- **クロスリポジトリ依存の扱い**: ecauth-website の checkout に失敗しても job を落とさず、`::warning` を出して当該 spec のみスキップする。別リポジトリへのアクセス権が無い環境でも本体の E2E は回る。

## この spec が実際に検出した契約齟齬

ecauth-website#15 のフォームは実 API に対して必ず 422 になっていた。いずれもスタブ層では検出できず、本 spec が見つけたもの（修正は ecauth-website#15 側）。

| 内容 | 実 API の応答 |
|---|---|
| サイト URL・EC-CUBE バージョンの入力欄が無い | `422 invalid_site_url` |
| 組織名がフォームでは「任意」だが backend は 1〜100 文字必須 | `422「組織名は 1〜100 文字で入力してください。」` |

## 検証

ローカルに CI 相当のスタック（SQL Server / mailpit / IdentityProvider / hugo --tlsAuto）を立てて実行:

```
24 passed (website_signup_flow 8 + account_signup_flow / account_magic_link_flow /
           oidc_discovery / platform_client_resolve)
```

- `E2E_WEBSITE_BASE_URL` 未設定時に当該 spec が 8 件ともスキップされることも確認済み。

## ecauth-website との依存関係（解消済み）

本 spec は ecauth-website の申込／マイページのテンプレートに依存する。**ecauth-website#15 はマージ済み（`a312403`）のため、現在は追加設定なしで CI 実行される。**

- checkout 後にテンプレートの実在を確認し、無ければ `::warning` を出して当該 spec のみスキップする（ジョブは落とさない）。ecauth-website 側で該当ページが消えた場合も、原因が分かる形で退避できる。
- 特定ブランチに対して検証したい場合は `workflow_dispatch` で `website_ref` を指定する。

## CI での検証結果

**① マージ後の本番相当の検証**（`workflow_dispatch`、`website_ref` **指定なし** = デフォルトの `main` を checkout）— [run 30183412750](https://github.com/EcAuth/EcAuth/actions/runs/30183412750) ✅ success

ecauth-website#15 マージ後、**追加設定なしで 8 件とも実行される**ことを確認した（直前の run では `8 skipped` だった）。

```
ecauth-website is ready
  /signup/ -> 200   /signup/confirm/ -> 200   /signin/ -> 200
  /signin/magic-link/ -> 200   /mypage/ -> 200   /auth/callback/ -> 200

Running 37 tests using 1 worker
  1 flaky      ← federate_authorization_code_flow（MockIdP 依存の既存 spec。リトライで pass）
  36 passed (1.1m)   ← skipped 0
```

IdentityProvider のログ:

```
Added RedirectUri https://ec-auth.io:1313/auth/callback for client ecauth-admin-console
client_secret revealed for client ec-web-<runSuffix>-example-com-... by account <sub>
client_secret regenerated for client ec-web-<runSuffix>-example-com-... by account <sub>
```

`web-<runSuffix>.example.com` の org は本 spec だけが作るため、マイページ UI から実 API の reveal / 再生成が叩かれたことの直接的な証拠になる。

**② マージ前の検証**（`workflow_dispatch` / `website_ref=feat/signup-form`）— [run 30183127423](https://github.com/EcAuth/EcAuth/actions/runs/30183127423) ✅ success

```
ecauth-website is ready
  /signup/          -> 200
  /signup/confirm/  -> 200
  /signin/          -> 200
  /signin/magic-link/ -> 200
  /mypage/          -> 200
  /auth/callback/   -> 200

Running 37 tests using 1 worker
  1 flaky      ← federate_authorization_code_flow（MockIdP 依存の既存 spec。リトライで pass）
  36 passed (1.1m)
```

IdentityProvider のログに `client_secret revealed for client ec-web-<runSuffix>-example-com-...` が出ており、本 spec がマイページ UI から実 API の reveal を叩いたことが確認できる（この org は本 spec だけが作る）。

**③ 未マージ時のスキップ挙動**（push トリガー、マージ前）— [run 30183121765](https://github.com/EcAuth/EcAuth/actions/runs/30183121765) ✅ pass

```
##[warning]ecauth-website の ref に申込/マイページのテンプレートがありません（未マージ）: layouts/_default/signup.html layouts/_default/mypage.html layouts/_default/auth-callback.html
  8 skipped
  29 passed (18.1s)
```

## 初回 CI 失敗とその修正（4f6a541）

初回の push では Playwright が失敗した（`29 passed / 1 failed / 7 did not run`）。原因は本 PR の CI 実装側の 2 点。

1. **checkout に `ref` 指定が無く、デフォルトブランチ（main）を取得していた** — 申込ページが未マージのため全ページ 404 になり、`#email` 待ちのタイムアウトという分かりにくい形で落ちていた。
2. **ヘルスチェックが `curl -sk` で 404 を成功と誤判定していた** — `-f` が無いと 404 でも exit 0 になるため、「hugo は起動したが全ページ 404」を ready と判定していた。

→ `website_ref` 入力の追加、テンプレート実在チェック、`curl -fsk` + 上記 6 ページの 200 検証で修正。既存 spec（29 件）は初回から一貫して pass しており、`ACCOUNTS_REDIRECT_URI` 変更の影響が無いことも確認できている。

## 関連

- ecauth-website#15
- EcAuthDocs#39 (Phase E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

