### PR TITLE
test: EC-CUBE 4系/2系のプラグインを実際に通す結合 E2E を追加

### DIFF
--- a/.github/workflows/eccube_plugin_e2e.yml
+++ b/.github/workflows/eccube_plugin_e2e.yml
@@ -1,0 +1,192 @@
+name: EC-CUBE Plugin E2E
+
+# 申込 → プラグイン設定 → パスキー登録 → 管理画面ログイン を、EC-CUBE 4 系 / 2 系の
+# プラグインを実際に動かして通す結合 E2E。
+#
+# playwright.yml（EcAuth 単体の E2E）と分けている理由:
+#   - EC-CUBE のイメージビルドと初回インストールに数分かかり、EcAuth 単体の
+#     fail-fast を鈍らせる
+#   - プラグインの ref を差し替えて回したいケースがあり、入力を持つ必要がある
+#
+# EC-CUBE 本体のバージョンはプラグインリポジトリの Dockerfile の FROM が決める。
+# 本体版を変えたいときは plugin4_ref / plugin2_ref にその本体版を指すブランチ/タグを渡す。
+
+on:
+  workflow_call:
+    inputs:
+      plugin4_ref:
+        description: 'ec-cube4-ecauth の ref（空ならデフォルトブランチ）'
+        type: string
+        required: false
+        default: ''
+      plugin2_ref:
+        description: 'ec-cube2-ecauth の ref（空ならデフォルトブランチ）'
+        type: string
+        required: false
+        default: ''
+      install_source:
+        description: '4 系プラグインのインストール元（local / package-api）'
+        type: string
+        required: false
+        default: 'local'
+      plugin_version:
+        description: 'package-api から入れる 4 系プラグインのバージョン（空なら最新）'
+        type: string
+        required: false
+        default: ''
+  workflow_dispatch:
+    inputs:
+      plugin4_ref:
+        description: 'ec-cube4-ecauth の ref（空ならデフォルトブランチ）'
+        type: string
+        required: false
+        default: ''
+      plugin2_ref:
+        description: 'ec-cube2-ecauth の ref（空ならデフォルトブランチ）'
+        type: string
+        required: false
+        default: ''
+      install_source:
+        description: '4 系プラグインのインストール元'
+        type: choice
+        options: [local, package-api]
+        default: local
+      plugin_version:
+        description: 'package-api から入れる 4 系プラグインのバージョン（空なら最新）'
+        type: string
+        required: false
+        default: ''
+
+jobs:
+  eccube-plugin-e2e:
+    name: EC-CUBE 4系 / 2系 プラグイン結合 E2E
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout EcAuth
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # プラグインは docker build のコンテキストとして使う。ref を切り替えると
+      # Dockerfile の FROM ごと変わるため、EC-CUBE 本体のバージョンもこれで決まる。
+      - name: Checkout ec-cube4-ecauth
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: EcAuth/ec-cube4-ecauth
+          ref: ${{ inputs.plugin4_ref }}
+          path: plugins/ec-cube4-ecauth
+          token: ${{ secrets.ORG_PAT || secrets.PACKAGES_READ_TOKEN || github.token }}
+
+      - name: Checkout ec-cube2-ecauth
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: EcAuth/ec-cube2-ecauth
+          ref: ${{ inputs.plugin2_ref }}
+          path: plugins/ec-cube2-ecauth
+          token: ${{ secrets.ORG_PAT || secrets.PACKAGES_READ_TOKEN || github.token }}
+
+      - name: Load base environment variables
+        # compose.yaml が補間する非機密のローカル/ダミー値。playwright.yml の同名 step と
+        # 同じ性格の値で、クレデンシャルは含まない。EC-CUBE 結合 E2E は外部 IdP を使わない
+        # ため FEDERATE_* もダミーで足りる（Seeder が値の存在だけを要求する）。
+        # 注意: heredoc は $GITHUB_ENV に追記されるため KEY=value 行のみ許容。
+        run: |
+          cat <<'EOF' >> $GITHUB_ENV
+          DB_HOST=db
+          DB_NAME=EcAuthDb
+          DB_USER=SA
+          DB_PASSWORD=<YourStrong@Passw0rd>
+          STATE_PASSWORD=<strong_password_string_of_at_least_32_characters>
+          DEFAULT_ORGANIZATION_CODE=example
+          DEFAULT_ORGANIZATION_NAME=example
+          DEFAULT_ORGANIZATION_TENANT_NAME=example
+          DEFAULT_ORGANIZATION_REDIRECT_URI=https://localhost:8081/v1/auth/callback
+          DEFAULT_CLIENT_ID=client_id
+          DEFAULT_CLIENT_SECRET=client_secret
+          DEFAULT_APP_NAME=app_name
+          FEDERATE_OAUTH2_APP_NAME=federate-oauth2
+          FEDERATE_OAUTH2_CLIENT_ID=federateclientid
+          FEDERATE_OAUTH2_CLIENT_SECRET=federate-client-secret
+          FEDERATE_OAUTH2_AUTHORIZATION_ENDPOINT=https://localhost:9091/authorization?org=dev
+          FEDERATE_OAUTH2_TOKEN_ENDPOINT=https://localhost:9091/token?org=dev
+          FEDERATE_OAUTH2_USERINFO_ENDPOINT=https://localhost:9091/userinfo?org=dev
+          DEV_B2B_USER_SUBJECT=3f7c0ab4-b004-4102-b6ed-a730369dd237
+          DEV_B2B_USER_EXTERNAL_ID=test-admin
+          DEV_B2B_REDIRECT_URI=https://localhost:8081/admin/ecauth/callback
+          DEV_B2B_ALLOWED_RP_IDS=localhost
+          ACCOUNTS_CLIENT_ID=ecauth-admin-console
+          ACCOUNTS_CLIENT_PUBLIC=true
+          ACCOUNTS_CLIENT_SECRET=accounts_client_secret
+          ACCOUNTS_ALLOWED_RP_IDS=accounts.ec-auth.io,localhost
+          ACCOUNTS_REDIRECT_URI=https://localhost:8081/auth/callback
+          Signup__ConfirmBaseUrl__accounts=https://localhost:8081
+          MagicLink__BaseUrl__accounts=https://localhost:8081
+          E2E_ECCUBE4_PLUGIN_DIR=./plugins/ec-cube4-ecauth
+          E2E_ECCUBE2_PLUGIN_DIR=./plugins/ec-cube2-ecauth
+          E2E_SKIP_OP=1
+          EOF
+
+      # オーナーズストアの検証キー（X-ECCUBE-KEY）。package-api から「申請中のパッケージ」を
+      # 入れる場合だけ必要。既定（local）ではこの step が動かず、プラグインの
+      # docker-entrypoint.sh は /plugin のワーキングツリーから入れる。
+      - name: Load EC-CUBE verification key from 1Password
+        if: ${{ inputs.install_source == 'package-api' }}
+        uses: 1password/load-secrets-action@eb2efd0703da22a93c467f2d1ffbb6826c11e19c # v4.1.1
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_NONPROD }}
+          ECCUBE_AUTHENTICATION_KEY: op://EcAuth/eccube4-ecauth-plugin/eccube_authentication_key
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          package_json_file: E2ETests/package.json
+
+      - name: Install Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+
+      - name: Install Playwright
+        working-directory: E2ETests
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm exec playwright install --with-deps chromium
+
+      - name: Start the stack
+        # ECCUBE_AUTHENTICATION_KEY は直前の 1Password step が export-env で job env に載せる
+        # （動かなければ未設定のまま = ローカルソースからのインストール）。
+        #
+        # GITHUB_USERNAME / GITHUB_TOKEN は identityprovider イメージのビルド引数
+        # （GitHub Packages の NuGet 認証）。GITHUB_ 接頭辞は $GITHUB_ENV では扱えないため
+        # step の env で渡す。
+        run: ./E2ETests/scripts/eccube-e2e.sh up
+        env:
+          ECAUTH_PLUGIN_VERSION: ${{ inputs.plugin_version }}
+          GITHUB_USERNAME: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.ORG_PAT || secrets.PACKAGES_READ_TOKEN }}
+
+      - name: Run EC-CUBE plugin E2E
+        run: ./E2ETests/scripts/eccube-e2e.sh test tests/specs/eccube_plugin_signup_login.spec.ts --reporter=list
+
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          mkdir -p e2e-logs
+          for svc in identityprovider caddy ec-cube4 ec-cube2; do
+            ./E2ETests/scripts/eccube-e2e.sh logs --tail 300 "$svc" > "e2e-logs/${svc}.log" 2>&1 || true
+          done
+
+      - name: Upload evidence
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: eccube-plugin-e2e
+          path: |
+            E2ETests/test-results/
+            e2e-logs/
+          retention-days: 7
+
+      - name: Stop the stack
+        if: always()
+        run: ./E2ETests/scripts/eccube-e2e.sh down

--- a/.github/workflows/eccube_plugin_e2e.yml
+++ b/.github/workflows/eccube_plugin_e2e.yml
@@ -34,6 +34,20 @@ on:
         type: string
         required: false
         default: ''
+    # 呼び出し元から secrets: inherit で全部渡させず、このワークフローが実際に
+    # 使うものだけを契約として宣言する。すべて required: false なのは、fork や
+    # シークレット未設定のリポジトリでも（プラグインを public として取得できる範囲で）
+    # 起動自体は成立させるため。未設定なら空文字になり、各所のフォールバックが効く。
+    secrets:
+      ORG_PAT:
+        description: 'プラグインリポジトリの checkout と GitHub Packages の NuGet 認証に使う Organization トークン'
+        required: false
+      PACKAGES_READ_TOKEN:
+        description: 'ORG_PAT が無い場合のフォールバック（後方互換）'
+        required: false
+      OP_SERVICE_ACCOUNT_TOKEN_NONPROD:
+        description: 'install_source=package-api のときだけ使う 1Password Service Account トークン'
+        required: false
   workflow_dispatch:
     inputs:
       plugin4_ref:
@@ -63,8 +77,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # checkout 後に git 操作をするステップは無い（イメージビルドの NuGet 認証は
+      # ビルド引数、プラグインの composer install はコンテナ内で完結する）。
+      # 認証情報を runner に残す必要が無いので 3 つとも persist-credentials: false にする。
       - name: Checkout EcAuth
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       # プラグインは docker build のコンテキストとして使う。ref を切り替えると
       # Dockerfile の FROM ごと変わるため、EC-CUBE 本体のバージョンもこれで決まる。
@@ -75,6 +94,7 @@ jobs:
           ref: ${{ inputs.plugin4_ref }}
           path: plugins/ec-cube4-ecauth
           token: ${{ secrets.ORG_PAT || secrets.PACKAGES_READ_TOKEN || github.token }}
+          persist-credentials: false
 
       - name: Checkout ec-cube2-ecauth
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -83,6 +103,7 @@ jobs:
           ref: ${{ inputs.plugin2_ref }}
           path: plugins/ec-cube2-ecauth
           token: ${{ secrets.ORG_PAT || secrets.PACKAGES_READ_TOKEN || github.token }}
+          persist-credentials: false
 
       - name: Load base environment variables
         # compose.yaml が補間する非機密のローカル/ダミー値。playwright.yml の同名 step と

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,13 @@ jobs:
   # 申込が登録する初期値とプラグインが送る値のズレ（EcAuth#481）は、この経路でしか出ない。
   # EC-CUBE のイメージビルドと初回インストールで他スイートより時間がかかるが、
   # 本番に出てから気付く類の不具合なので PR 時に回す。
