### PR TITLE
fix(signup): 申込 Client の redirect_uri / allowed_rp_ids を実利用に合わせる

### DIFF
--- a/IdentityProvider.Test/Services/SignupServiceTests.cs
+++ b/IdentityProvider.Test/Services/SignupServiceTests.cs
@@ -591,20 +591,40 @@ namespace IdentityProvider.Test.Services
                 client.RedirectUris!.Single().Uri);
         }
 
-        [Fact]
-        public async Task ConfirmAsync_SiteUrlEndsWithFileName_DropsFileNameFromBasePath()
+        [Theory]
+        // トップページとして "…/index.php" を貼られるケース。
+        [InlineData("https://shop.example.jp/store/index.php", "https://shop.example.jp/store/ecauth/callback")]
+        // index 以外のウェブ文書でもファイル名として落とす。
+        [InlineData("https://shop.example.jp/top.php", "https://shop.example.jp/ecauth/callback")]
+        [InlineData("https://shop.example.jp/store/index.html", "https://shop.example.jp/store/ecauth/callback")]
+        public async Task ConfirmAsync_SiteUrlEndsWithWebDocument_DropsFileNameFromBasePath(
+            string siteUrl, string expectedUri)
         {
-            // トップページとして "https://shop.example.jp/store/index.php" を貼られるケース。
             var tenantService = CreateTenantService();
             using var context = CreateContextWithAccountsOrg(tenantService);
             var service = CreateService(context, tenantService, out var emailMock, out _);
 
-            var input = ValidInput() with { ProductionSiteUrl = "https://shop.example.jp/store/index.php" };
+            var input = ValidInput() with { ProductionSiteUrl = siteUrl };
             var client = await ConfirmAndGetClientAsync(service, emailMock, context, input, "shop-example-jp");
 
-            Assert.Equal(
-                "https://shop.example.jp/store/ecauth/callback",
-                client.RedirectUris!.Single().Uri);
+            Assert.Equal(expectedUri, client.RedirectUris!.Single().Uri);
+        }
+
+        [Theory]
+        // ドットを含むディレクトリ名（末尾スラッシュ無し）をファイル名と誤判定してはいけない。
+        [InlineData("https://shop.example.jp/ec-cube-4.2", "https://shop.example.jp/ec-cube-4.2/ecauth/callback")]
+        [InlineData("https://shop.example.jp/shop.jp", "https://shop.example.jp/shop.jp/ecauth/callback")]
+        public async Task ConfirmAsync_SiteUrlEndsWithDottedDirectory_KeepsDirectoryInBasePath(
+            string siteUrl, string expectedUri)
+        {
+            var tenantService = CreateTenantService();
+            using var context = CreateContextWithAccountsOrg(tenantService);
+            var service = CreateService(context, tenantService, out var emailMock, out _);
+
+            var input = ValidInput() with { ProductionSiteUrl = siteUrl };
+            var client = await ConfirmAndGetClientAsync(service, emailMock, context, input, "shop-example-jp");
+
+            Assert.Equal(expectedUri, client.RedirectUris!.Single().Uri);
         }
 
         [Fact]

--- a/IdentityProvider.Test/Services/SignupServiceTests.cs
+++ b/IdentityProvider.Test/Services/SignupServiceTests.cs
@@ -526,6 +526,187 @@ namespace IdentityProvider.Test.Services
             Assert.False(customerOrgs[0].IsSandbox);
         }
 
