### PR TITLE
docs: 確認メールの受信口（mailpit / E2E メールボックス）の使い分けを記録する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,6 +257,38 @@ ECCUBE_AUTHENTICATION_KEY=$(op read 'op://EcAuth/eccube4-ecauth-plugin/eccube_au
 ボリュームごと破棄する。`E2E_RUN_ID` を環境変数で固定すると同じホストで再実行してしまうので、
 意図的に再現したいとき以外は設定しない。
 
+### 確認メールの受信口（mailpit と E2E メールボックスの使い分け）
+
+申込フローの E2E は確認メールの本文からトークンを取り出す必要がある（トークンは本文にしか
+存在せず、DB には SHA-256 ハッシュしか残らない）。受信口は環境で変わる。
+
+| 環境 | 受信口 | 参照方法 |
+|---|---|---|
+| ローカル / CI | mailpit | `tests/helpers/mailpit.ts`（`MAILPIT_BASE_URL`、既定 `http://localhost:8025`） |
+| staging / production | Cloudflare Worker の E2E メールボックス | 下記（**未実装**。デプロイ後 E2E を組むときに吸収層を作る） |
+
+デプロイ済み環境は SendGrid 送信なので mailpit が使えない。代わりに
+`ecauth-infrastructure` が用意した受信口を使う（構成の詳細と設計上の制約は
+[ecauth-infrastructure の CLAUDE.md](https://github.com/EcAuth/ecauth-infrastructure/blob/main/CLAUDE.md)
+「E2E 用メールボックス」を参照）。
+
+| 項目 | 値 |
+|------|-----|
+| ベース URL | `https://e2e-mail.ec-auth.io` |
+| 宛先 | `e2e-{RUN_ID}@e2e.ec-auth.io` |
+| 読み出しトークン | `op://EcAuth/ecauth-e2e-mailbox/api_token`（`Authorization: Bearer`） |
+| API | `GET` / `DELETE /messages?to=<address>` |
+| レスポンス | `{"messages":[{to, from, subject, text, html, received_at}, ...]}` |
+
+呼び出し側の注意:
+
+- **Workers KV は結果整合**で、書き込みが読み出しに反映されるまで最大 1 分程度かかりうる。
+  mailpit 相当の短いポーリング間隔だと取りこぼすので、タイムアウトは余裕を持たせる。
+- メッセージは 1 時間で自動失効するため、後始末の `DELETE` は必須ではない。
+- 本文のフィールド名が mailpit（`Text` / `HTML` / `Subject` / `ID`）と異なる。
+  spec からは直接触らず、`waitForMessage` / `extractToken` と同じインターフェースの
+  吸収層を挟むこと。
+
 ### マイグレーション設計ルール
 
 - `migrationBuilder.Sql()` でカラムを参照する UPDATE/INSERT 文を書く場合、`EXEC()` 動的 SQL でラップすること


### PR DESCRIPTION
## 背景

申込フローの E2E は確認メールの本文からトークンを取り出す必要があります（トークンは本文にしか存在せず、DB には SHA-256 ハッシュしか残らない）。この受信口が環境で変わるのですが、その事実も接続情報も EcAuth 側のどこにも書かれていませんでした。

| 環境 | 受信口 | 記録状況 |
|---|---|---|
| ローカル / CI | mailpit | `tests/helpers/mailpit.ts` にある |
| staging / production | Cloudflare Worker の E2E メールボックス | **どこにも無い** |

デプロイ済み環境は SendGrid 送信なので mailpit が使えず、`ecauth-infrastructure` が用意した受信口（[#131](https://github.com/EcAuth/ecauth-infrastructure/pull/131) / [#132](https://github.com/EcAuth/ecauth-infrastructure/pull/132) / [#134](https://github.com/EcAuth/ecauth-infrastructure/pull/134)）を使います。この PR が無いと、デプロイ後 E2E を組むときに毎回インフラのソースから再導出することになります。

## 追加した内容

`CLAUDE.md` の EC-CUBE 結合 E2E の節に「確認メールの受信口」を追加しました。

- 環境ごとの受信口の対応表（staging / production 側は**未実装**である旨も明記）
- 接続情報（ベース URL / 宛先の形 / Bearer トークンの `op://` 参照 / API / レスポンス形状）
- 呼び出し側が踏みやすい点
  - **Workers KV は結果整合**で反映まで最大 1 分かかりうる。mailpit 相当の短いポーリングだと取りこぼす
  - メッセージは 1 時間で自動失効するので後始末の `DELETE` は必須ではない
  - 本文のフィールド名が mailpit（`Text` / `HTML` / `Subject` / `ID`）と異なるため、`waitForMessage` / `extractToken` と同じインターフェースの吸収層を挟む必要がある

構成の詳細と設計上の制約（Cloudflare Email Routing を使えない理由など）はインフラ側の担当なので、[ecauth-infrastructure#135](https://github.com/EcAuth/ecauth-infrastructure/pull/135) で同リポジトリの `CLAUDE.md` に記録し、こちらからはリンクしています。

## 検証

ドキュメントのみの変更で、コードへの影響はありません。記述はすべて実装と突き合わせ済みです。

| 記述 | 根拠 |
|---|---|
| mailpit の既定 URL と環境変数名 | `E2ETests/tests/helpers/mailpit.ts:16` |
| mailpit のフィールド名（`ID` / `Text` / `HTML` / `Subject`） | 同 `:18-24` |
| 吸収層が満たすべきインターフェース | 同 `waitForMessage` / `deleteMessages` / `extractToken` |
| メールボックスの API・レスポンス・KV の性質 | `ecauth-infrastructure/environments/cdn/workers/e2e-mailbox.js` |
| トークンの 1Password 参照 | `ecauth-infrastructure/.github/workflows/terraform.yml:457` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * E2Eテストでの確認メール受信方法を文書化しました。
  * ローカル／CI環境のmailpitと、staging／production環境のE2Eメールボックスの利用方法を追加しました。
  * URL、宛先、認証、API形式、結果整合性、メール有効期限などの注意事項を記載しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->