+  # secrets: inherit ではなく、呼び出し先が実際に使う 3 つだけを明示的に渡す
+  # （呼び出し先の workflow_call.secrets に契約として宣言してある）。
+  # 他の 3 スイートは既存のまま inherit なので、揃えるのは別途行う。
   eccube-plugin-e2e:
     needs: dotnet-tests
     uses: ./.github/workflows/eccube_plugin_e2e.yml
-    secrets: inherit
+    secrets:
+      ORG_PAT: ${{ secrets.ORG_PAT }}
+      PACKAGES_READ_TOKEN: ${{ secrets.PACKAGES_READ_TOKEN }}
+      OP_SERVICE_ACCOUNT_TOKEN_NONPROD: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_NONPROD }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,3 +32,11 @@ jobs:
     needs: dotnet-tests
     uses: ./.github/workflows/selenium.yml
     secrets: inherit
+  # EC-CUBE 4系 / 2系のプラグインを実際に動かす結合 E2E。
+  # 申込が登録する初期値とプラグインが送る値のズレ（EcAuth#481）は、この経路でしか出ない。
+  # EC-CUBE のイメージビルドと初回インストールで他スイートより時間がかかるが、
+  # 本番に出てから気付く類の不具合なので PR 時に回す。
+  eccube-plugin-e2e:
+    needs: dotnet-tests
+    uses: ./.github/workflows/eccube_plugin_e2e.yml
+    secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,12 @@
 # dotenv files
 .env
 
+# eccube-e2e.sh が採番するホスト名（秘密は含まないが実行ごとに変わる）
+.e2e-eccube.env
+
+# EC-CUBE プラグイン結合 E2E が checkout するプラグインリポジトリ（CI の既定パス）
+/plugins/
+
 # HTTPS certificates for Linux environment
 certs/
 *.pfx

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,6 +220,25 @@ cd E2ETests && pnpm exec playwright test tests/specs/signup_client_b2b_login.spe
 CI は `.github/workflows/eccube_plugin_e2e.yml`（`main.yml` から呼ばれる）。プラグインの ref と
 package-api 経由インストールを `workflow_dispatch` の入力で切り替えられる。
 
+#### package-api（検証キー）経由でローカル実行する
+
+オーナーズストアのリリース申請で発行される検証キー（`X-ECCUBE-KEY`）を渡すと、4 系プラグインを
+実際の package-api から入れて検証できる。`op run` は env-file に無い変数をシェルからそのまま通すので、
+インラインで渡せばよい。
+
+```bash
+ECCUBE_AUTHENTICATION_KEY=$(op read 'op://EcAuth/eccube4-ecauth-plugin/eccube_authentication_key') \
+  ./E2ETests/scripts/eccube-e2e.sh up
+# バージョンを固定する場合は ECAUTH_PLUGIN_VERSION=1.0.1 も併せて渡す（非秘密）
+```
+
+> ⚠️ **`ECCUBE_AUTHENTICATION_KEY` を `.env.dev.tpl` に入れてはいけない**（レビュー bot が
+> 「配線が漏れている」と指摘しがちだが、意図的に入れていない）。4 系プラグインの
+> `docker-entrypoint.sh` は**キーが非空ならインストール元を package-api に切り替える**。
+> `.env.dev.tpl` に入れると、この E2E と無関係な通常のローカル起動まで既定のインストール元が
+> ワーキングツリーから package-api に変わり、開発中のプラグインを検証できなくなる。
+> ec-cube4-ecauth 側でも同じ理由で `.env.tpl` とは別の `.env.verify.tpl` に分離してある。
+
 #### 構成上の決めごと（変更するとき用）
 
 | 事項 | 決め |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,92 @@ AppServiceConsoleLogs
   リクエスト処理時（host start 後）の診断は **`traces` / `AppTraces`**。「App Insights に出ない」と感じたら、
   まず参照テーブルの取り違えを疑う（起動前ログを App Insights に押し込む `ForceFlush` 等の小細工は不要・無効）。
 
+### E2E テストの実装上の要点
+
+`E2ETests/` で B2B パスキーや申込フローを扱うときに、毎回ソースから再導出する羽目になる事実をまとめる。
+
+#### プラグインが呼ぶのは `https://{tenant_name}.ec-auth.io`（店舗のホストではない）
+
+EC-CUBE プラグインは、まず `/platform/v1/client-resolve` に `client_id` を投げ、返ってきた
+`base_url`（= `https://{tenant_name}.{PlatformApi:BaseDomain}`、`Controllers/Platform/ClientResolveController.cs:60-61`）を
+設定値 `ecauth_base_url` として保存し、**以降の API 呼び出しをすべてそこへ送る**
+（4 系 `Controller/Admin/ConfigController.php` の `clientResolveService->resolve()`、
+2 系 `SC_Helper_EcAuthLogin2.php` の `CLIENT_RESOLVE_PATH`）。
+
+つまり実運用では **1 リクエストに 2 種類のホストが登場する**:
+
+| 役割 | ホスト | 理由 |
+|---|---|---|
+| ブラウザ（`navigator.credentials.create` / `get`） | 店舗のホスト（= `rp_id`） | WebAuthn が origin と `rp_id` の一致を要求する |
+| サーバー（`*/options`・`*/verify` の HTTP 呼び出し） | `{tenant_name}.ec-auth.io` | プラグインが保存した `ecauth_base_url` |
+
+E2E でこれを一体にして「ブラウザから直接 API を叩く」と、`Host` が店舗のホストになって
+`TenantMiddleware` が既定テナントに解決してしまい、`WebAuthnChallenge` のグローバルクエリフィルタ
+（`Models/EcAuthDbContext.cs`）が顧客 Organization の行に一致せず **`Session not found or expired` (400)** になる。
+これは **テストの誤りであってプロダクトの不具合ではない**。`tests/helpers/b2b-passkey.ts` の `B2BContext` が
+`api`（テナントの `Host` を付けた `APIRequestContext`）と `page`（`rp_id` と一致する origin）を分けているのはこのため。
+
+#### `redirect_uri` / `rp_id` をテスト側で組み立てない
+
+`authenticate/verify` の `redirect_uri` は登録値と**完全一致**で検証される（`Controllers/B2BPasskeyController.cs`）。
+テストで期待値を組み立てると「申込が登録した初期値」と「プラグインが送る値」のズレ（EcAuth#481 の本体）が
+検出できない。`GET /v1/account/clients` で取得した登録済みの値をそのまま使うこと。
+
+#### 疑似店舗ホストに `.test` を使う
+
+`.test` は RFC 6761 の予約 TLD で公開解決されず、実在ドメインと衝突しない。本番 DB に残っても
+テストデータであることが明確になる。`Middlewares/TenantMiddleware.cs` の `ExtractTenantNameFromHost` が先頭セグメントを
+テナント名として扱うのは **3 セグメント以上**のときだけなので、`e2e-{RUN}.test` の 2 セグメントに
+保てば既定テナントに解決される。Playwright 側は `playwright.config.ts` の
+`--host-resolver-rules` に `MAP *.test 127.0.0.1` を入れて解決させる。
+
+#### `wwwroot/b2b-passkey-test.html` の配信条件
+
+静的ファイル配信は **`app.Environment.IsProduction()` のときだけ**テナント限定になる
+（`Program.cs` の `UseWhen` — ホストが 3 セグメント以上かつ先頭が `DEFAULT_ORGANIZATION_TENANT_NAME`）。
+本番では `production.ec-auth.io` からしか見えず、顧客テナントのサブドメインでは 404 になる。
+Development / Staging では `app.UseStaticFiles()` が無条件に効く。
+
+#### ローカルでの再実行
+
+```bash
+op run --env-file=.env.dev.tpl -- docker compose -p ec-auth up -d --build identityprovider
+cd E2ETests && pnpm exec playwright test tests/specs/signup_client_b2b_login.spec.ts --reporter=list
+```
+
+### EC-CUBE プラグイン結合 E2E
+
+`eccube_plugin_signup_login.spec.ts` は EC-CUBE 4 系 / 2 系を実際に起動し、
+**申込 → プラグイン設定 → パスキー登録 → 管理画面ログイン**を通す。API だけで検証する
+`signup_client_b2b_login.spec.ts` では守れない「プラグインが実際に送る値」まで突き合わせる。
+
+```bash
+./E2ETests/scripts/eccube-e2e.sh up      # ホスト名を採番して compose を起動（op run 経由）
+./E2ETests/scripts/eccube-e2e.sh test tests/specs/eccube_plugin_signup_login.spec.ts --reporter=list
+./E2ETests/scripts/eccube-e2e.sh down    # ボリュームごと破棄
+```
+
+CI は `.github/workflows/eccube_plugin_e2e.yml`（`main.yml` から呼ばれる）。プラグインの ref と
+package-api 経由インストールを `workflow_dispatch` の入力で切り替えられる。
+
+#### 構成上の決めごと（変更するとき用）
+
+| 事項 | 決め |
+|---|---|
+| リバースプロキシ | Caddy 1 台で 443 に集約（`docker/e2e/Caddyfile`）。ポート付き URL だと rp_id / redirect_uri が本番と変わるため |
+| 証明書 | Caddy の `local_certs`。ルート CA を EC-CUBE の信頼ストアへ注入する（`docker/e2e/eccube-entrypoint.sh`）。2 系は `CURLOPT_SSL_VERIFYPEER => true` なので検証を切らずに通す |
+| ホスト名 | `up` の時点で採番。Caddy のサイトアドレスと docker network alias の両方に同じ名前が要るため、テスト実行時には決められない |
+| discovery の宛先 | `api.ec-auth.io`（両プラグインの既定値）を network alias で Caddy に引き込む。`ECAUTH_CLIENT_RESOLVE_URL` では上書きしない — 顧客が通る既定のままの経路を検証したいため |
+| `PlatformApi:BaseDomain` | この E2E だけ `ec-auth.io` に上書きする（`compose.e2e-eccube.yaml`）。Development の既定 `localhost:8081` だと `{tenant}.localhost` が 2 セグメントになり、`TenantMiddleware` がテナントを取り出せない |
+| EC-CUBE 本体のバージョン | プラグインリポジトリの `Dockerfile` の `FROM` が決める。compose 側にノブは置かない |
+
+#### 再実行時の注意
+
+申込は組織コードの重複を弾く（`organization_already_exists`）。組織コードはサイトホストから
+導出されるため、**同じホストで二度申し込めない**。`up` は毎回新しい RUN_ID を振り、`down` は
+ボリュームごと破棄する。`E2E_RUN_ID` を環境変数で固定すると同じホストで再実行してしまうので、
+意図的に再現したいとき以外は設定しない。
+
 ### マイグレーション設計ルール
 
 - `migrationBuilder.Sql()` でカラムを参照する UPDATE/INSERT 文を書く場合、`EXEC()` 動的 SQL でラップすること