+        // ---- ConfirmAsync: Client の初期値（redirect_uri / allowed_rp_ids）----
+
+        /// <summary>
+        /// Request → Confirm を通し、指定した組織コードの Org に作られた Client を返す。
+        /// </summary>
+        private async Task<Client> ConfirmAndGetClientAsync(
+            SignupService service,
+            Mock<IEmailService> emailMock,
+            EcAuthDbContext context,
+            SignupInput input,
+            string organizationCode)
+        {
+            var token = await RequestAndCaptureTokenAsync(service, emailMock, input);
+            await service.ConfirmAsync(token);
+
+            var org = await context.Organizations
+                .IgnoreQueryFilters()
+                .FirstAsync(o => o.Code == organizationCode);
+            return await context.Clients
+                .IgnoreQueryFilters()
+                .Include(c => c.RedirectUris)
+                .FirstAsync(c => c.OrganizationId == org.Id);
+        }
+
+        [Theory]
+        // EC-CUBE 4 系プラグインのコールバックは Route "/ecauth/callback"。
+        [InlineData("4", "https://shop.example.jp/ecauth/callback")]
+        // EC-CUBE 2 系プラグインは HTTPS_URL . 'ecauth/callback.php'。
+        [InlineData("2", "https://shop.example.jp/ecauth/callback.php")]
+        // EC-CUBE 以外は 4 系と同じパスを初期値にする。
+        [InlineData("other", "https://shop.example.jp/ecauth/callback")]
+        public async Task ConfirmAsync_RegistersPluginCallbackAsRedirectUri(string version, string expectedUri)
+        {
+            var tenantService = CreateTenantService();
+            using var context = CreateContextWithAccountsOrg(tenantService);
+            var service = CreateService(context, tenantService, out var emailMock, out _);
+
+            var input = ValidInput() with { EcCubeVersion = version };
+            var client = await ConfirmAndGetClientAsync(service, emailMock, context, input, "shop-example-jp");
+
+            // サイトのトップ URL は実際のコールバックにならないため登録しない。
+            var uris = client.RedirectUris!.Select(r => r.Uri).ToList();
+            Assert.Equal(new[] { expectedUri }, uris);
+        }
+
+        [Fact]
+        public async Task ConfirmAsync_SiteUrlWithSubdirectory_KeepsBasePathInRedirectUri()
+        {
+            // EC-CUBE 2 系・4 系ともサブディレクトリインストールがあり得る。
+            var tenantService = CreateTenantService();
+            using var context = CreateContextWithAccountsOrg(tenantService);
+            var service = CreateService(context, tenantService, out var emailMock, out _);
+
+            var input = ValidInput() with
+            {
+                ProductionSiteUrl = "https://shop.example.jp/store/",
+                EcCubeVersion = "2"
+            };
+            var client = await ConfirmAndGetClientAsync(service, emailMock, context, input, "shop-example-jp");
+
+            Assert.Equal(
+                "https://shop.example.jp/store/ecauth/callback.php",
+                client.RedirectUris!.Single().Uri);
+        }
+
+        [Fact]
+        public async Task ConfirmAsync_SiteUrlEndsWithFileName_DropsFileNameFromBasePath()
+        {
+            // トップページとして "https://shop.example.jp/store/index.php" を貼られるケース。
+            var tenantService = CreateTenantService();
+            using var context = CreateContextWithAccountsOrg(tenantService);
+            var service = CreateService(context, tenantService, out var emailMock, out _);
+
+            var input = ValidInput() with { ProductionSiteUrl = "https://shop.example.jp/store/index.php" };
+            var client = await ConfirmAndGetClientAsync(service, emailMock, context, input, "shop-example-jp");
+
+            Assert.Equal(
+                "https://shop.example.jp/store/ecauth/callback",
+                client.RedirectUris!.Single().Uri);
+        }
+
+        [Fact]
+        public async Task ConfirmAsync_SiteUrlWithNonDefaultPort_KeepsPortInRedirectUriButNotInRpId()
+        {
+            // redirect_uri は完全一致検証のためポートが必要。RP ID はポートを含まないドメイン名。
+            var tenantService = CreateTenantService();
+            using var context = CreateContextWithAccountsOrg(tenantService);
+            var service = CreateService(context, tenantService, out var emailMock, out _);
+
+            var input = ValidInput() with { ProductionSiteUrl = "https://shop.example.jp:8443/" };
+            var client = await ConfirmAndGetClientAsync(service, emailMock, context, input, "shop-example-jp");
+
+            Assert.Equal(
+                "https://shop.example.jp:8443/ecauth/callback",
+                client.RedirectUris!.Single().Uri);
+            Assert.Equal(new[] { "shop.example.jp" }, client.AllowedRpIds);
+        }
+
+        [Fact]
+        public async Task ConfirmAsync_WwwHost_AllowsBothWwwAndApexRpIds()
+        {
+            // www 付きで申込んでも apex ドメインの管理画面からパスキーを登録できるようにする。
+            var tenantService = CreateTenantService();
+            using var context = CreateContextWithAccountsOrg(tenantService);
+            var service = CreateService(context, tenantService, out var emailMock, out _);
+
+            var input = ValidInput() with { ProductionSiteUrl = "https://www.example.jp" };
+            var client = await ConfirmAndGetClientAsync(service, emailMock, context, input, "example-jp");
+
+            Assert.Equal(new[] { "www.example.jp", "example.jp" }, client.AllowedRpIds);
+            Assert.Equal("https://www.example.jp/ecauth/callback", client.RedirectUris!.Single().Uri);
+        }
+
+        [Fact]
+        public async Task ConfirmAsync_SubdomainHost_AllowsSingleRpId()
+        {
+            var tenantService = CreateTenantService();
+            using var context = CreateContextWithAccountsOrg(tenantService);
+            var service = CreateService(context, tenantService, out var emailMock, out _);
+
+            var client = await ConfirmAndGetClientAsync(
+                service, emailMock, context, ValidInput(), "shop-example-jp");
+
+            Assert.Equal(new[] { "shop.example.jp" }, client.AllowedRpIds);
+        }
+
+        [Fact]
+        public async Task ConfirmAsync_IdnHost_UsesPunycodeInRedirectUriAndRpId()
+        {
+            // ブラウザが送る Host ヘッダは Punycode なので、プラグインが組み立てる
+            // redirect_uri / rp_id と一致させるには初期値も Punycode である必要がある。
+            var tenantService = CreateTenantService();
+            using var context = CreateContextWithAccountsOrg(tenantService);
+            var service = CreateService(context, tenantService, out var emailMock, out _);
+
+            var punycodeHost = new Uri("https://日本.jp").IdnHost;
+            var input = ValidInput() with { ProductionSiteUrl = "https://日本.jp" };
+
+            var customerCode = await RequestAndCaptureTokenAsync(service, emailMock, input);
+            await service.ConfirmAsync(customerCode);
+
+            var org = await context.Organizations
+                .IgnoreQueryFilters()
+                .FirstAsync(o => o.Code != Tenant);
+            var client = await context.Clients
+                .IgnoreQueryFilters()
+                .Include(c => c.RedirectUris)
+                .FirstAsync(c => c.OrganizationId == org.Id);
+
+            Assert.Equal($"https://{punycodeHost}/ecauth/callback", client.RedirectUris!.Single().Uri);
+            Assert.Equal(new[] { punycodeHost }, client.AllowedRpIds);
+        }
+
+        [Fact]
+        public async Task ConfirmAsync_ProductionAndTest_EachClientGetsOwnCallback()
+        {
+            var tenantService = CreateTenantService();
+            using var context = CreateContextWithAccountsOrg(tenantService);
+            var service = CreateService(context, tenantService, out var emailMock, out _);
+
+            var input = ValidInput() with
+            {
+                ProductionSiteUrl = "https://shop.example.jp",
+                TestSiteUrl = "https://test.example.jp/store/",
+                EcCubeVersion = "2"
+            };
+            var token = await RequestAndCaptureTokenAsync(service, emailMock, input);
+            await service.ConfirmAsync(token);
+
+            var clients = await context.Clients
+                .IgnoreQueryFilters()
+                .Include(c => c.Organization)
+                .Include(c => c.RedirectUris)
+                .ToListAsync();
+
+            var production = clients.Single(c => c.Organization!.Code == "shop-example-jp");
+            var sandbox = clients.Single(c => c.Organization!.Code == "test-example-jp");
+            Assert.Equal("https://shop.example.jp/ecauth/callback.php", production.RedirectUris!.Single().Uri);
+            Assert.Equal("https://test.example.jp/store/ecauth/callback.php", sandbox.RedirectUris!.Single().Uri);
+        }
+
         // ---- ConfirmAsync 異常系 ----
 
         [Fact]