--- a/E2ETests/scripts/eccube-e2e.sh
+++ b/E2ETests/scripts/eccube-e2e.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+#
+# EC-CUBE 4 系 / 2 系のプラグインを実際に動かす結合 E2E のランチャー。
+#
+#   ./E2ETests/scripts/eccube-e2e.sh up            # ホスト名を採番して compose を起動
+#   ./E2ETests/scripts/eccube-e2e.sh test [args]   # Playwright を実行（args はそのまま渡す）
+#   ./E2ETests/scripts/eccube-e2e.sh logs [svc]
+#   ./E2ETests/scripts/eccube-e2e.sh down          # 停止（ボリュームも削除）
+#
+# ホスト名を up の時点で確定させるのは、Caddy のサイトアドレスと docker network
+# alias の両方へ同じ名前を配る必要があるため（compose.e2e-eccube.yaml 冒頭参照）。
+# 採番結果は .e2e-eccube.env に残し、test / logs / down から読み直す。
+#
+# 申込は組織コードの重複を弾く（SignupService の organization_already_exists）。
+# up のたびに新しい RUN_ID を振り、down で EcAuth の DB ごと落とすことで、
+# 同じホスト名で二度申し込む状況を作らない。
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+STATE_FILE="${ROOT}/.e2e-eccube.env"
+ENV_TEMPLATE="${E2E_ENV_TEMPLATE:-${ROOT}/.env.dev.tpl}"
+
+compose() {
+    docker compose -p ec-auth \
+        -f "${ROOT}/compose.yaml" \
+        -f "${ROOT}/compose.e2e-eccube.yaml" \
+        "$@"
+}
+
+# 採番した設定を環境へ載せる。無ければ理由を添えて止める（暗黙の既定値を作らない）。
+load_state() {
+    if [ ! -f "${STATE_FILE}" ]; then
+        echo "${STATE_FILE} がありません。先に '$0 up' を実行してください。" >&2
+        exit 1
+    fi
+    set -a
+    # shellcheck disable=SC1090
+    . "${STATE_FILE}"
+    set +a
+}
+
+cmd_up() {
+    # RUN_ID はホスト名の 1 ラベルに収まる英数字。組織コードは
+    # e2e-{RUN_ID}-shop4-test のようにホストから導出される（DeriveOrganizationCode）。
+    local run_id="${E2E_RUN_ID:-$(date +%s)-$RANDOM}"
+
+    # 秘密は入らない（ホスト名とディレクトリのみ）。再実行のたびに作り直すのが正しいので
+    # 追記ではなく生成する。プロジェクトの .env とは別ファイル。
+    cat > "${STATE_FILE}" <<EOF
+# eccube-e2e.sh up が生成。手で編集しない（次の up で上書きされる）。
+E2E_RUN_ID=${run_id}
+E2E_ECCUBE4_SHOP_HOST=e2e-${run_id}.shop4.test
+E2E_ECCUBE2_SHOP_HOST=e2e-${run_id}.shop2.test
+E2E_ECCUBE4_TENANT_HOST=e2e-${run_id}-shop4-test.ec-auth.io
+E2E_ECCUBE2_TENANT_HOST=e2e-${run_id}-shop2-test.ec-auth.io
+E2E_ECCUBE4_PLUGIN_DIR=${E2E_ECCUBE4_PLUGIN_DIR:-../ec-cube4-ecauth}
+E2E_ECCUBE2_PLUGIN_DIR=${E2E_ECCUBE2_PLUGIN_DIR:-../ec-cube2-ecauth}
+EOF
+    load_state
+
+    echo "[eccube-e2e] RUN_ID=${E2E_RUN_ID}"
+    echo "[eccube-e2e] 4系 shop=${E2E_ECCUBE4_SHOP_HOST} tenant=${E2E_ECCUBE4_TENANT_HOST}"
+    echo "[eccube-e2e] 2系 shop=${E2E_ECCUBE2_SHOP_HOST} tenant=${E2E_ECCUBE2_TENANT_HOST}"
+
+    # identityprovider 側のシークレットは op run で注入する（平文 .env は作らない）。
+    # CI など op を使わない環境では E2E_SKIP_OP=1 で素の docker compose に落とす。
+    if [ "${E2E_SKIP_OP:-}" = "1" ]; then
+        compose up -d --build --wait
+    else
+        op run --env-file="${ENV_TEMPLATE}" -- \
+            docker compose -p ec-auth \
+                -f "${ROOT}/compose.yaml" \
+                -f "${ROOT}/compose.e2e-eccube.yaml" \
+                up -d --build --wait
+    fi
+
+    # --wait は healthcheck を持たないサービスを「起動した」としか見ない。EC-CUBE は
+    # entrypoint が本体インストールとプラグイン導入を終えてから Apache を exec するので、
+    # 「HTTP で応答する」= 準備完了。Caddy 越しに叩いて経路ごと確認する。
+    wait_for_url "${E2E_ECCUBE4_TENANT_HOST}" /healthz 'EcAuth（4系テナント）' caddy
+    wait_for_url "${E2E_ECCUBE2_TENANT_HOST}" /healthz 'EcAuth（2系テナント）' caddy
+    wait_for_url "${E2E_ECCUBE4_SHOP_HOST}" /admin/login 'EC-CUBE 4系' ec-cube4
+    wait_for_url "${E2E_ECCUBE2_SHOP_HOST}" "${E2E_ECCUBE2_ADMIN_BASE:-/admin/}" 'EC-CUBE 2系' ec-cube2
+
+    echo "[eccube-e2e] 準備完了。'$0 test' で Playwright を実行してください。"
+}
+
+# Caddy が 443 で受けるホストを、ホスト側の DNS に手を入れずに叩く。
+# --resolve で名前解決だけを差し替えるので SNI / Host ヘッダは本番同様のまま。
+# 証明書は Caddy のローカル CA 発行なので -k で通す（TLS 検証は EC-CUBE 側で行う）。
+wait_for_url() {
+    local host="$1" path="$2" label="$3" service="$4"
+    local attempts="${E2E_WAIT_ATTEMPTS:-120}"
+
+    echo "[eccube-e2e] Waiting for ${label}: https://${host}${path}"
+    for _ in $(seq 1 "${attempts}"); do
+        if curl -sfk --resolve "${host}:443:127.0.0.1" --max-time 10 \
+                -o /dev/null "https://${host}${path}"; then
+            echo "[eccube-e2e] ${label} ready"
+            return 0
+        fi
+        sleep 5
+    done
+
+    echo "[eccube-e2e] ${label} の起動待ちが上限に達しました。直近のログ:" >&2
+    compose logs --no-color --tail 120 "${service}" >&2 || true
+    return 1
+}
+
+cmd_test() {
+    load_state
+    cd "${ROOT}/E2ETests"
+    pnpm exec playwright test "$@"
+}
+
+cmd_logs() {
+    load_state
+    compose logs --no-color "$@"
+}
+
+cmd_down() {
+    if [ -f "${STATE_FILE}" ]; then
+        load_state
+    else
+        # down だけ先に呼ばれても compose の必須変数チェックで落ちないようにする。
+        export E2E_ECCUBE4_SHOP_HOST=unset.shop4.test
+        export E2E_ECCUBE2_SHOP_HOST=unset.shop2.test
+        export E2E_ECCUBE4_TENANT_HOST=unset-shop4-test.ec-auth.io
+        export E2E_ECCUBE2_TENANT_HOST=unset-shop2-test.ec-auth.io
+    fi
+    compose down -v
+    rm -f "${STATE_FILE}"
+}
+
+case "${1:-}" in
+    up) shift; cmd_up "$@" ;;
+    test) shift; cmd_test "$@" ;;
+    logs) shift; cmd_logs "$@" ;;
+    down) shift; cmd_down "$@" ;;
+    *)
+        echo "usage: $0 {up|test|logs|down} [args...]" >&2
+        exit 2
+        ;;
+esac

--- a/E2ETests/scripts/eccube-e2e.sh
+++ b/E2ETests/scripts/eccube-e2e.sh
@@ -44,6 +44,15 @@ cmd_up() {
     # e2e-{RUN_ID}-shop4-test のようにホストから導出される（DeriveOrganizationCode）。
     local run_id="${E2E_RUN_ID:-$(date +%s)-$RANDOM}"
 
+    # ボリューム名（eccube4-pg / eccube2-pg / eccube2-vendor / caddy-data）は RUN_ID に
+    # 紐付かない固定名なので、down を挟まずに up を再実行すると、新しいホスト名に対して
+    # 前回の EC-CUBE DB（プラグイン設定を含む）が残ったまま起動してしまう。
+    # 「無設定から始める」ことがこのテストの前提なので、残骸を検知したら作り直す。
+    if [ -f "${STATE_FILE}" ]; then
+        echo "[eccube-e2e] 前回の環境が残っています。EcAuth の DB を含むボリュームごと down してから起動し直します。" >&2
+        cmd_down
+    fi
+
     # 秘密は入らない（ホスト名とディレクトリのみ）。再実行のたびに作り直すのが正しいので
     # 追記ではなく生成する。プロジェクトの .env とは別ファイル。
     cat > "${STATE_FILE}" <<EOF

--- a/E2ETests/tests/helpers/accounts.ts
+++ b/E2ETests/tests/helpers/accounts.ts
@@ -41,6 +41,16 @@ export interface SignupResult {
   messageId: string;
 }
 
+/** 申込で払い出された Client。値はすべて API から取得したもので、テスト側では組み立てない。 */
+export interface SignupClient {
+  id: number;
+  clientId: string;
+  clientSecret: string;
+  organizationCode: string;
+  /** 申込時に登録された redirect_uri。プラグインが送る値と完全一致する必要がある */
+  redirectUris: string[];
+}
+
 /**
  * 申込 → 確認メール → confirm → パスキー登録 → パスキー認証 → トークン交換 を通し、
  * Account のアクセストークンを返す。
@@ -143,6 +153,59 @@ export async function signupAndGetAccountToken(
   } finally {
     await page.close();
   }
+}
+
+/**
+ * マイページと同じ経路（Account トークン → 一覧 → secret の reveal）で、申込が払い出した
+ * Client を取得する。DB を直接読まないのは、顧客が実際に client_id / client_secret を
+ * 手に入れる経路そのものを検証するため。
+ */
+export async function fetchSignupClient(
+  api: APIRequestContext,
+  baseUrl: string,
+  accessToken: string,
+  organizationCode: string
+): Promise<SignupClient> {
+  const headers = { Authorization: `Bearer ${accessToken}` };
+
+  const listResponse = await api.get(`${baseUrl}/v1/account/clients`, { headers });
+  if (listResponse.status() !== 200) {
+    throw new Error(
+      `Client 一覧の取得に失敗しました (${listResponse.status()}): ${await listResponse.text()}`
+    );
+  }
+
+  const clients = (await listResponse.json()).clients as Array<{
+    id: number;
+    client_id: string;
+    organization_code: string;
+    redirect_uris: string[];
+  }>;
+
+  const client = clients.find((c) => c.organization_code === organizationCode);
+  if (!client) {
+    throw new Error(
+      `organization_code=${organizationCode} の Client が見つかりません` +
+        `（取得できたのは ${clients.map((c) => c.organization_code).join(', ') || '(なし)'}）`
+    );
+  }
+
+  const revealResponse = await api.post(`${baseUrl}/v1/account/clients/${client.id}/secret/reveal`, {
+    headers,
+  });
+  if (revealResponse.status() !== 200) {
+    throw new Error(
+      `client_secret の取得に失敗しました (${revealResponse.status()}): ${await revealResponse.text()}`
+    );
+  }
+
+  return {
+    id: client.id,
+    clientId: client.client_id,
+    clientSecret: (await revealResponse.json()).client_secret as string,
+    organizationCode: client.organization_code,
+    redirectUris: client.redirect_uris,
+  };
 }
 
 /**

--- a/E2ETests/tests/helpers/eccube-admin.ts
+++ b/E2ETests/tests/helpers/eccube-admin.ts
@@ -1,0 +1,324 @@
+import { expect, BrowserContext, Page } from '@playwright/test';
+
+/**
+ * EC-CUBE 管理画面の操作を 4 系 / 2 系で共通のインターフェースに揃えるアダプタ。
+ *
+ * 「申込 → 設定投入 → パスキー登録 → ログイン」という検証したい筋書きは両系で同一で、
+ * 違うのは URL とセレクタだけ。spec を 2 本書くと筋書きの差分が埋もれるため、
+ * 筋書きは 1 本にまとめ、系ごとの差分をここへ閉じ込める。
+ *
+ * セレクタはプラグインリポジトリ（ec-cube4-ecauth / ec-cube2-ecauth）のテンプレートに
+ * 由来する。プラグイン側の E2E と重複するが、こちらが検証しているのは
+ * **申込で払い出された値を無設定のまま使えるか** で、プラグイン側 E2E が
+ * ecauth_base_url / rp_id を「高度な設定」で明示指定しているのとは目的が異なる。
+ */
+export interface EcCubeAdmin {
+  /** ID / パスワードで管理画面にログインする */
+  login(page: Page, shopBaseUrl: string, loginId: string, password: string): Promise<void>;
+
+  /**
+   * プラグイン設定画面で client_id / client_secret **だけ** を保存する。
+   * ecauth_base_url と rp_id は空のままにして、プラグイン側の自動解決に委ねる。
+   */
+  saveClientCredentials(
+    page: Page,
+    shopBaseUrl: string,
+    clientId: string,
+    clientSecret: string
+  ): Promise<void>;
+
+  /** 保存後の設定画面を開き直し、自動解決された ecauth_base_url を読む */
+  readResolvedBaseUrl(page: Page, shopBaseUrl: string): Promise<string>;
+
+  /** パスキーを 1 件登録し、サーバーが返した credential_id を返す */
+  registerPasskey(page: Page, shopBaseUrl: string, adminPassword: string): Promise<string>;
+
+  /** ログアウトしてログイン画面に戻る */
+  logout(page: Page, shopBaseUrl: string): Promise<void>;
+
+  /** ログイン画面のパスキーボタンからログインし、管理画面ホームまで遷移する */
+  passkeyLogin(page: Page, shopBaseUrl: string): Promise<void>;
+}
+
+/**
+ * WebAuthn 周りの診断とワークアラウンドをブラウザ側に仕込む。
+ *
+ * プラグインの JS が navigator.credentials を直接呼ぶため、テスト側からは介入できない。
+ * 一方でプラグインの catch は NotAllowedError を握り潰すので、失敗しても画面には
+ * 「登録に失敗しました」しか出ず CI から原因が追えない。そこで:
+ *
+ *   - サーバーが timeout=0 を返した場合に有効値へ落とす（0 のままだと環境によって
+ *     セレモニーが即座に打ち切られる）
+ *   - create / get の解決値と例外名を console に流し、Playwright のログへ届かせる
+ *
+ * ec-cube4-ecauth / ec-cube2-ecauth の E2E が同じ仕掛けを持っており、その必要性は
+ * 両リポジトリの CI で実証済み。
+ */
+export async function installBrowserDiagnostics(context: BrowserContext): Promise<void> {
+  await context.addInitScript(() => {
+    const FALLBACK_TIMEOUT_MS = 60000;
+
+    const originalCreate = navigator.credentials.create.bind(navigator.credentials);
+    navigator.credentials.create = async (options?: CredentialCreationOptions) => {
+      if (options?.publicKey && !options.publicKey.timeout) {
+        options.publicKey.timeout = FALLBACK_TIMEOUT_MS;
+      }
+      try {
+        const cred = await originalCreate(options);
+        console.log('[E2E] credentials.create resolved: id=' + (cred as PublicKeyCredential | null)?.id);
+        return cred;
+      } catch (e) {
+        const err = e as Error;
+        console.log('[E2E] credentials.create rejected: ' + err.name + ': ' + err.message);
+        throw e;
+      }
+    };
+
+    const originalGet = navigator.credentials.get.bind(navigator.credentials);
+    navigator.credentials.get = async (options?: CredentialRequestOptions) => {
+      if (options?.publicKey && !options.publicKey.timeout) {
+        options.publicKey.timeout = FALLBACK_TIMEOUT_MS;
+      }
+      try {
+        const cred = await originalGet(options);
+        console.log('[E2E] credentials.get resolved: id=' + (cred as PublicKeyCredential | null)?.id);
+        return cred;
+      } catch (e) {
+        const err = e as Error;
+        console.log('[E2E] credentials.get rejected: ' + err.name + ': ' + err.message);
+        throw e;
+      }
+    };
+
+    window.addEventListener('unhandledrejection', (e) => {
+      console.log('[E2E] unhandledrejection: ' + String((e as PromiseRejectionEvent).reason));
+    });
+  });
+}
+
+/**
+ * 設定保存が失敗したときに、画面に出ているエラー文言を拾って一行にまとめる。
+ * 4 系は Symfony フォームの .invalid-feedback、2 系は設定テンプレートの
+ * `<div class="message">`（$arrErr のループ）に出る。
+ */
+async function describeFormErrors(page: Page): Promise<string> {
+  const texts = await page
+    .locator('.invalid-feedback, .message, .attention, .alert-danger, .alert-warning')
+    .allInnerTexts()
+    .catch(() => [] as string[]);
+  const visible = texts.map((t) => t.trim()).filter(Boolean);
+  return visible.length > 0
+    ? `画面のエラー表示: ${visible.join(' / ')}`
+    : '画面にエラー表示はありませんでした';
+}
+
+/** register/verify のレスポンス。両系とも同じ形を返す。 */
+interface RegisterVerifyBody {
+  success: boolean;
+  credential_id: string;
+}
+
+/**
+ * 登録ボタン押下から register/verify の応答までを待つ共通処理。
+ *
+ * パスキー一覧はセッションに access_token が入るまで空表示になる（access_token は
+ * パスキーログイン成功後に初めて入る）ため、画面ではなくサーバーの応答で登録完了を判定する。
+ */
+async function awaitRegisterVerify(
+  page: Page,
+  urlFragment: string,
+  clickConfirm: () => Promise<void>
+): Promise<string> {
+  const verifyPromise = page.waitForResponse(
+    (res) => res.url().includes(urlFragment) && res.request().method() === 'POST',
+    { timeout: 30000 }
+  );
+  await clickConfirm();
+  const response = await verifyPromise;
+
+  const text = await response.text();
+  if (response.status() !== 200) {
+    throw new Error(`${urlFragment} が ${response.status()} を返しました: ${text}`);
+  }
+  const body = JSON.parse(text) as RegisterVerifyBody;
+  expect(body.success, `register/verify が success=false を返しました: ${text}`).toBe(true);
+  expect(typeof body.credential_id).toBe('string');
+  return body.credential_id;
+}
+
+// ---------------------------------------------------------------------------
+// EC-CUBE 4 系
+// ---------------------------------------------------------------------------
+
+const ADVANCED_TOGGLE_4 =
+  'button[data-bs-toggle="collapse"][data-bs-target="#ecauth-advanced-settings"]';
+
+export const eccube4Admin: EcCubeAdmin = {
+  async login(page, shopBaseUrl, loginId, password) {
+    await page.goto(`${shopBaseUrl}/admin/login`);
+    await page.fill('input[name="login_id"]', loginId);
+    await page.fill('input[name="password"]', password);
+    await Promise.all([
+      page.waitForURL((url) => /^\/admin\/?$/.test(new URL(url).pathname), { timeout: 30000 }),
+      page.click('button[type="submit"]'),
+    ]);
+  },
+
+  async saveClientCredentials(page, shopBaseUrl, clientId, clientSecret) {
+    await page.goto(`${shopBaseUrl}/admin/ecauth_login43/config`);
+    await page.fill('input[name="config[client_id]"]', clientId);
+    await page.fill('input[name="config[client_secret]"]', clientSecret);
+    // 「高度な設定」（ecauth_base_url / rp_id）は開かない。空のまま保存することで、
+    // ConfigController が client-resolve を叩いて base_url を埋める経路を通す。
+    await page.click('button[type="submit"]');
+    try {
+      await expect(page.locator('.alert-success')).toBeVisible({ timeout: 30000 });
+    } catch (e) {
+      // 失敗の主因は client-resolve の失敗で、その理由はフォームのエラー欄にしか出ない。
+      // タイムアウトだけでは原因が分からないので添えて投げ直す。
+      throw new Error(`${await describeFormErrors(page)} / 元エラー: ${(e as Error).message}`);
+    }
+  },
+
+  async readResolvedBaseUrl(page, shopBaseUrl) {
+    await page.goto(`${shopBaseUrl}/admin/ecauth_login43/config`);
+    await page.click(ADVANCED_TOGGLE_4);
+    await expect(page.locator('#ecauth-advanced-settings')).toHaveClass(/show/);
+    return page.inputValue('input[name="config[ecauth_base_url]"]');
+  },
+
+  async registerPasskey(page, shopBaseUrl, adminPassword) {
+    await page.goto(`${shopBaseUrl}/admin/ecauth/passkey/`);
+    await expect(page.locator('.card-header:has-text("登録済みパスキー")')).toBeVisible();
+
+    await page.click('#ecauth-passkey-add');
+    await expect(page.locator('#ecauth-password-modal')).toBeVisible();
+    await page.fill('#ecauth-password-input', adminPassword);
+
+    return awaitRegisterVerify(page, '/ecauth/passkey/register/verify', () =>
+      page.click('#ecauth-password-confirm')
+    );
+  },
+
+  async logout(page, shopBaseUrl) {
+    await page.goto(`${shopBaseUrl}/admin/logout`);
+    await expect(page).toHaveURL(/\/admin\/login/);
+    await expect(page.locator('input[name="login_id"]')).toBeVisible();
+  },
+
+  async passkeyLogin(page, shopBaseUrl) {
+    await page.goto(`${shopBaseUrl}/admin/login`);
+    const passkeyBtn = page.locator('#ecauth-passkey-login');
+    await expect(passkeyBtn).toBeVisible();
+
+    // options → assertion → verify → redirect_url → /ecauth/callback → /admin/
+    await Promise.all([
+      page.waitForURL((url) => /^\/admin\/?$/.test(new URL(url).pathname), { timeout: 30000 }),
+      passkeyBtn.click(),
+    ]);
+    await expect(page.locator('input[name="login_id"]')).toHaveCount(0);
+    await expect(page.locator('h2', { hasText: 'ホーム' })).toBeVisible();
+  },
+};
+
+// ---------------------------------------------------------------------------
+// EC-CUBE 2 系
+// ---------------------------------------------------------------------------
+
+/**
+ * ADMIN_DIR は前後スラッシュ付き（既定 '/admin/'）。EC-CUBE 2 は管理画面 URL を
+ * 秘匿するためインストール時に変更できるので、ハードコードせず env から読む。
+ */
+const ADMIN_BASE_2 = process.env.E2E_ECCUBE2_ADMIN_BASE || '/admin/';
+const ADMIN_BASE_2_RE = ADMIN_BASE_2.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+/** 2 系のプラグイン設定は「オーナーズストア > プラグイン」からのポップアップだが、直リンクでも同じ画面が出る */
+const PLUGIN_ID_2 = process.env.E2E_ECCUBE2_PLUGIN_ID || '10000';
+
+export const eccube2Admin: EcCubeAdmin = {
+  async login(page, shopBaseUrl, loginId, password) {
+    await page.goto(`${shopBaseUrl}${ADMIN_BASE_2}`);
+    await page.fill('input[name="login_id"]', loginId);
+    await page.fill('input[name="password"]', password);
+    await Promise.all([
+      page.waitForURL(new RegExp(`${ADMIN_BASE_2_RE}home\\.php`), { timeout: 30000 }),
+      page.click('a:has-text("LOGIN")'),
+    ]);
+  },
+
+  async saveClientCredentials(page, shopBaseUrl, clientId, clientSecret) {
+    await page.goto(`${shopBaseUrl}${ADMIN_BASE_2}load_plugin_config.php?plugin_id=${PLUGIN_ID_2}`);
+    await page.fill('input[name="client_id"]', clientId);
+    await page.fill('input[name="client_secret"]', clientSecret);
+    // ecauth_base_url / rp_id は空のまま。4 系と同じく自動解決の経路を通す。
+
+    // 保存に成功すると tpl_onload の alert("設定を保存しました。") が出る。
+    // 失敗した場合はダイアログではなく画面上のエラー欄に出るため、待ち切れなかったら
+    // その内容を添えて投げる（client-resolve 失敗がここに現れる）。
+    const dialogMessage = page.waitForEvent('dialog', { timeout: 30000 }).then(async (dialog) => {
+      const message = dialog.message();
+      await dialog.accept().catch(() => {});
+      return message;
+    });
+    await page.click('button:has-text("登録")');
+
+    let message: string;
+    try {
+      message = await dialogMessage;
+    } catch (e) {
+      throw new Error(
+        `設定保存の完了ダイアログが出ませんでした。${await describeFormErrors(page)}` +
+          ` / 元エラー: ${(e as Error).message}`
+      );
+    }
+    expect(message).toContain('設定を保存しました');
+    await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
+  },
+
+  async readResolvedBaseUrl(page, shopBaseUrl) {
+    await page.goto(`${shopBaseUrl}${ADMIN_BASE_2}load_plugin_config.php?plugin_id=${PLUGIN_ID_2}`);
+    return page.inputValue('input[name="ecauth_base_url"]');
+  },
+
+  async registerPasskey(page, shopBaseUrl, adminPassword) {
+    await page.goto(`${shopBaseUrl}${ADMIN_BASE_2}ecauth/passkey.php`);
+    await expect(page.locator('span', { hasText: '登録済みパスキー' })).toBeVisible();
+
+    await page.click('#ecauth-passkey-add');
+    await expect(page.locator('#ecauth-password-modal')).toBeVisible();
+    await page.fill('#ecauth-password-input', adminPassword);
+
+    // 登録成功時の alert → reload が走るので、後続の goto と競合しないよう
+    // ダイアログを受け流してから networkidle を待つ。
+    page.on('dialog', (dialog) => {
+      dialog.accept().catch(() => {});
+    });
+
+    const credentialId = await awaitRegisterVerify(
+      page,
+      `${ADMIN_BASE_2}ecauth/api/register-verify.php`,
+      () => page.click('#ecauth-password-confirm')
+    );
+    await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
+    return credentialId;
+  },
+
+  async logout(page, shopBaseUrl) {
+    await page.goto(`${shopBaseUrl}${ADMIN_BASE_2}logout.php`);
+    await expect(page).toHaveURL(new RegExp(`${ADMIN_BASE_2_RE.replace(/\/$/, '')}/?$`));
+    await expect(page.locator('input[name="login_id"]')).toBeVisible();
+  },
+
+  async passkeyLogin(page, shopBaseUrl) {
+    await page.goto(`${shopBaseUrl}${ADMIN_BASE_2}`);
+    const passkeyBtn = page.locator('#ecauth-passkey-login');
+    await expect(passkeyBtn).toBeVisible();
+
+    // options → assertion → verify → redirect_url → /ecauth/callback.php → <ADMIN_BASE>home.php
+    await Promise.all([
+      page.waitForURL(new RegExp(`${ADMIN_BASE_2_RE}home\\.php`), { timeout: 30000 }),
+      passkeyBtn.click(),
+    ]);
+    await expect(page.locator('input[name="login_id"]')).toHaveCount(0);
+    await expect(page.locator('h1, h2', { hasText: 'ホーム' })).toBeVisible();
+  },
+};

--- a/E2ETests/tests/specs/eccube_plugin_signup_login.spec.ts
+++ b/E2ETests/tests/specs/eccube_plugin_signup_login.spec.ts
@@ -74,6 +74,13 @@ for (const variant of VARIANTS) {
       `${variant.label} の店舗ホストが未設定のためスキップ（E2ETests/scripts/eccube-e2e.sh up で起動してください）`
     );
 
+    // この筋書きはリトライできない。申込は組織コードの重複を弾き
+    // （SignupService の organization_already_exists）、組織コードは compose 起動時に
+    // 確定した店舗ホストから導出されるため、再実行しても必ず同じコードになる。
+    // config の retries（CI では 2）のままだと、後段の失敗がリトライのたびに
+    // organization_already_exists に化けて本当の失敗理由が隠れる。
+    test.describe.configure({ retries: 0 });
+
     const baseUrl = process.env.E2E_BASE_URL || 'https://localhost:8081';
     const accountsHost = process.env.E2E_ACCOUNTS_HOST || 'accounts.ec-auth.io';
     const accountsPageBaseUrl = process.env.E2E_ACCOUNTS_PAGE_URL || `https://${accountsHost}:8081`;

--- a/E2ETests/tests/specs/eccube_plugin_signup_login.spec.ts
+++ b/E2ETests/tests/specs/eccube_plugin_signup_login.spec.ts
@@ -1,0 +1,214 @@
+import { test, expect, APIRequestContext, BrowserContext, Page, request } from '@playwright/test';
+import { signupAndGetAccountToken, fetchSignupClient } from '../helpers/accounts';
+import { deleteMessages } from '../helpers/mailpit';
+import {
+  EcCubeAdmin,
+  eccube4Admin,
+  eccube2Admin,
+  installBrowserDiagnostics,
+} from '../helpers/eccube-admin';
+
+/**
+ * EC-CUBE のプラグインを実際に動かして、申込から管理画面ログインまでを 1 本で通す。
+ *
+ * signup_client_b2b_login.spec.ts が EcAuth の API だけで同じ筋書きを検証しているのに対し、
+ * こちらは **プラグインの実コードを経由する**。EcAuth#481 のように「申込が登録する初期値」と
+ * 「プラグインが実際に送る値」がズレる不具合は、両者を突き合わせないと出ない。
+ * API 版で守れるのは EcAuth 側の初期値だけで、プラグインが送る値の方は守れない。
+ *
+ * 検証する筋書き（顧客が実際に踏む手順そのもの）:
+ *   1. 申込 → 確認メール → Account トークン
+ *   2. マイページと同じ経路で client_id / client_secret を取得
+ *   3. EC-CUBE 管理画面のプラグイン設定に **client_id / client_secret だけ** を入力して保存
+ *      → ecauth_base_url は client-resolve で自動解決される（無設定で使えることの検証）
+ *      → rp_id も未設定のままにして、リクエストホストが使われることを検証
+ *   4. パスキーを登録
+ *   5. ログアウト
+ *   6. パスキーでログインし、管理画面ホームに到達する
+ *
+ * 実行には compose.e2e-eccube.yaml で起動した EC-CUBE が必要。ホスト名は
+ * E2ETests/scripts/eccube-e2e.sh up が採番して環境変数で渡す。未設定なら skip する。
+ */
+
+interface Variant {
+  label: string;
+  /** 申込フォームの ec_cube_version。登録される redirect_uri の分岐に効く */
+  ecCubeVersion: '2' | '4';
+  /** 店舗のホスト（= WebAuthn の rp_id）。compose の Caddy が 443 で受ける */
+  shopHost: string | undefined;
+  /** プラグインが ecauth_base_url として解決するはずのホスト */
+  tenantHost: string | undefined;
+  /** プラグインが redirect_uri として送るパス */
+  callbackPath: string;
+  admin: EcCubeAdmin;
+}
+
+const VARIANTS: Variant[] = [
+  {
+    label: 'EC-CUBE 4系',
+    ecCubeVersion: '4',
+    shopHost: process.env.E2E_ECCUBE4_SHOP_HOST,
+    tenantHost: process.env.E2E_ECCUBE4_TENANT_HOST,
+    // EcAuthCallbackController の @Route("/ecauth/callback")
+    callbackPath: '/ecauth/callback',
+    admin: eccube4Admin,
+  },
+  {
+    label: 'EC-CUBE 2系',
+    ecCubeVersion: '2',
+    shopHost: process.env.E2E_ECCUBE2_SHOP_HOST,
+    tenantHost: process.env.E2E_ECCUBE2_TENANT_HOST,
+    // LC_Page_EcAuthLogin2_PasskeyApi の HTTPS_URL . 'ecauth/callback.php'
+    callbackPath: '/ecauth/callback.php',
+    admin: eccube2Admin,
+  },
+];
+
+const ADMIN_LOGIN_ID = process.env.E2E_ECCUBE_ADMIN_LOGIN_ID || 'admin';
+const ADMIN_PASSWORD = process.env.E2E_ECCUBE_ADMIN_PASSWORD || 'password';
+
+for (const variant of VARIANTS) {
+  test.describe.serial(`${variant.label}: 申込 → プラグイン設定 → パスキー登録 → 管理画面ログイン`, () => {
+    test.skip(
+      !variant.shopHost || !variant.tenantHost,
+      `${variant.label} の店舗ホストが未設定のためスキップ（E2ETests/scripts/eccube-e2e.sh up で起動してください）`
+    );
+
+    const baseUrl = process.env.E2E_BASE_URL || 'https://localhost:8081';
+    const accountsHost = process.env.E2E_ACCOUNTS_HOST || 'accounts.ec-auth.io';
+    const accountsPageBaseUrl = process.env.E2E_ACCOUNTS_PAGE_URL || `https://${accountsHost}:8081`;
+    const accountsClientId = process.env.ACCOUNTS_CLIENT_ID || 'ecauth-admin-console';
+    const accountsRedirectUri =
+      process.env.ACCOUNTS_REDIRECT_URI || 'https://localhost:8081/auth/callback';
+
+    // describe のボディは skip の判定に関係なく収集時に実行される。未設定でも
+    // 落ちないようにプレースホルダを置く（この値が実際に使われることは無い）。
+    const shopHost = variant.shopHost || 'unconfigured.invalid';
+    const tenantHost = variant.tenantHost || 'unconfigured.ec-auth.io';
+    // Caddy が 443 で終端するのでポートは付かない。本番と同じ形の URL になる。
+    const shopBaseUrl = `https://${shopHost}`;
+    // Organization code はサイトホストから導出される（SignupService.DeriveOrganizationCode）。
+    const expectedOrgCode = shopHost.replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+    const email = `${expectedOrgCode}@e2e.ec-auth.io`;
+
+    let apiAccounts: APIRequestContext;
+    let mailpitCtx: APIRequestContext;
+    let context: BrowserContext;
+    let page: Page;
+
+    const messageIds: string[] = [];
+
+    let accessToken: string;
+    let clientId: string;
+    let clientSecret: string;
+    let registeredRedirectUri: string;
+
+    test.beforeAll(async ({ browser }) => {
+      // compose が採番したテナントホストと、申込から導出される組織コードがズレていると
+      // プラグインの解決先が Caddy のサイトアドレスに一致せず、原因が分かりにくい失敗になる。
+      // 先に突き合わせて、設定ミスをテスト失敗より前に顕在化させる。
+      expect(
+        `${expectedOrgCode}.ec-auth.io`,
+        'compose が採番したテナントホストと申込から導出される組織コードが一致しません'
+      ).toBe(tenantHost);
+
+      apiAccounts = await request.newContext({
+        ignoreHTTPSErrors: true,
+        extraHTTPHeaders: { Host: accountsHost },
+      });
+      mailpitCtx = await request.newContext();
+
+      context = await browser.newContext({ ignoreHTTPSErrors: true });
+      await context.credentials.install();
+      await installBrowserDiagnostics(context);
+
+      // accounts のパスキー登録後の遷移先（マイページ）は E2E 環境に実体が無いので握り潰す。
+      await context.route(/\/mypage\//, (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: 'text/html',
+          body: '<html><body>mypage stub</body></html>',
+        })
+      );
+
+      page = await context.newPage();
+      page.on('console', (msg) => console.log(`[browser:${msg.type()}] ${msg.text()}`));
+      page.on('pageerror', (err) => console.log(`[pageerror] ${err.message}`));
+    });
+
+    test.afterAll(async () => {
+      await deleteMessages(mailpitCtx, messageIds);
+      await apiAccounts?.dispose();
+      await mailpitCtx?.dispose();
+      await context?.close();
+    });
+
+    test('申込 → 確認 → Account トークン取得', async () => {
+      test.setTimeout(120000);
+
+      const result = await signupAndGetAccountToken(apiAccounts, mailpitCtx, context, {
+        baseUrl,
+        accountsHost,
+        accountsPageBaseUrl,
+        accountsClientId,
+        accountsRedirectUri,
+        email,
+        organizationName: `E2E ${variant.label} ${expectedOrgCode}`,
+        productionSiteUrl: `${shopBaseUrl}/`,
+        ecCubeVersion: variant.ecCubeVersion,
+      });
+
+      accessToken = result.accessToken;
+      messageIds.push(result.messageId);
+      expect(accessToken).toBeTruthy();
+    });
+
+    test('マイページと同じ経路で client_id / client_secret を取得する', async () => {
+      const client = await fetchSignupClient(apiAccounts, baseUrl, accessToken, expectedOrgCode);
+
+      clientId = client.clientId;
+      clientSecret = client.clientSecret;
+      expect(clientSecret).toBeTruthy();
+
+      // 申込が登録する redirect_uri は、この系のプラグインが送るコールバック URL と
+      // 一致していなければならない（authenticate/verify は完全一致で検証する）。
+      const expectedRedirectUri = `${shopBaseUrl}${variant.callbackPath}`;
+      expect(client.redirectUris).toContain(expectedRedirectUri);
+      registeredRedirectUri = expectedRedirectUri;
+    });
+
+    test('プラグイン設定に client_id / client_secret だけを入力して保存する', async () => {
+      test.setTimeout(90000);
+
+      await variant.admin.login(page, shopBaseUrl, ADMIN_LOGIN_ID, ADMIN_PASSWORD);
+      await variant.admin.saveClientCredentials(page, shopBaseUrl, clientId, clientSecret);
+
+      // 高度な設定を空のまま保存したので、プラグインは /platform/v1/client-resolve で
+      // base_url を解決したはず。ここが申込 Organization のテナントを指していないと、
+      // 以降の options / verify は既定テナントに解決されて challenge を見失う。
+      const resolvedBaseUrl = await variant.admin.readResolvedBaseUrl(page, shopBaseUrl);
+      expect(resolvedBaseUrl).toBe(`https://${tenantHost}`);
+    });
+
+    test('パスキーを登録する', async () => {
+      test.setTimeout(90000);
+
+      const credentialId = await variant.admin.registerPasskey(page, shopBaseUrl, ADMIN_PASSWORD);
+      expect(credentialId).toBeTruthy();
+    });
+
+    test('ログアウトする', async () => {
+      await variant.admin.logout(page, shopBaseUrl);
+    });
+
+    test('パスキーでログインし管理画面ホームに到達する', async () => {
+      test.setTimeout(90000);
+
+      // ここが通れば、申込が登録した redirect_uri（= registeredRedirectUri）と
+      // プラグインが送る値が一致していることになる。ズレていれば
+      // authenticate/verify が 400 を返し、コールバックまで到達しない。
+      await variant.admin.passkeyLogin(page, shopBaseUrl);
+      expect(registeredRedirectUri).toBe(`${shopBaseUrl}${variant.callbackPath}`);
+    });
+  });
+}