--- a/IdentityProvider/Services/SignupService.cs
+++ b/IdentityProvider/Services/SignupService.cs
@@ -28,6 +28,9 @@ namespace IdentityProvider.Services
         // [A-Za-z0-9_] 以外を "_" に置換する（例: "stg-accounts" -> "stg_accounts"）。
         private static readonly Regex NonConfigKeyChar = new("[^A-Za-z0-9_]", RegexOptions.Compiled);
 
+        // 申込 URL のベースパス正規化: 末尾セグメントをファイル名とみなして落とす拡張子。
+        private static readonly string[] WebDocumentExtensions = [".php", ".html", ".htm"];
+
         private readonly EcAuthDbContext _context;
         private readonly ITenantService _tenantService;
         private readonly IEmailService _emailService;
@@ -585,14 +588,17 @@ namespace IdentityProvider.Services
         /// <summary>
         /// 申込 URL のパスを、コールバック URL の基点になるベースパスへ正規化する（先頭・末尾がスラッシュ）。
         /// EC-CUBE 2 系・4 系ともサブディレクトリインストールがあり得るため、パスを捨てずに引き継ぐ。
-        /// 末尾セグメントがファイル名（"." を含む）の場合は落とす（<c>.../index.php</c> を貼られるケース）。
+        /// 末尾セグメントがウェブ文書の場合のみ落とす（<c>.../index.php</c> を貼られるケース）。
         /// </summary>
         private static string NormalizeBasePath(string absolutePath)
         {
             var path = string.IsNullOrEmpty(absolutePath) ? "/" : absolutePath;
 
+            // ドットの有無で判定すると "ec-cube-4.2" のようなディレクトリ名をファイル名と
+            // 誤判定してサブディレクトリごと落としてしまうため、拡張子で判定する。
             var lastSlash = path.LastIndexOf('/');
-            if (lastSlash >= 0 && path[(lastSlash + 1)..].Contains('.'))
+            var lastSegment = lastSlash >= 0 ? path[(lastSlash + 1)..] : string.Empty;
+            if (WebDocumentExtensions.Any(ext => lastSegment.EndsWith(ext, StringComparison.OrdinalIgnoreCase)))
             {
                 path = path[..(lastSlash + 1)];
             }

--- a/IdentityProvider/Services/SignupService.cs
+++ b/IdentityProvider/Services/SignupService.cs
@@ -244,7 +244,8 @@ namespace IdentityProvider.Services
                     // ここで一度 SaveChanges して採番された Id を確定させる。
                     await _context.SaveChangesAsync(ct);
 
-                    var client = CreateClient(organization, site, signupRequest.OrganizationName);
+                    var client = CreateClient(
+                        organization, site, signupRequest.OrganizationName, signupRequest.EcCubeVersion);
                     // 保存前に client_secret を暗号化する（レガシー/dev は平文パススルー）。
                     // Key Vault 暗号化の所要時間を confirm 内の独立ステップとして計測する。
                     using (TimingScope.Begin("client_secret_protect"))
@@ -435,38 +436,42 @@ namespace IdentityProvider.Services
                     field: "production_site_url");
             }
 