--- a/E2ETests/tests/specs/eccube_plugin_signup_login.spec.ts
+++ b/E2ETests/tests/specs/eccube_plugin_signup_login.spec.ts
@@ -108,7 +108,6 @@ for (const variant of VARIANTS) {
     let accessToken: string;
     let clientId: string;
     let clientSecret: string;
-    let registeredRedirectUri: string;
 
     test.beforeAll(async ({ browser }) => {
       // compose が採番したテナントホストと、申込から導出される組織コードがズレていると
@@ -179,9 +178,10 @@ for (const variant of VARIANTS) {
 
       // 申込が登録する redirect_uri は、この系のプラグインが送るコールバック URL と
       // 一致していなければならない（authenticate/verify は完全一致で検証する）。
-      const expectedRedirectUri = `${shopBaseUrl}${variant.callbackPath}`;
-      expect(client.redirectUris).toContain(expectedRedirectUri);
-      registeredRedirectUri = expectedRedirectUri;
+      // ここでは登録値の突き合わせだけを行い、値をテストの後段へは持ち回さない。
+      // プラグインは redirect_uri を自分で組み立てて送るため、テスト側が値を渡す余地が無く、
+      // 一致しているかどうかは後段のパスキーログインが通るかどうかで現れる。
+      expect(client.redirectUris).toContain(`${shopBaseUrl}${variant.callbackPath}`);
     });
 
     test('プラグイン設定に client_id / client_secret だけを入力して保存する', async () => {
@@ -211,11 +211,10 @@ for (const variant of VARIANTS) {
     test('パスキーでログインし管理画面ホームに到達する', async () => {
       test.setTimeout(90000);
 
-      // ここが通れば、申込が登録した redirect_uri（= registeredRedirectUri）と
-      // プラグインが送る値が一致していることになる。ズレていれば
-      // authenticate/verify が 400 を返し、コールバックまで到達しない。
+      // ここが通ること自体が、申込が登録した redirect_uri とプラグインが送る値の
+      // 一致を意味する。ズレていれば authenticate/verify が 400 を返し、
+      // コールバックにも管理画面ホームにも到達しない（EcAuth#481 の再現条件）。
       await variant.admin.passkeyLogin(page, shopBaseUrl);
-      expect(registeredRedirectUri).toBe(`${shopBaseUrl}${variant.callbackPath}`);
     });
   });
 }

--- a/E2ETests/tests/specs/signup_client_b2b_login.spec.ts
+++ b/E2ETests/tests/specs/signup_client_b2b_login.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, APIRequestContext, BrowserContext, Page, request } from '@playwright/test';
 import { randomUUID } from 'crypto';
-import { signupAndGetAccountToken } from '../helpers/accounts';
+import { signupAndGetAccountToken, fetchSignupClient } from '../helpers/accounts';
 import { registerB2BPasskey, authenticateB2BPasskey } from '../helpers/b2b-passkey';
 import { deleteMessages } from '../helpers/mailpit';
 import { generatePkcePair } from '../helpers/pkce';
@@ -119,40 +119,21 @@ test.describe.serial('申込で作られた Client での B2B パスキーログ
   });
 
   test('マイページと同じ経路で client_id / client_secret を取得する', async () => {
-    const listResponse = await apiAccounts.get(`${baseUrl}/v1/account/clients`, {
-      headers: { Authorization: `Bearer ${accessToken}` },
-    });
-    expect(listResponse.status()).toBe(200);
+    const client = await fetchSignupClient(apiAccounts, baseUrl, accessToken, expectedOrgCode);
 
-    const clients = (await listResponse.json()).clients as Array<{
-      id: number;
-      client_id: string;
-      organization_code: string;
-      redirect_uris: string[];
-    }>;
-
-    const client = clients.find((c) => c.organization_code === expectedOrgCode);
-    expect(client, `organization_code=${expectedOrgCode} の Client が見つかりません`).toBeTruthy();
-
-    clientId = client!.client_id;
+    clientId = client.clientId;
+    clientSecret = client.clientSecret;
+    expect(clientSecret).toBeTruthy();
 
     // ---- ここが EcAuth#481 の核心 ----
     // 申込時に登録される redirect_uri は、EC-CUBE 4 系プラグインが送るコールバック URL
     // （{サイトのベース URL}/ecauth/callback）と一致していなければならない。
     // authenticate/verify は完全一致で検証するため、ズレていると確定的に 400 になる。
-    expect(client!.redirect_uris).toContain(`https://${siteHost}:8081/ecauth/callback`);
+    expect(client.redirectUris).toContain(`https://${siteHost}:8081/ecauth/callback`);
     // 暫定のトップ URL は登録しない（余分な許可を残さない）。
-    expect(client!.redirect_uris).not.toContain(`https://${siteHost}:8081/`);
+    expect(client.redirectUris).not.toContain(`https://${siteHost}:8081/`);
 
-    registeredRedirectUri = client!.redirect_uris.find((u) => u.endsWith('/ecauth/callback'))!;
-
-    const revealResponse = await apiAccounts.post(
-      `${baseUrl}/v1/account/clients/${client!.id}/secret/reveal`,
-      { headers: { Authorization: `Bearer ${accessToken}` } }
-    );
-    expect(revealResponse.status()).toBe(200);
-    clientSecret = (await revealResponse.json()).client_secret;
-    expect(clientSecret).toBeTruthy();
+    registeredRedirectUri = client.redirectUris.find((u) => u.endsWith('/ecauth/callback'))!;
   });
 
   test('サイトのオリジンでパスキーを登録する', async () => {

--- a/compose.e2e-eccube.yaml
+++ b/compose.e2e-eccube.yaml
@@ -1,0 +1,189 @@
+# EC-CUBE 4 系 / 2 系のプラグインを実際に動かす結合 E2E 用のオーバーレイ。
+#
+#   ./E2ETests/scripts/eccube-e2e.sh up      # ホスト名を採番して compose を起動
+#   ./E2ETests/scripts/eccube-e2e.sh test    # Playwright を実行
+#   ./E2ETests/scripts/eccube-e2e.sh down
+#
+# compose.yaml（identityprovider / db / mailpit）に重ねて使う。
+#
+# ■ なぜ Caddy を挟むのか
+#   プラグインの実運用では 1 フローに 2 種類のホストが登場し、どちらも 443 の
+#   HTTPS でなければ成立しない（WebAuthn は secure context 必須、プラグインの
+#   サーバー間通信は証明書検証あり）。それぞれ別ポートで公開すると rp_id や
+#   redirect_uri にポートが混ざり、本番と違う経路を検証することになる。
+#   Caddy 1 台で 443 に集約し、ローカル CA で発行した証明書を EC-CUBE の信頼
+#   ストアへ入れることで、本番と同じ「ポート無しの https ホスト」を再現する。
+#
+# ■ ホスト名を compose 起動時に確定させる理由
+#   Caddy のサイトアドレスと docker network alias の両方に同じ名前を配る必要が
+#   あるため。テスト実行時に採番すると alias を後から足せない。
+#   E2E_RUN_ID は eccube-e2e.sh が採番し、.e2e-eccube.env に書き出す。
+#
+# ■ EC-CUBE 本体のバージョン
+#   プラグインリポジトリの Dockerfile の FROM が決める（4 系 ec-cube-php:*-apache-4.3、
+#   2 系 ec-cube2-php:*-apache-eccube-2.25.0）。したがって本体版を指定したい場合は
+#   プラグインの ref（E2E_ECCUBE4_PLUGIN_DIR が指すワーキングツリーの checkout）を
+#   切り替える。compose 側には本体版のノブを置かない。
+
+volumes:
+  caddy-data:
+    driver: local
+  eccube4-pg:
+    driver: local
+  eccube2-pg:
+    driver: local
+  eccube2-vendor:
+    driver: local
+
+services:
+  # compose.yaml の identityprovider への上書き。
+  #
+  # client-resolve が返す base_url は {tenant_name}.{PlatformApi:BaseDomain} で組み立てられる。
+  # appsettings.Development.json の既定は localhost:8081 だが、それだと
+  # {tenant}.localhost という 2 セグメントのホストになり、TenantMiddleware が
+  # サブドメインからテナントを取り出せない（3 セグメント以上が条件）。
+  # この E2E は本番と同じ形（{tenant}.ec-auth.io）で検証したいので明示的に上書きする。
+  identityprovider:
+    environment:
+      PlatformApi__BaseDomain: ec-auth.io
+
+  caddy:
+    image: caddy:2-alpine
+    depends_on:
+      - identityprovider
+    environment:
+      E2E_ECCUBE4_SHOP_HOST: ${E2E_ECCUBE4_SHOP_HOST:?E2E_ECCUBE4_SHOP_HOST が未設定です（eccube-e2e.sh up 経由で起動してください）}
+      E2E_ECCUBE2_SHOP_HOST: ${E2E_ECCUBE2_SHOP_HOST:?E2E_ECCUBE2_SHOP_HOST が未設定です}
+      E2E_ECCUBE4_TENANT_HOST: ${E2E_ECCUBE4_TENANT_HOST:?E2E_ECCUBE4_TENANT_HOST が未設定です}
+      E2E_ECCUBE2_TENANT_HOST: ${E2E_ECCUBE2_TENANT_HOST:?E2E_ECCUBE2_TENANT_HOST が未設定です}
+    ports:
+      - "443:443"
+    volumes:
+      - ./docker/e2e/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+    networks:
+      backend:
+        # EC-CUBE コンテナからの名前解決を Caddy に向ける。docker の埋め込み DNS が
+        # alias を引くので、コンテナ内では公開 DNS より先にここへ解決される。
+        #
+        # api.ec-auth.io は両プラグインが持つ discovery の既定値（4 系 services.yaml の
+        # ecauth_default_discovery_url、2 系 DEFAULT_DISCOVERY_URL）。ECAUTH_CLIENT_RESOLVE_URL
+        # で上書きするのではなく alias で引き込むことで、顧客が通るのと同じ「既定のまま」の
+        # 経路を検証する。プラグイン側で既定値を変えたらここも合わせる必要がある。
+        aliases:
+          - api.ec-auth.io
+          - ${E2E_ECCUBE4_TENANT_HOST}
+          - ${E2E_ECCUBE2_TENANT_HOST}
+    healthcheck:
+      # 自分自身のローカル CA を信頼していないので -k で足りる。
+      # ここでは「443 で TLS 終端して応答できる」ことだけ確認する。
+      test: ["CMD", "wget", "--no-check-certificate", "-q", "-O", "-", "https://${E2E_ECCUBE4_TENANT_HOST}/healthz"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 10s
+
+  # --- EC-CUBE 4 系 ----------------------------------------------------------
+  ec-cube4:
+    build:
+      context: ${E2E_ECCUBE4_PLUGIN_DIR:-../ec-cube4-ecauth}
+    entrypoint: ["/bin/bash", "/e2e/eccube-entrypoint.sh", "/docker-entrypoint-plugin.sh"]
+    command: ["apache2-foreground"]
+    depends_on:
+      caddy:
+        condition: service_started
+      eccube4-db:
+        condition: service_healthy
+    environment:
+      APP_ENV: dev
+      DATABASE_URL: "postgresql://eccube:password@eccube4-db:5432/eccube_db"
+      DATABASE_SERVER_VERSION: 15
+      # オーナーズストアのリリース申請で発行される検証キー（X-ECCUBE-KEY）。
+      # 設定するとプラグインの entrypoint が package-api から申請中のパッケージを
+      # 入れる。未設定なら /plugin のワーキングツリーから入れる。
+      ECCUBE_AUTHENTICATION_KEY: ${ECCUBE_AUTHENTICATION_KEY:-}
+      ECAUTH_PLUGIN_VERSION: ${ECAUTH_PLUGIN_VERSION:-}
+    volumes:
+      - ${E2E_ECCUBE4_PLUGIN_DIR:-../ec-cube4-ecauth}:/plugin:cached
+      - ./docker/e2e:/e2e:ro
+      - caddy-data:/caddy-data:ro
+    networks:
+      - backend
+
+  eccube4-db:
+    image: postgres:15-alpine
+    environment:
+      TZ: Asia/Tokyo
+      POSTGRES_DB: eccube_db
+      POSTGRES_USER: eccube
+      POSTGRES_PASSWORD: password
+    volumes:
+      - eccube4-pg:/var/lib/postgresql/data
+    networks:
+      - backend
+    healthcheck:
+      test: pg_isready -U eccube -d eccube_db
+      interval: 3s
+      timeout: 3s
+      retries: 20
+
+  # --- EC-CUBE 2 系 ----------------------------------------------------------
+  ec-cube2:
+    build:
+      context: ${E2E_ECCUBE2_PLUGIN_DIR:-../ec-cube2-ecauth}
+    entrypoint: ["/bin/bash", "/e2e/eccube-entrypoint.sh", "/usr/local/bin/ecauth-docker-entrypoint.sh"]
+    command: ["apache2-foreground"]
+    depends_on:
+      caddy:
+        condition: service_started
+      eccube2-db:
+        condition: service_healthy
+    environment:
+      TZ: Asia/Tokyo
+      PHP_LOG_ERRORS: "On"
+      PHP_ERROR_REPORTING: "E_ALL"
+      PHP_ERROR_LOG: "/proc/self/fd/2"
+      # 2 系は URL を定数で持つ。ポートを含めないことで rp_id / redirect_uri が
+      # 本番と同じ形（https://{host}/ecauth/callback.php）になる。
+      HTTP_URL: https://${E2E_ECCUBE2_SHOP_HOST}/
+      HTTPS_URL: https://${E2E_ECCUBE2_SHOP_HOST}/
+      ROOT_URLPATH: /
+      DOMAIN_NAME: ~
+      DB_TYPE: pgsql
+      DB_USER: eccube_db_user
+      DB_PASSWORD: password
+      DB_SERVER: eccube2-db
+      DB_NAME: eccube_db
+      DB_PORT: 5432
+      ADMIN_DIR: ${E2E_ECCUBE2_ADMIN_DIR:-admin/}
+      ADMIN_FORCE_SSL: 'false'
+      ADMIN_ALLOW_HOSTS: 'a:0:{}'
+      AUTH_MAGIC: ~
+      PASSWORD_HASH_ALGOS: sha256
+      # 接続情報は E2E の中で管理画面から設定する（申込で払い出された値を使う）。
+      # install-plugin.php が ECAUTH_BASE_URL を見て初期値を書き込むため、
+      # 空のままにして「無設定から始まる」状態を再現する。
+      ECAUTH_BASE_URL: ""
+    volumes:
+      - eccube2-vendor:/var/www/app/data/vendor
+      - ./docker/e2e:/e2e:ro
+      - caddy-data:/caddy-data:ro
+    networks:
+      - backend
+
+  eccube2-db:
+    image: postgres:15-alpine
+    environment:
+      TZ: Asia/Tokyo
+      POSTGRES_DB: eccube_db
+      POSTGRES_USER: eccube_db_user
+      POSTGRES_PASSWORD: password
+    volumes:
+      - eccube2-pg:/var/lib/postgresql/data
+    networks:
+      - backend
+    healthcheck:
+      test: pg_isready -U eccube_db_user -d eccube_db
+      interval: 3s
+      timeout: 3s
+      retries: 20

--- a/docker/e2e/Caddyfile
+++ b/docker/e2e/Caddyfile
@@ -1,0 +1,55 @@
+# EC-CUBE プラグイン結合 E2E 用のリバースプロキシ。
+#
+# 目的は「本番と同じホスト名構成を 1 台の 443 に収める」こと。プラグインの実運用では
+# 1 つのフローに 2 種類のホストが登場する（EcAuth CLAUDE.md「E2E テストの実装上の要点」）。
+#
+#   ブラウザ  → https://{店舗ホスト}          … WebAuthn の rp_id と一致させる必要がある
+#   EC-CUBE   → https://{tenant}.ec-auth.io  … /platform/v1/client-resolve が返す base_url
+#
+# 後者は EC-CUBE コンテナからの **サーバー間** 通信で、2 系は CURLOPT_SSL_VERIFYPEER => true、
+# 4 系は Symfony HttpClient（既定で検証あり）のため、証明書が信頼できないと即座に落ちる。
+# そこで Caddy のローカル CA（local_certs）で発行し、そのルート証明書を EC-CUBE コンテナの
+# 信頼ストアへ流し込む（docker/e2e/eccube-entrypoint.sh）。
+#
+# ホスト名は compose 起動時に E2E_RUN_ID から確定させる。Caddy のサイトアドレスと
+# docker network alias の両方へ同じ名前を配る必要があり、テスト実行時には決められないため。
+
+{
+	# ローカル CA で発行する。*.test / *.ec-auth.io はここでは公開解決できないので
+	# 公開 ACME（Let's Encrypt / ZeroSSL）に出しても必ず失敗する。
+	local_certs
+	# 443 しか publish しないため、80 番での HTTPS リダイレクトは不要。
+	auto_https disable_redirects
+	admin off
+}
+
+# --- EcAuth（IdP）------------------------------------------------------------
+# api.ec-auth.io は「まだ base_url を知らない段階」でプラグインが叩く discovery の宛先。
+# 両プラグインがこのホストを既定値として持つ（4 系 services.yaml の
+# ecauth_default_discovery_url、2 系 SC_Helper_EcAuthLogin2::DEFAULT_DISCOVERY_URL）。
+# 環境変数 ECAUTH_CLIENT_RESOLVE_URL で上書きせず、docker network alias でここに
+# 引き込むことで、顧客が実際に通る **既定のまま** の経路を検証する。
+# /platform/ 配下は TenantMiddleware がテナント解決をスキップするため、
+# api という実在しないテナント名でも client-resolve は正しく動く。
+#
+# 残り 2 つは EC-CUBE が ecauth_base_url として叩くテナントのホスト。
+# client-resolve が返す https://{tenant_name}.ec-auth.io と完全に一致させること。
+#
+# identityprovider は HTTP:8080 で待ち受け、Program.cs が KnownProxies を空にして
+# 全フォワーダを信頼する設定なので、X-Forwarded-Proto はそのまま効く。
+https://api.ec-auth.io, https://{$E2E_ECCUBE4_TENANT_HOST}, https://{$E2E_ECCUBE2_TENANT_HOST} {
+	reverse_proxy identityprovider:8080
+}
+
+# --- EC-CUBE 4 系の店舗 ------------------------------------------------------
+# ブラウザはこのホストで開く。プラグインは rp_id 未設定時に Request::getHost() を
+# 使う（PasskeyAuthService::getRpId）ため、このホスト名がそのまま rp_id になる。
+https://{$E2E_ECCUBE4_SHOP_HOST} {
+	reverse_proxy ec-cube4:80
+}
+
+# --- EC-CUBE 2 系の店舗 ------------------------------------------------------
+# 2 系は HTTP_HOST からポートを除いたものを rp_id にする（SC_Helper_EcAuthLogin2::getRpId）。
+https://{$E2E_ECCUBE2_SHOP_HOST} {
+	reverse_proxy ec-cube2:80
+}

--- a/docker/e2e/eccube-entrypoint.sh
+++ b/docker/e2e/eccube-entrypoint.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# EC-CUBE コンテナ（4 系 / 2 系共通）の entrypoint ラッパー。
+# 本来の entrypoint を引数に取り、前処理を済ませてから exec する。
+#
+#   entrypoint: ["/bin/bash", "/e2e/eccube-entrypoint.sh", "/docker-entrypoint-plugin.sh"]
+#   command:    ["apache2-foreground"]
+#
+# やることは 2 つだけ。どちらもプラグイン側のリポジトリを汚さずに済ませたいので、
+# EcAuth 側の E2E オーバーレイからマウントして注入する。
+set -eo pipefail
+
+# --- 1. Caddy のローカル CA を信頼ストアへ ------------------------------------
+#
+# プラグインは https://{tenant}.ec-auth.io へサーバー間通信する。2 系は
+# CURLOPT_SSL_VERIFYPEER => true（SC_Helper_EcAuthLogin2::httpRequest）、4 系は
+# Symfony HttpClient で、いずれも既定で証明書を検証する。検証を切ると「本番では
+# 検証が有効」という前提を E2E が踏まなくなるため、切らずに CA を信頼させる。
+#
+# Debian 系では update-ca-certificates が /etc/ssl/certs/ca-certificates.crt を
+# 更新し、cURL / OpenSSL の既定バンドルがそれを指すため、PHP 側の設定変更は要らない。
+CA_SRC=/caddy-data/caddy/pki/authorities/local/root.crt
+CA_DST=/usr/local/share/ca-certificates/caddy-e2e-root.crt
+
+# ルート証明書は Caddy が初回起動時に生成する。compose の depends_on では
+# 「プロセスが上がった」ことしか保証されないので、ファイルの出現を待つ。
+for i in $(seq 1 60); do
+    if [ -s "${CA_SRC}" ]; then
+        break
+    fi
+    if [ "${i}" -eq 1 ]; then
+        echo "[e2e-entrypoint] Waiting for Caddy local CA at ${CA_SRC} ..."
+    fi
+    sleep 1
+done
+
+if [ -s "${CA_SRC}" ]; then
+    cp "${CA_SRC}" "${CA_DST}"
+    update-ca-certificates >/dev/null
+    echo "[e2e-entrypoint] Installed Caddy local CA into the system trust store"
+else
+    # ここで落とすとプラグインのインストールログすら残らず原因が追いにくい。
+    # 起動は続行し、TLS 検証エラーとして後段のテストで顕在化させる。
+    echo "[e2e-entrypoint] WARNING: Caddy local CA not found; EcAuth への TLS 接続は失敗します" >&2
+fi
+
+# --- 2. X-Forwarded-Proto を PHP の HTTPS 環境変数へ ---------------------------
+#
+# Caddy が TLS を終端し、コンテナへは平文 HTTP で届く。素のままだと
+#   - 4 系: generateUrl(..., ABSOLUTE_URL) が http:// のコールバック URL を作る
+#           （PasskeyAuthController）→ 登録済み redirect_uri と完全一致せず 400
+#   - 2 系: SC_Utils::sfIsHTTPS() が false になり HTTPS 前提の導線が崩れる
+# となる。
+#
+# Symfony の TRUSTED_PROXIES を使う手もあるが、$_SERVER['HTTPS'] を立てる方が
+# 2 系（Symfony 非依存）と共通化でき、EC-CUBE 側の設定に踏み込まずに済む。
+# ポートは付けない: Host ヘッダにポートが無ければ Symfony の getPort() は
+# スキームから 443 を導くため、getHttpHost() はホスト名だけを返す。
+cat > /etc/apache2/conf-enabled/e2e-forwarded-proto.conf <<'CONF'
+# E2E 専用。Caddy が付ける X-Forwarded-Proto を PHP から見える HTTPS に写す。
+SetEnvIf X-Forwarded-Proto "^https$" HTTPS=on
+CONF
+
+exec "$@"