-            string? productionHost = null;
-            string? testHost = null;
+            SiteUrl? productionSite = null;
+            SiteUrl? testSite = null;
 
             if (production != null)
             {
-                productionHost = ValidateHttpsAndGetHost(production, "production_site_url");
+                productionSite = ValidateHttpsAndParseSiteUrl(production, "production_site_url");
             }
             if (test != null)
             {
-                testHost = ValidateHttpsAndGetHost(test, "test_site_url");
+                testSite = ValidateHttpsAndParseSiteUrl(test, "test_site_url");
             }
 
             var sites = new List<SiteEntry>();
 
             string? productionCode = null;
-            if (productionHost != null)
+            if (productionSite != null)
             {
-                productionCode = DeriveOrganizationCode(productionHost);
-                sites.Add(new SiteEntry(productionCode, productionHost, IsSandbox: false, "production_site_url"));
+                productionCode = DeriveOrganizationCode(productionSite.Host);
+                sites.Add(new SiteEntry(
+                    productionCode, productionSite.Host, productionSite.BaseUrl,
+                    IsSandbox: false, "production_site_url"));
             }
 
             // テスト Org は、本番がない場合か、本番と「導出後の組織コード」が異なる場合のみ作成する。
             // ホスト名は異なっても導出後コードが同一になるケース（例: www.shop.example.jp と
             // shop.example.jp はいずれも shop-example-jp）があるため、生ホスト名ではなく
             // 導出後コードで比較し、コード重複によるユニーク制約違反を防ぐ。
-            if (testHost != null)
+            if (testSite != null)
             {
-                var testCode = DeriveOrganizationCode(testHost);
+                var testCode = DeriveOrganizationCode(testSite.Host);
                 if (productionCode == null
                     || !string.Equals(testCode, productionCode, StringComparison.OrdinalIgnoreCase))
                 {
-                    sites.Add(new SiteEntry(testCode, testHost, IsSandbox: true, "test_site_url"));
+                    sites.Add(new SiteEntry(
+                        testCode, testSite.Host, testSite.BaseUrl,
+                        IsSandbox: true, "test_site_url"));
                 }
             }
 
@@ -529,14 +534,19 @@ namespace IdentityProvider.Services
         /// </summary>
         private static string DeriveOrganizationCode(string host)
         {
-            var normalized = host.Trim().ToLowerInvariant();
-            if (normalized.StartsWith("www.", StringComparison.Ordinal))
-            {
-                normalized = normalized["www.".Length..];
-            }
-
+            var normalized = StripWwwPrefix(host.Trim().ToLowerInvariant());
             var code = NonAlphanumericRun.Replace(normalized, "-").Trim('-');
             return code;
+        }
+
+        /// <summary>
+        /// 先頭の <c>www.</c> を除去する（無ければそのまま返す）。呼び出し側で小文字化済みであることを前提とする。
+        /// </summary>
+        private static string StripWwwPrefix(string host)
+        {
+            return host.StartsWith("www.", StringComparison.Ordinal)
+                ? host["www.".Length..]
+                : host;
         }
 
         private static string? NormalizeOptionalUrl(string? url)
@@ -546,9 +556,10 @@ namespace IdentityProvider.Services
         }
 
         /// <summary>
-        /// URL が HTTPS であることを検証し、ホスト名を返す。
+        /// URL が HTTPS であることを検証し、RP ID 用のホスト名と、コールバック URL の基点になる
+        /// ベース URL（scheme + authority + 末尾スラッシュ付きベースパス）を返す。
         /// </summary>
-        private static string ValidateHttpsAndGetHost(string url, string field)
+        private static SiteUrl ValidateHttpsAndParseSiteUrl(string url, string field)
         {
             if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)
                 || !string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
@@ -560,7 +571,38 @@ namespace IdentityProvider.Services
 
             // IDN（国際化ドメイン）は Uri.Host だと Unicode のまま返り、組織コード導出の
             // [^a-z0-9] 除去で空文字や衝突を招く。IdnHost（Punycode, ASCII）を使う。
-            return uri.IdnHost;
+            // ブラウザが送る Host ヘッダも Punycode なので、プラグインが組み立てる
+            // redirect_uri / rp_id と一致する。
+            var host = uri.IdnHost;
+
+            // 非既定ポートは redirect_uri の完全一致検証に必要なので保持する
+            // （RP ID はポートを含まないドメイン名なので host 側では使わない）。
+            var authority = uri.IsDefaultPort ? host : $"{host}:{uri.Port}";
+
+            return new SiteUrl(host, $"https://{authority}{NormalizeBasePath(uri.AbsolutePath)}");
+        }
+
+        /// <summary>
+        /// 申込 URL のパスを、コールバック URL の基点になるベースパスへ正規化する（先頭・末尾がスラッシュ）。
+        /// EC-CUBE 2 系・4 系ともサブディレクトリインストールがあり得るため、パスを捨てずに引き継ぐ。
+        /// 末尾セグメントがファイル名（"." を含む）の場合は落とす（<c>.../index.php</c> を貼られるケース）。
+        /// </summary>
+        private static string NormalizeBasePath(string absolutePath)
+        {
+            var path = string.IsNullOrEmpty(absolutePath) ? "/" : absolutePath;
+
+            var lastSlash = path.LastIndexOf('/');
+            if (lastSlash >= 0 && path[(lastSlash + 1)..].Contains('.'))
+            {
+                path = path[..(lastSlash + 1)];
+            }
+
+            if (!path.StartsWith('/'))
+            {
+                path = "/" + path;
+            }
+
+            return path.EndsWith('/') ? path : path + "/";
         }
 
         private static bool IsValidEmail(string email)