### PR DESCRIPTION
## 背景

EcAuth#481（申込 Client でパスキーログインが必ず失敗する）が本番に出たのは、**「申込が登録する初期値」と「プラグインが実際に送る値」を突き合わせるテストが誰の担当でもなかった**ためです。

| 既存の E2E | 何を守っていたか | 抜けていたもの |
|---|---|---|
| `b2b_passkey_authentication.spec.ts` | B2B パスキーの API | シード済み Client を使うので申込の初期値は見ない |
| `account_signup_flow.spec.ts` | 申込フロー | 認証は accounts コンソール Client で行う |
| `signup_client_b2b_login.spec.ts`（#488） | 申込 Client の初期値 | **プラグインが送る値**は EcAuth 側から組み立てているので検証できない |

この PR は最後の穴を埋めます。EC-CUBE 4 系 / 2 系を実際に起動し、**申込 → プラグイン設定 → パスキー登録 → 管理画面ログイン**をプラグインの実コード経由で 1 本に通します。

肝は **「高度な設定」を触らないこと**です。`client_id` / `client_secret` だけを入力して保存し、`ecauth_base_url` は `client-resolve` に、`rp_id` はリクエストホストに解決させます。プラグインリポジトリ側の既存 E2E は両方を明示指定しているため、この経路は今まで誰も通していませんでした。

## この PR で見つかった不具合

**EC-CUBE 2 系プラグインの設定画面が `client_id` を 50 文字で切り詰める**（→ [ec-cube2-ecauth#9](https://github.com/EcAuth/ec-cube2-ecauth/pull/9)）

`ec-{組織コード}-{UUID32桁}` は固定部だけで 36 文字あり、組織コードが 15 文字以上（例 `shop.example.jp` → `shop-example-jp`）になると `STEXT_LEN`(50) を超えます。ブラウザが `maxlength` で静かに切り詰めるためエラーにならず、「Client ID に対応するテナントが見つかりません」として設定を保存できません。**ごく一般的なドメインで既に踏みます。**

> ✅ [ec-cube2-ecauth#9](https://github.com/EcAuth/ec-cube2-ecauth/pull/9) はマージ済みです。この PR の CI もグリーンになりました。

## 構成上の決めごと

| 事項 | 決め | 理由 |
|---|---|---|
| リバースプロキシ | Caddy 1 台で 443 に集約 | 店舗ホストと `{tenant}.ec-auth.io` を別ポートで公開すると rp_id / redirect_uri にポートが混ざり、本番と違う経路を検証することになる |
| 証明書 | Caddy の `local_certs`、ルート CA を EC-CUBE の信頼ストアへ注入 | 2 系は `CURLOPT_SSL_VERIFYPEER => true`。検証を切ると「本番では検証が有効」という前提を E2E が踏まなくなる |
| プロキシ配下のスキーム | `SetEnvIf X-Forwarded-Proto https HTTPS=on` | 4 系の `generateUrl(ABSOLUTE_URL)` が `http://` を作ると redirect_uri の完全一致に落ちる |
| discovery の宛先 | `api.ec-auth.io` を network alias で Caddy に引き込む | `ECAUTH_CLIENT_RESOLVE_URL` で上書きせず、顧客が通る**既定のまま**の経路を検証する |
| `PlatformApi:BaseDomain` | この E2E だけ `ec-auth.io` に上書き | Development の既定 `localhost:8081` だと `{tenant}.localhost` が 2 セグメントになり `TenantMiddleware` がテナントを取り出せない |
| ホスト名 | compose 起動時に採番 | Caddy のサイトアドレスと network alias の両方に同じ名前が要り、テスト実行時には決められない |
| リトライ | この spec だけ `retries: 0` | 申込は組織コードの重複を弾き、組織コードは採番済みホストから導出されるので再試行しても必ず同じになる。リトライすると後段の失敗が `organization_already_exists` に化けて本当の理由が消える |
| EC-CUBE 本体のバージョン | プラグインの `Dockerfile` の `FROM` が決める | compose 側にノブを置かない。本体版を変えたいときはプラグインの ref を切り替える |

## 使い方

```bash
./E2ETests/scripts/eccube-e2e.sh up
./E2ETests/scripts/eccube-e2e.sh test tests/specs/eccube_plugin_signup_login.spec.ts --reporter=list
./E2ETests/scripts/eccube-e2e.sh down
```

CI は `.github/workflows/eccube_plugin_e2e.yml`。`main.yml` から他スイートと並列で呼びます。`workflow_dispatch` の入力でプラグインの ref と package-api 経由インストール（検証キー）を切り替えられます。

> **CI 時間**: ジョブ全体で約 4 分半（うち EC-CUBE のビルドと初回インストールが大半）。PR ごとに回す価値はあると判断して `main.yml` に入れましたが、重ければ `workflow_dispatch` / nightly に落とすのも妥当です。

## 検証

### (a) ローカル実機: 12 件すべてグリーン（ec-cube2-ecauth#9 適用後）

```
✓ EC-CUBE 4系 › 申込 → 確認 → Account トークン取得
✓ EC-CUBE 4系 › マイページと同じ経路で client_id / client_secret を取得する
✓ EC-CUBE 4系 › プラグイン設定に client_id / client_secret だけを入力して保存する
✓ EC-CUBE 4系 › パスキーを登録する
✓ EC-CUBE 4系 › ログアウトする
✓ EC-CUBE 4系 › パスキーでログインし管理画面ホームに到達する
✓ EC-CUBE 2系 › （同上 6 件）
  12 passed (8.8s)
```

### (b) CI 実機: 12 件すべてグリーン

[actions/runs/30588454116](https://github.com/EcAuth/EcAuth/actions/runs/30588454116/job/91027807409)（`E2E_SKIP_OP=1` + ワークフロー同梱の env 一式）

```
✓ EC-CUBE 4系 › 6 件すべて
✓ EC-CUBE 2系 › 6 件すべて
  12 passed (22.9s)
```

ランナー上で checkout・イメージビルド・443 の bind・ローカル CA の注入・Caddy 経由の疎通がすべて動作します。ジョブ全体で 3〜4 分半です。

なお ec-cube2-ecauth#9 のマージ前は、ここで 2 系の設定保存だけが落ちていました（下記 (c)）。**この E2E が実際に不具合を検出し、修正で解消したことが CI 上でも確認できています。**

### (c) 不具合を実際に検出した

EcAuth 側ログで、2 系から送られてきた client_id がちょうど 50 文字で切れていることを確認：

```
Client not found or has no organization: client_id=ec-e2e-1785450651-32760-shop2-test-c9a25e92e30c41d
Client resolved: client_id=ec-e2e-1785450651-32760-shop4-test-0a31bfe55b5445b3baa091921b303e37, tenant=e2e-1785450651-32760-shop4-test
```

### (d) 既存 spec への影響なし

`PlatformApi:BaseDomain` 上書きと `fetchSignupClient` 抽出の影響確認（ローカル）:

```
platform_client_resolve / signup_client_b2b_login / b2b_passkey_authentication /
account_signup_flow / account_magic_link_flow / oidc_discovery
  28 passed (3.0s)
```

CI 側でも `playwright / test` と `selenium / selenium` がグリーンです。

また、ec-cube2-ecauth の main に [#8](https://github.com/EcAuth/ec-cube2-ecauth/pull/8)（設定画面への申込・マイページ導線の追加）がマージされた後にもローカルで 12/12 を再確認しました。導線カードが増えても管理画面操作のセレクタは影響を受けません。

### (e) 未検証

- `install_source: package-api`（検証キー経由のインストール）の経路は未実行です。既定の `local` のみ検証しています。

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `compose.e2e-eccube.yaml` | Caddy + EC-CUBE 4系/2系 + それぞれの PostgreSQL のオーバーレイ |
| `docker/e2e/Caddyfile` | 443 集約とローカル CA |
| `docker/e2e/eccube-entrypoint.sh` | CA 注入と X-Forwarded-Proto の写し込み |
| `E2ETests/scripts/eccube-e2e.sh` | ホスト名の採番と起動・実行・破棄 |
| `E2ETests/tests/specs/eccube_plugin_signup_login.spec.ts` | 筋書き本体（4系/2系で共通） |
| `E2ETests/tests/helpers/eccube-admin.ts` | 系ごとの管理画面操作アダプタ |
| `E2ETests/tests/helpers/accounts.ts` | `fetchSignupClient` を抽出（#488 の spec と共有） |
| `.github/workflows/eccube_plugin_e2e.yml` / `main.yml` | CI |
| `CLAUDE.md` | 実装上の要点と構成の決めごと |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