@@ -583,7 +625,8 @@ namespace IdentityProvider.Services
         /// 顧客 Org 用 Client を生成する。ClientSecret 生成・AllowedRpIds 設定・RedirectUri 付与の流儀は
         /// <c>AccountsOrganizationSeeder.SeedClientAsync</c> / <c>SeedRedirectUriAsync</c> を流用する。
         /// </summary>
-        private static Client CreateClient(Organization organization, SiteEntry site, string appName)
+        private static Client CreateClient(
+            Organization organization, SiteEntry site, string appName, string ecCubeVersion)
         {
             var client = new Client
             {
@@ -592,16 +635,48 @@ namespace IdentityProvider.Services
                 AppName = appName,
                 OrganizationId = organization.Id,
                 SubjectType = SubjectType.B2B,
-                AllowedRpIds = new List<string> { site.Host }
+                AllowedRpIds = BuildAllowedRpIds(site.Host)
             };
 
-            // RedirectUri は申込時には不明のため、サイトのトップ URL を暫定登録する。
+            // プラグインが authenticate/verify に送る redirect_uri は完全一致で検証される
+            // （B2BPasskeyController）。サイトのトップ URL では一致しないため、申込時に
+            // 選ばれた EC プラットフォームのコールバック URL を登録する。
             client.RedirectUris!.Add(new RedirectUri
             {
-                Uri = $"https://{site.Host}/"
+                Uri = site.BaseUrl + CallbackPathFor(ecCubeVersion)
             });
 
             return client;
+        }
+
+        /// <summary>
+        /// 申込時に選ばれた EC プラットフォームのコールバックパスを返す（ベースパスからの相対）。
+        /// EC-CUBE 4 系はルート <c>ecauth_callback</c>（<c>/ecauth/callback</c>）、
+        /// 2 系は <c>HTTPS_URL . 'ecauth/callback.php'</c> を使う。
+        /// </summary>
+        private static string CallbackPathFor(string ecCubeVersion) => ecCubeVersion switch
+        {
+            "2" => "ecauth/callback.php",
+            // "4" と "other"（EC-CUBE 以外）は 4 系と同じパスを初期値にする。
+            _ => "ecauth/callback"
+        };
+
+        /// <summary>
+        /// 初期の allowed_rp_ids を組み立てる。申込 URL が <c>www.</c> 付きでも管理画面は apex
+        /// ドメインというケースがあるため、<c>www.</c> 除去版も許可しておく。
+        /// RP ID はポートを含まないドメイン名（WebAuthn の valid domain string）。
+        /// </summary>
+        private static List<string> BuildAllowedRpIds(string host)
+        {
+            var rpIds = new List<string> { host };
+
+            var stripped = StripWwwPrefix(host);
+            if (!string.Equals(stripped, host, StringComparison.Ordinal))
+            {
+                rpIds.Add(stripped);
+            }
+
+            return rpIds;
         }
 
         /// <summary>
@@ -728,6 +803,13 @@ namespace IdentityProvider.Services
 
         private sealed record SiteSet(string? ProductionUrl, string? TestUrl, List<SiteEntry> Sites);
 
-        private sealed record SiteEntry(string Code, string Host, bool IsSandbox, string Field);
+        private sealed record SiteEntry(
+            string Code, string Host, string BaseUrl, bool IsSandbox, string Field);
+
+        /// <summary>
+        /// 申込 URL の解析結果。<c>Host</c> は RP ID / 組織コード導出用（ポートを含まない）、
+        /// <c>BaseUrl</c> は redirect_uri 組み立て用（非既定ポートとベースパスを含み、末尾はスラッシュ）。
+        /// </summary>
+        private sealed record SiteUrl(string Host, string BaseUrl);
     }
 }


### PR DESCRIPTION
## 概要

申込フローで作成された Client は、**パスキーログインがどの顧客でも必ず失敗する**状態でした（#481 の症状 1・2）。初期値が実際の利用形態と合っていないことが原因です。本 PR はその初期値だけを修正します。

- `redirect_uri` がサイトのトップ URL（`https://{host}/`）1 件だけでしたが、プラグインが `authenticate/verify` に送るのはコールバック URL であり、`B2BPasskeyController` の検証は完全一致のため確定的に 400 になっていました
- `allowed_rp_ids` が申込サイトの生ホスト 1 件だけで、組織コード側は `www.` を除去する一方 rp_id は除去しないため、`https://www.example.jp` で申込むと `example.jp` の管理画面で 400 になっていました

## 変更内容

`IdentityProvider/Services/SignupService.cs`

- **`ec_cube_version` でコールバックパスを分岐**。申込フォームで既に選択済み（`SignupRequest.EcCubeVersion`）の値を使う
  - `4` / `other`（EC-CUBE 以外） → `ecauth/callback`（4 系の Route `ecauth_callback`）
  - `2` → `ecauth/callback.php`（2 系の `HTTPS_URL . 'ecauth/callback.php'`）
- **申込 URL の非既定ポートとベースパスを `redirect_uri` に引き継ぐ**。EC-CUBE は 2 系・4 系ともサブディレクトリインストールがあり得るため、従来破棄していたパスを保持する。末尾が `index.php` 等のファイル名なら落とす
- **`allowed_rp_ids` に `www.` 除去版を追加**して www 有無の揺れを吸収する。RP ID はポートを含まないドメイン名（WebAuthn の valid domain string）なので、ポートは付けない
- 実際のコールバックにならないトップ URL は登録しない

`www.` 除去は組織コード導出と共通ロジック（`StripWwwPrefix`）に切り出しました。

## スコープ外（別 PR で対応）

1. 許可 origin のポート追加（`B2BPasskeyService` の `:8081` / `:443` ハードコード。EC-CUBE docker の 4430・symfony CLI の 8000 が通らない）
2. #481-B: `AccountController` への redirect_uri / allowed_rp_ids 更新系 API（顧客の自己解決手段）
3. EcAuth/ecauth-website#19: マイページの編集 UI（上記 API が前提）
4. 4 系プラグインの `error_description` 透過

既存 Client のデータ補正は対象が限定的なため行いません。

## 検証

**ユニットテスト**: `dotnet test IdentityProvider.Test` → **失敗 0 / 合格 707**（`SignupServiceTests` に 10 ケース追加: バージョン別コールバック 3 件、サブディレクトリ、末尾ファイル名、非既定ポート、www 揺れ、サブドメイン、IDN（Punycode）、本番/テスト 2 サイト）

**EF モデル差分**: `dotnet ef migrations has-pending-model-changes` → `No changes have been made to the model since the last migration.`

**ローカル Docker で申込フローを実行し、DB の実値を確認**:

| 申込 URL | version | `allowed_rp_ids` | `redirect_uri` |
|---|---|---|---|
| `https://v4-….example.com` | `4` | `["v4-….example.com"]` | `https://v4-….example.com/ecauth/callback` |
| `https://www.v2-….example.com/store/` | `2` | `["www.v2-….example.com","v2-….example.com"]` | `https://www.v2-….example.com/store/ecauth/callback.php` |
| `https://other-….example.com:8443/index.php` | `other` | `["other-….example.com"]` | `https://other-….example.com:8443/ecauth/callback` |

www 揺れ吸収・サブディレクトリ保持・`index.php` 除去・非既定ポート保持・トップ URL 不登録をいずれも確認済みです。

**未検証**: 実プラグイン（EC-CUBE 4 系 / 2 系）を接続したパスキーログインの通し確認。ローカルで EcAuth と EC-CUBE の docker がいずれも 8081 を使うため、スコープ外の「許可 origin のポート追加」PR とあわせて確認します。

Closes #481 の A（初期値の修正）

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **機能改善**
  - サイトURLのサブディレクトリを維持したコールバックURLを登録できるようになりました。
  - EC-CUBEのバージョンに応じたコールバックパスに対応しました。
  - 非標準ポート、`www` ホスト、サブドメイン、国際化ドメイン名（IDN）を適切に処理します。
  - 本番環境とテスト環境で、それぞれ正しいコールバックURLを登録します。

- **バグ修正**
  - URL末尾のファイル名を除外し、正しいベースパスからコールバックURLを生成するよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->