### PR TITLE
feat: 本番デプロイ後に申込スモークを回し、インフラ apply 後の verify を自動化する

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -11,6 +11,10 @@ on:
           - migrate-and-deploy
           - deploy-only
           - migrate-only
+          # デプロイせず verify だけを回す。ecauth-infrastructure の apply 後（アプリを
+          # 再デプロイしないが app_settings や DNS は変わる）に、外から叩くための入口。
+          # dry_run は既定 true なので、verify を動かすには dry_run=false を明示すること。
+          - verify-only
         default: 'migrate-and-deploy'
       dry_run:
         description: 'Dry run (generate migration script only, skip deploy and verify)'
@@ -307,10 +311,13 @@ jobs:
 
   verify:
     needs: deploy
+    # verify-only のときは deploy が skipped になる。デプロイ直後の検証と、
+    # インフラ変更後の検証（アプリは変わらないが設定は変わる）を同じジョブで賄う。
     if: |
       always() &&
-      needs.deploy.result == 'success' &&
-      inputs.dry_run != true
+      inputs.dry_run != true &&
+      (needs.deploy.result == 'success' ||
+       (inputs.action == 'verify-only' && needs.deploy.result == 'skipped'))
     runs-on: ubuntu-latest
     environment:
       name: production
@@ -341,6 +348,15 @@ jobs:
           B2B_USER_SUBJECT: op://EcAuth/ecauth-prod-app/b2b_user_subject
           B2B_REDIRECT_URI: op://EcAuth/ecauth-prod-app/b2b_redirect_uri
           WEB_APP_SUFFIX: op://EcAuth/ecauth-prod-app/web_app_suffix
+          # 申込スモーク（stg-accounts テナント）。本物の顧客が入る accounts テナントは使わない。
+          # stg-accounts の管理コンソール Client は confidential（STG_ACCOUNTS_CLIENT_PUBLIC が
+          # 設定されていない）ため、PKCE に加えて client_secret も要る。
+          STG_ACCOUNTS_CLIENT_ID: op://EcAuth/ecauth-prod-app/stg_accounts_client_id
+          STG_ACCOUNTS_CLIENT_SECRET: op://EcAuth/ecauth-prod-app/stg_accounts_client_secret
+          STG_ACCOUNTS_REDIRECT_URI: op://EcAuth/ecauth-prod-app/stg_accounts_redirect_uri
+          # 確認メールの受信口（SendGrid Inbound Parse → Cloudflare Worker）。
+          # 詳細は ecauth-infrastructure の CLAUDE.md「E2E 用メールボックス」。
+          E2E_MAILBOX_TOKEN: op://EcAuth/ecauth-e2e-mailbox/api_token
 
       - name: Federation authentication verification
         id: federation_verify
@@ -388,6 +404,34 @@ jobs:
           set -o pipefail
           pnpm exec playwright test tests/specs/b2b_passkey_authentication.spec.ts --reporter=list 2>&1 | tee playwright-output.txt
 
+      # 申込 → client-resolve → B2B パスキー登録/認証 → トークン交換 を、実環境の設定で通す。
+      # シード済み Client を使う b2b_passkey_authentication では守れない範囲を埋める:
+      #   - 申込が登録する redirect_uri / allowed_rp_ids の初期値（EcAuth#481 の再発防止）
+      #   - PlatformApi:BaseDomain とテナント解決が本番のホスト名で噛み合うこと
+      #   - SendGrid 送信 → Inbound Parse → Worker の受信口が生きていること
+      # EC-CUBE プラグイン実物を通す版は CI（main.yml）が担当する。イメージビルドで
+      # 10 分前後かかるうえ、本番 DB に残る Organization が run あたり 2 倍になるため。
+      #
+      # 前段が落ちても切り分けられるよう、B2B verify の結果に関わらず実行する。
+      - name: Signup smoke (申込 Client でのパスキーログイン)
+        id: signup_smoke
+        if: ${{ !cancelled() }}
+        working-directory: E2ETests
+        env:
+          # 実ホスト名でテナントを解決する（Cloudflare 配下では Host ヘッダ差し替えが使えない）。
+          E2E_TENANT_BASE_DOMAIN: ec-auth.io
+          # 申込は stg-accounts テナントで行う。本物の顧客が入る accounts は使わない。
+          E2E_ACCOUNTS_HOST: stg-accounts.ec-auth.io
+          ACCOUNTS_CLIENT_ID: ${{ env.STG_ACCOUNTS_CLIENT_ID }}
+          ACCOUNTS_CLIENT_SECRET: ${{ env.STG_ACCOUNTS_CLIENT_SECRET }}
+          ACCOUNTS_REDIRECT_URI: ${{ env.STG_ACCOUNTS_REDIRECT_URI }}
+          # 受信口を mailpit から E2E 用メールボックスへ切り替える。
+          E2E_MAILBOX_KIND: e2e-mailbox
+          E2E_MAILBOX_API_TOKEN: ${{ env.E2E_MAILBOX_TOKEN }}
+        run: |
+          set -o pipefail
+          pnpm exec playwright test tests/specs/signup_client_b2b_login.spec.ts --reporter=list 2>&1 | tee signup-smoke-output.txt
+
       - name: Upload E2E test results
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -412,4 +456,27 @@ jobs:
             echo ""
             echo "--- Playwright Output ---"
             cat E2ETests/playwright-output.txt
+          fi
+
+      - name: Signup smoke result
+        if: always()
+        env:
+          SMOKE_OUTCOME: ${{ steps.signup_smoke.outcome }}
+        run: |
+          echo "### Signup Smoke (申込 Client でのパスキーログイン)" >> $GITHUB_STEP_SUMMARY
+          case "$SMOKE_OUTCOME" in
+            success) echo "✅ Signup smoke passed" | tee -a $GITHUB_STEP_SUMMARY ;;
+            skipped) echo "⏭️ Signup smoke skipped" | tee -a $GITHUB_STEP_SUMMARY ;;
+            *)       echo "❌ Signup smoke failed" | tee -a $GITHUB_STEP_SUMMARY ;;
+          esac
+          if [ -f E2ETests/signup-smoke-output.txt ]; then
+            # 出力冒頭の [signup-smoke] 行に org_code / email が出る。
+            # 本番 DB に残った E2E データを後から特定するときの手掛かりになる。
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            cat E2ETests/signup-smoke-output.txt >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo ""
+            echo "--- Signup Smoke Output ---"
+            cat E2ETests/signup-smoke-output.txt
           fi

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -14,6 +14,9 @@ on:
           - migrate-and-deploy
           - deploy-only
           - migrate-only
+          # デプロイせず verify だけを回す。ecauth-infrastructure の apply 後（アプリを
+          # 再デプロイしないが app_settings は変わる）に、外から叩くための入口。
+          - verify-only
         default: 'migrate-and-deploy'
       dry_run:
         description: 'Dry run (generate migration script only, skip deploy and verify)'
@@ -275,11 +278,17 @@ jobs:
 
   verify:
     needs: deploy
-    # push イベント時は inputs.dry_run が undefined になるため || false でフォールバック
+    # push イベント時は inputs.dry_run が undefined になるため || false でフォールバック。
+    # verify-only のときは deploy が skipped になる（インフラ変更後の再検証用）。
+    #
+    # なお staging には申込スモークを入れていない。AccountsOrganizationSeeder が
+    # ACCOUNTS_* / STG_ACCOUNTS_* 未設定の環境では Org を投入せず（Account 機能は本番のみ）、
+    # staging の app_settings にはこれらが無いため、申込 API 自体が存在しない。
     if: |
       always() &&
-      needs.deploy.result == 'success' &&
-      (inputs.dry_run || false) != true
+      (inputs.dry_run || false) != true &&
+      (needs.deploy.result == 'success' ||
+       (inputs.action == 'verify-only' && needs.deploy.result == 'skipped'))
     runs-on: ubuntu-latest
     environment:
       name: staging

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,10 +262,17 @@ ECCUBE_AUTHENTICATION_KEY=$(op read 'op://EcAuth/eccube4-ecauth-plugin/eccube_au
 申込フローの E2E は確認メールの本文からトークンを取り出す必要がある（トークンは本文にしか
 存在せず、DB には SHA-256 ハッシュしか残らない）。受信口は環境で変わる。
 
-| 環境 | 受信口 | 参照方法 |
+spec は受信口を直接触らず、`tests/helpers/mailbox.ts` の `Mailbox` 越しに読む。
+実装の選択は `E2E_MAILBOX_KIND`（既定 `mailpit`）。
+
+| 環境 | `E2E_MAILBOX_KIND` | 実装 |
 |---|---|---|
-| ローカル / CI | mailpit | `tests/helpers/mailpit.ts`（`MAILPIT_BASE_URL`、既定 `http://localhost:8025`） |
-| staging / production | Cloudflare Worker の E2E メールボックス | 下記（**未実装**。デプロイ後 E2E を組むときに吸収層を作る） |
+| ローカル / CI | `mailpit`（既定） | `tests/helpers/mailpit.ts`（`MAILPIT_BASE_URL`、既定 `http://localhost:8025`） |
+| production | `e2e-mailbox` | `tests/helpers/e2e-mailbox.ts`（`E2E_MAILBOX_BASE_URL` / `E2E_MAILBOX_API_TOKEN`） |
+
+後始末が「ID の配列」ではなく `cleanup(宛先)` なのは、Worker 側が宛先単位でしか削除
+できないため（1 メッセージ 1 キーで保存し ID を返さない）。mailpit 実装は全 spec で
+共有される単一インスタンスを壊さないよう、**自分が読んだ ID だけ**を覚えて消す。
 
 デプロイ済み環境は SendGrid 送信なので mailpit が使えない。代わりに
 `ecauth-infrastructure` が用意した受信口を使う（構成の詳細と設計上の制約は
@@ -283,11 +290,46 @@ ECCUBE_AUTHENTICATION_KEY=$(op read 'op://EcAuth/eccube4-ecauth-plugin/eccube_au
 呼び出し側の注意:
 
 - **Workers KV は結果整合**で、書き込みが読み出しに反映されるまで最大 1 分程度かかりうる。
-  mailpit 相当の短いポーリング間隔だと取りこぼすので、タイムアウトは余裕を持たせる。
+  そのため `e2e-mailbox` 実装の既定タイムアウトは 180 秒（mailpit は 20 秒）。
 - メッセージは 1 時間で自動失効するため、後始末の `DELETE` は必須ではない。
-- 本文のフィールド名が mailpit（`Text` / `HTML` / `Subject` / `ID`）と異なる。
-  spec からは直接触らず、`waitForMessage` / `extractToken` と同じインターフェースの
-  吸収層を挟むこと。
+- 本文のフィールド名が mailpit（`Text` / `HTML` / `Subject` / `ID`）と異なるが、
+  `Mailbox` が `{subject, text, html}` に正規化するので spec 側は意識しなくてよい。
+
+### 本番デプロイ後の申込スモーク
+
+`production.yml` の `verify` ジョブは、シード済み Client を使う
+`b2b_passkey_authentication.spec.ts` に加えて `signup_client_b2b_login.spec.ts` を
+**実本番に対して**回す。CI（`main.yml`）が守るのはコードの整合性だけで、
+「デプロイ済み環境の設定が実際の認証フローと噛み合っているか」は別物のため。
+
+| 項目 | 決め |
+|---|---|
+| 申込先テナント | `stg-accounts`。本物の顧客が入る `accounts` は汚さない |
+| `client_secret` | **必要**。`STG_ACCOUNTS_CLIENT_PUBLIC` が設定されていないので stg-accounts の管理コンソール Client は confidential。無いと「client_secretが正しくありません。」で落ちる |
+| テナント解決 | Host ヘッダの差し替えではなく実ホスト名（`E2E_TENANT_BASE_DOMAIN=ec-auth.io`）。Cloudflare 配下では SNI と Host の不一致を避ける必要があり、オリジンへの直アクセスも許可 IP で塞がれている（`environments/production/main.tf` の `cloudflare_ip_restrictions`） |
+| 疑似サイトのオリジン | `context.route` で stub。`.test` は公開解決されないため実体を持たせない |
+| EC-CUBE 実物版 | 入れない。イメージビルドで 10 分前後かかり、本番 DB に残る Organization も run あたり 2 倍になる。プラグインの実コードは CI 側で担保する |
+
+**staging には入れられない。** `AccountsOrganizationSeeder` は `ACCOUNTS_*` /
+`STG_ACCOUNTS_*` が未設定の環境では Organization を投入せず（Account 機能は本番のみ）、
+`environments/staging/main.tf` の `app_settings` にこれらは存在しない。
+つまり staging には申込 API 自体が無い。
+
+#### 残留データ
+
+このスモークは本番 DB に Organization / Client / B2BUser / パスキーを **1 run あたり 1 組**
+残す。クリーンアップコマンドは [EcAuth#487](https://github.com/EcAuth/EcAuth/issues/487) で未着手。
+それまでは run ごとの識別子（`e2e-{timestamp}-{rand}-test`）を手掛かりに手で消す。
+識別子は Playwright 出力の先頭 `[signup-smoke]` 行と、`verify` ジョブの Step Summary に出る。
+
+#### インフラ変更後の再検証
+
+`ecauth-infrastructure` の apply はアプリを再デプロイしないため、`app_settings` や DNS を
+変えても EcAuth 側では誰も検証しない。この空白を埋めるため、`terraform.yml` の
+`verify-staging` / `verify-production` ジョブが apply 成功後に
+`gh workflow run <staging|production>.yml -f action=verify-only -f dry_run=false` を撃つ。
+`verify-only` は migrate / build / deploy を skip して `verify` だけを回す入口。
+`production.yml` の `dry_run` は既定 `true` なので、明示的に `false` を渡さないと verify も skip される。
 
 ### マイグレーション設計ルール
 

--- a/E2ETests/tests/helpers/accounts.ts
+++ b/E2ETests/tests/helpers/accounts.ts
@@ -1,5 +1,5 @@
 import { expect, APIRequestContext, BrowserContext, Page } from '@playwright/test';
-import { extractToken, Mailbox } from './mailbox';
+import { extractTokenFromMessage, Mailbox } from './mailbox';
 import { generatePkcePair } from './pkce';
 
 /**
@@ -104,7 +104,7 @@ export async function signupAndGetAccountToken(
 
   // --- 確認メール → confirm ---
   const message = await mailbox.waitForMessage(options.email, { subjectIncludes: 'お申し込み確認' });
-  const confirmToken = extractToken(message.text || message.html);
+  const confirmToken = extractTokenFromMessage(message);
 
   const confirmResponse = await api.post(`${options.baseUrl}/api/signup/confirm`, {
     data: { token: confirmToken },

--- a/E2ETests/tests/helpers/accounts.ts
+++ b/E2ETests/tests/helpers/accounts.ts
@@ -1,5 +1,5 @@
 import { expect, APIRequestContext, BrowserContext, Page } from '@playwright/test';
-import { waitForMessage, extractToken } from './mailpit';
+import { extractToken, Mailbox } from './mailbox';
 import { generatePkcePair } from './pkce';
 
 /**
@@ -16,15 +16,26 @@ import { generatePkcePair } from './pkce';
  */
 
 export interface SignupOptions {
-  /** IdP のベース URL（既定 https://localhost:8081） */
+  /**
+   * 申込 API（/api/signup/*）とトークン交換の宛先。
+   * ローカルでは IdP のベース URL（https://localhost:8081）＋ Host ヘッダでテナントを解決するが、
+   * デプロイ済み環境では実ホスト（https://stg-accounts.ec-auth.io）をそのまま渡す。
+   */
   baseUrl: string;
   /** accounts テナントに解決させる Host ヘッダ */
   accountsHost: string;
   /** accounts テナントのページ配信元（origin と rp_id を一致させる） */
   accountsPageBaseUrl: string;
-  /** 管理コンソール Client（public client） */
+  /** 管理コンソール Client */
   accountsClientId: string;
   accountsRedirectUri: string;
+  /**
+   * 管理コンソール Client が confidential の場合に渡す。
+   * 本番の accounts は public client（PKCE のみ）だが、stg-accounts は
+   * ACCOUNTS_CLIENT_PUBLIC 相当の設定を持たず confidential のままなので、
+   * こちらを指定しないとトークン交換が「client_secretが正しくありません。」で落ちる。
+   */
+  accountsClientSecret?: string;
 
   email: string;
   organizationName: string;
@@ -37,8 +48,6 @@ export interface SignupOptions {
 export interface SignupResult {
   /** SubjectType=Account のアクセストークン。/v1/account/* の認可に使う */
   accessToken: string;
-  /** mailpit 上の確認メール ID（後始末用） */
-  messageId: string;
 }
 
 /** 申込で払い出された Client。値はすべて API から取得したもので、テスト側では組み立てない。 */
@@ -61,11 +70,23 @@ export interface SignupClient {
  */
 export async function signupAndGetAccountToken(
   api: APIRequestContext,
-  mailpit: APIRequestContext,
+  mailbox: Mailbox,
   context: BrowserContext,
   options: SignupOptions
 ): Promise<SignupResult> {
   const { codeVerifier, codeChallenge } = generatePkcePair();
+
+  // 認可コードは URL から読み取るだけで、コールバック先の実体は要らない。
+  // デプロイ済み環境では redirect_uri が実在のホストを指すため、stub しないと
+  // ブラウザがそこへ本当に遷移する。相手が SPA だと同じ code を別の code_verifier で
+  // 交換しに行き、こちらのトークン交換が使えなくなる。
+  await context.route(`${options.accountsRedirectUri}**`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'text/html',
+      body: '<html><body>auth callback stub</body></html>',
+    })
+  );
 
   // --- 申込 ---
   const requestResponse = await api.post(`${options.baseUrl}/api/signup/request`, {
@@ -82,8 +103,8 @@ export async function signupAndGetAccountToken(
   }
 
   // --- 確認メール → confirm ---
-  const message = await waitForMessage(mailpit, options.email, { subjectIncludes: 'お申し込み確認' });
-  const confirmToken = extractToken(message.Text || message.HTML);
+  const message = await mailbox.waitForMessage(options.email, { subjectIncludes: 'お申し込み確認' });
+  const confirmToken = extractToken(message.text || message.html);
 
   const confirmResponse = await api.post(`${options.baseUrl}/api/signup/confirm`, {
     data: { token: confirmToken },
@@ -132,10 +153,11 @@ export async function signupAndGetAccountToken(
     const authorizationCode = new URL(page.url()).searchParams.get('code');
     expect(authorizationCode).toBeTruthy();
 
-    // --- トークン交換（public client なので PKCE 必須） ---
+    // --- トークン交換（PKCE 必須。confidential なら client_secret も添える） ---
     const tokenResponse = await api.post(`${options.baseUrl}/v1/token`, {
       form: {
         client_id: options.accountsClientId,
+        ...(options.accountsClientSecret ? { client_secret: options.accountsClientSecret } : {}),
         code: authorizationCode!,
         redirect_uri: options.accountsRedirectUri,
         grant_type: 'authorization_code',
@@ -149,7 +171,7 @@ export async function signupAndGetAccountToken(
     const accessToken = (await tokenResponse.json()).access_token as string;
     expect(accessToken).toBeTruthy();
 
-    return { accessToken, messageId: message.ID };
+    return { accessToken };
   } finally {
     await page.close();
   }

--- a/E2ETests/tests/helpers/e2e-mailbox.ts
+++ b/E2ETests/tests/helpers/e2e-mailbox.ts
@@ -49,13 +49,20 @@ export async function createE2EMailbox(): Promise<Mailbox> {
     extraHTTPHeaders: { Authorization: `Bearer ${token}` },
   });
 
+  /** 回復の見込みが無い失敗。ポーリングで粘らず即座に落とす。 */
+  class FatalMailboxError extends Error {}
+
   async function fetchMessages(toEmail: string): Promise<WorkerMessage[]> {
     const response = await ctx.get(`${baseUrl}/messages`, { params: { to: toEmail } });
     if (!response.ok()) {
-      // 401 はトークン不一致。本文にトークンは含まれないのでそのまま出してよい。
-      throw new Error(
-        `E2E メールボックスの取得に失敗しました (${response.status()}): ${await response.text()}`
-      );
+      const detail = `(${response.status()}): ${await response.text()}`;
+      // 401/403 はトークン不一致・設定ミスで、待っても直らない。
+      // 180 秒粘ってから同じ理由で落ちるより、即座に理由を出す方が早く直せる。
+      // 本文に読み出しトークンは含まれない。
+      if (response.status() === 401 || response.status() === 403) {
+        throw new FatalMailboxError(`E2E メールボックスの認証に失敗しました ${detail}`);
+      }
+      throw new Error(`E2E メールボックスの取得に失敗しました ${detail}`);
     }
     const body = await response.json();
     return Array.isArray(body.messages) ? (body.messages as WorkerMessage[]) : [];
@@ -70,10 +77,26 @@ export async function createE2EMailbox(): Promise<Mailbox> {
       const deadline = Date.now() + timeoutMs;
 
       let lastSubjects: string[] = [];
+      let lastTransientError: string | undefined;
 
       while (Date.now() < deadline) {
-        // Worker は受信順（古い順）で返す。mailpit と揃えて新しい順で扱う。
-        const messages = (await fetchMessages(toEmail)).reverse();
+        let messages: WorkerMessage[];
+        try {
+          // Worker は受信順（古い順）で返す。mailpit と揃えて新しい順で扱う。
+          messages = (await fetchMessages(toEmail)).reverse();
+        } catch (e) {
+          if (e instanceof FatalMailboxError) {
+            throw e;
+          }
+          // ネットワーク瞬断や Worker の一時的な 5xx で待機を打ち切らない。
+          // 既定タイムアウトが 180 秒なのは KV の結果整合を待つためで、
+          // その途中の 1 回の失敗で落ちると本番スモークが偽陰性になる
+          // （本番スモークは retries: 0 で回るため取り返しがきかない）。
+          lastTransientError = (e as Error).message;
+          await new Promise((resolve) => setTimeout(resolve, intervalMs));
+          continue;
+        }
+
         lastSubjects = messages.map((m) => m.subject ?? '');
 
         const found = opts.subjectIncludes
@@ -96,8 +119,10 @@ export async function createE2EMailbox(): Promise<Mailbox> {
         lastSubjects.length === 0
           ? '受信 0 件'
           : `受信済みの件名: ${lastSubjects.join(' / ')}`;
+      // 取得自体が失敗し続けていた場合は、それが本当の原因なので添える。
+      const transient = lastTransientError ? `。直近の取得エラー: ${lastTransientError}` : '';
       throw new Error(
-        `E2E メールボックス: ${toEmail} 宛のメール${suffix}が ${timeoutMs}ms 以内に受信されませんでした（${received}）。`
+        `E2E メールボックス: ${toEmail} 宛のメール${suffix}が ${timeoutMs}ms 以内に受信されませんでした（${received}）${transient}。`
       );
     },
 

--- a/E2ETests/tests/helpers/e2e-mailbox.ts
+++ b/E2ETests/tests/helpers/e2e-mailbox.ts
@@ -1,0 +1,114 @@
+import { request } from '@playwright/test';
+import type { Mailbox, MailboxMessage, WaitForMessageOptions } from './mailbox';
+
+/**
+ * デプロイ済み環境向けの受信口（SendGrid Inbound Parse → Cloudflare Worker）。
+ *
+ * ecauth-infrastructure の environments/cdn が提供する。経路と制約は
+ * ecauth-infrastructure の CLAUDE.md「E2E 用メールボックス」を参照。
+ *
+ *   GET    /messages?to=<address>   受信順（古い順）に返す。要 Bearer
+ *   DELETE /messages?to=<address>   宛先単位で削除。要 Bearer
+ *
+ * レスポンスは {"messages":[{to, from, subject, text, html, received_at}, ...]}。
+ * mailpit（Subject / Text / HTML）とフィールド名が違うので、ここで Mailbox の形に正規化する。
+ */
+
+const DEFAULT_BASE_URL = 'https://e2e-mail.ec-auth.io';
+
+/**
+ * 既定のタイムアウトが mailpit（20 秒）よりずっと長いのは、経路が根本的に違うため:
+ *   SendGrid の送信キュー → MX 受信 → Inbound Parse の POST → Workers KV への書き込み
+ *   → **Workers KV は結果整合**で、別ロケーションの読み出しに反映されるまで最大 1 分程度
+ * かかりうる。短いポーリングだと「送れているのに見つからない」で落ちる。
+ */
+const DEFAULT_TIMEOUT_MS = 180000;
+const DEFAULT_INTERVAL_MS = 5000;
+
+interface WorkerMessage {
+  to?: string;
+  from?: string;
+  subject?: string;
+  text?: string;
+  html?: string;
+  received_at?: string;
+}
+
+export async function createE2EMailbox(): Promise<Mailbox> {
+  const baseUrl = (process.env.E2E_MAILBOX_BASE_URL || DEFAULT_BASE_URL).replace(/\/+$/, '');
+  const token = process.env.E2E_MAILBOX_API_TOKEN;
+  if (!token) {
+    throw new Error(
+      'E2E_MAILBOX_API_TOKEN が未設定です。' +
+        "op read 'op://EcAuth/ecauth-e2e-mailbox/api_token' の値を渡してください。"
+    );
+  }
+
+  // トークンはコンテキストのヘッダに閉じ込める。個々の呼び出しで組み立てない。
+  const ctx = await request.newContext({
+    extraHTTPHeaders: { Authorization: `Bearer ${token}` },
+  });
+
+  async function fetchMessages(toEmail: string): Promise<WorkerMessage[]> {
+    const response = await ctx.get(`${baseUrl}/messages`, { params: { to: toEmail } });
+    if (!response.ok()) {
+      // 401 はトークン不一致。本文にトークンは含まれないのでそのまま出してよい。
+      throw new Error(
+        `E2E メールボックスの取得に失敗しました (${response.status()}): ${await response.text()}`
+      );
+    }
+    const body = await response.json();
+    return Array.isArray(body.messages) ? (body.messages as WorkerMessage[]) : [];
+  }
+
+  return {
+    kind: 'e2e-mailbox',
+
+    async waitForMessage(toEmail: string, opts: WaitForMessageOptions = {}): Promise<MailboxMessage> {
+      const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+      const intervalMs = opts.intervalMs ?? DEFAULT_INTERVAL_MS;
+      const deadline = Date.now() + timeoutMs;
+
+      let lastSubjects: string[] = [];
+
+      while (Date.now() < deadline) {
+        // Worker は受信順（古い順）で返す。mailpit と揃えて新しい順で扱う。
+        const messages = (await fetchMessages(toEmail)).reverse();
+        lastSubjects = messages.map((m) => m.subject ?? '');
+
+        const found = opts.subjectIncludes
+          ? messages.find((m) => (m.subject ?? '').includes(opts.subjectIncludes!))
+          : messages[0];
+
+        if (found) {
+          return {
+            subject: found.subject ?? '',
+            text: found.text ?? '',
+            html: found.html ?? '',
+          };
+        }
+        await new Promise((resolve) => setTimeout(resolve, intervalMs));
+      }
+
+      const suffix = opts.subjectIncludes ? `（件名: ${opts.subjectIncludes}）` : '';
+      // 「1 通も届いていない」のか「別の件名しか無い」のかで原因が全く違うので区別できるようにする。
+      const received =
+        lastSubjects.length === 0
+          ? '受信 0 件'
+          : `受信済みの件名: ${lastSubjects.join(' / ')}`;
+      throw new Error(
+        `E2E メールボックス: ${toEmail} 宛のメール${suffix}が ${timeoutMs}ms 以内に受信されませんでした（${received}）。`
+      );
+    },
+
+    async cleanup(toEmail: string): Promise<void> {
+      // 失効（expirationTtl 1 時間）に任せても残骸は消えるが、
+      // 同一宛先での再実行に備えて明示的に消す。
+      await ctx.delete(`${baseUrl}/messages`, { params: { to: toEmail } });
+    },
+
+    async dispose(): Promise<void> {
+      await ctx.dispose();
+    },
+  };
+}

--- a/E2ETests/tests/helpers/mailbox.ts
+++ b/E2ETests/tests/helpers/mailbox.ts
@@ -1,0 +1,81 @@
+/**
+ * 確認メール / マジックリンクの受信口を抽象化する。
+ *
+ * Account 申込のトークンは「メール本文にしか存在しない」（DB には SHA-256 ハッシュのみ）。
+ * E2E で申込フローを完走するには本文を機械的に読む必要があるが、受信口は環境で違う:
+ *
+ *   - ローカル / CI      … mailpit（compose で同居。plain HTTP）
+ *   - デプロイ済み環境   … SendGrid 送信なので、Inbound Parse → Cloudflare Worker の
+ *                          E2E 用メールボックス（詳細は EcAuth の CLAUDE.md）
+ *
+ * spec 側が受信口の違いを知らずに済むよう、両者をこの Mailbox に揃える。
+ * 選択は E2E_MAILBOX_KIND（既定 mailpit）。
+ *
+ * 後始末を「ID の配列」ではなく「宛先」で表現しているのは、Worker 側の DELETE が
+ * 宛先単位でしか消せないため（1 メッセージ 1 キーで保存し、ID を返さない）。
+ * mailpit 実装は他 spec のメールを巻き込まないよう、自分が読んだ ID だけを覚えて消す。
+ */
+import { createMailpitMailbox } from './mailpit';
+import { createE2EMailbox } from './e2e-mailbox';
+
+export type MailboxKind = 'mailpit' | 'e2e-mailbox';
+
+/** 受信口によらず spec が必要とする最小限のフィールド。 */
+export interface MailboxMessage {
+  subject: string;
+  /** プレーンテキスト本文 */
+  text: string;
+  /** HTML 本文 */
+  html: string;
+}
+
+export interface WaitForMessageOptions {
+  /** 件名に含まれる文字列で絞り込む（同一宛先に複数種のメールが届く場合） */
+  subjectIncludes?: string;
+  /** 最大待機時間。既定値は実装ごとに異なる（配送経路の長さが違うため） */
+  timeoutMs?: number;
+  /** ポーリング間隔。既定値は実装ごとに異なる */
+  intervalMs?: number;
+}
+
+export interface Mailbox {
+  readonly kind: MailboxKind;
+  /** 宛先宛の最新メッセージを、届くまでポーリングして返す。 */
+  waitForMessage(toEmail: string, opts?: WaitForMessageOptions): Promise<MailboxMessage>;
+  /** その宛先宛のメールを片付ける（テスト後の後始末）。 */
+  cleanup(toEmail: string): Promise<void>;
+  dispose(): Promise<void>;
+}
+
+/**
+ * E2E_MAILBOX_KIND に従って受信口を組み立てる。
+ * 呼び出し側は afterAll などで必ず dispose() すること。
+ */
+export async function createMailbox(): Promise<Mailbox> {
+  const kind = (process.env.E2E_MAILBOX_KIND || 'mailpit') as MailboxKind;
+
+  switch (kind) {
+    case 'mailpit':
+      return createMailpitMailbox();
+    case 'e2e-mailbox':
+      return createE2EMailbox();
+    default:
+      throw new Error(
+        `E2E_MAILBOX_KIND=${kind} は未対応です（mailpit / e2e-mailbox のいずれかを指定してください）。`
+      );
+  }
+}
+
+/**
+ * メール本文（プレーンテキスト推奨）から `token=...` クエリの値を抽出して URL デコードする。
+ * 確認 URL（/signup/confirm?token=...）とマジックリンク URL（/signin/magic-link?token=...）の
+ * どちらにも対応する。受信口に依存しない純関数。
+ */
+export function extractToken(body: string, tokenParam: string = 'token'): string {
+  // URL-safe な base64（英数字 + - _ . ~ %）を貪欲に拾い、区切り文字（引用符・空白・タグ・& 等）で止める。
+  const match = body.match(new RegExp(`[?&]${tokenParam}=([^"'&\\s<>\\)]+)`));
+  if (!match) {
+    throw new Error(`メール本文から ${tokenParam} を抽出できませんでした。`);
+  }
+  return decodeURIComponent(match[1]);
+}

--- a/E2ETests/tests/helpers/mailbox.ts
+++ b/E2ETests/tests/helpers/mailbox.ts
@@ -79,3 +79,34 @@ export function extractToken(body: string, tokenParam: string = 'token'): string
   }
   return decodeURIComponent(match[1]);
 }
+
+/**
+ * メッセージからトークンを取り出す。プレーンテキスト → HTML の順に試す。
+ *
+ * どちらか一方を決め打ちできないのは、**配送経路によって生の URL が残る本文が変わる**ため。
+ * SendGrid はクリックトラッキングが有効だと、プレーンテキスト中の裸の URL と HTML の
+ * `<a href>` を `https://<id>.ct.sendgrid.net/ls/click?upn=...` に書き換える。
+ * EcAuth の申込確認メール（EmailTemplates.BuildSignupConfirmation）では、HTML の
+ * 「ボタンが動作しない場合は」の行だけがリンクではない生テキストなので書き換えを免れ、
+ * そこにしか `token=` が残らない。ローカルの mailpit は SMTP 直結で書き換えが無いため
+ * プレーンテキストで取れる。
+ */
+export function extractTokenFromMessage(
+  message: MailboxMessage,
+  tokenParam: string = 'token'
+): string {
+  for (const body of [message.text, message.html]) {
+    if (!body) {
+      continue;
+    }
+    try {
+      return extractToken(body, tokenParam);
+    } catch {
+      // この本文には無かった。次を試す。
+    }
+  }
+  throw new Error(
+    `メール本文（text / html いずれも）から ${tokenParam} を抽出できませんでした。` +
+      `件名: ${message.subject}`
+  );
+}

--- a/E2ETests/tests/helpers/mailpit.ts
+++ b/E2ETests/tests/helpers/mailpit.ts
@@ -1,4 +1,5 @@
-import { APIRequestContext } from '@playwright/test';
+import { APIRequestContext, request } from '@playwright/test';
+import type { Mailbox, MailboxMessage, WaitForMessageOptions } from './mailbox';
 
 /**
  * mailpit REST API のラッパ。
@@ -84,15 +85,37 @@ export async function deleteMessages(request: APIRequestContext, ids: string[]):
 }
 
 /**
- * メール本文（プレーンテキスト推奨）から `token=...` クエリの値を抽出して URL デコードする。
- * 確認 URL（/signup/confirm?token=...）とマジックリンク URL（/signin/magic-link?token=...）の
- * どちらにも対応する。
+ * mailpit を {@link Mailbox} として使えるようにする。
+ *
+ * cleanup が宛先単位のインターフェースなのに ID 指定で消しているのは、mailpit が
+ * 全 spec で共有される単一インスタンスだから。宛先で一括削除する API に寄せると、
+ * 並列実行中の他 spec のメールまで巻き込みかねない。**自分が読んだ ID だけ**を
+ * 覚えておいて消す（このモジュール冒頭の注意書きと同じ理由）。
  */
-export function extractToken(body: string, tokenParam: string = 'token'): string {
-  // URL-safe な base64（英数字 + - _ . ~ %）を貪欲に拾い、区切り文字（引用符・空白・タグ・& 等）で止める。
-  const match = body.match(new RegExp(`[?&]${tokenParam}=([^"'&\\s<>\\)]+)`));
-  if (!match) {
-    throw new Error(`メール本文から ${tokenParam} を抽出できませんでした。`);
-  }
-  return decodeURIComponent(match[1]);
+export async function createMailpitMailbox(): Promise<Mailbox> {
+  const ctx = await request.newContext();
+  const seenIds = new Map<string, Set<string>>();
+
+  return {
+    kind: 'mailpit',
+
+    async waitForMessage(toEmail: string, opts: WaitForMessageOptions = {}): Promise<MailboxMessage> {
+      const message = await waitForMessage(ctx, toEmail, opts);
+
+      const ids = seenIds.get(toEmail) ?? new Set<string>();
+      ids.add(message.ID);
+      seenIds.set(toEmail, ids);
+
+      return { subject: message.Subject, text: message.Text, html: message.HTML };
+    },
+
+    async cleanup(toEmail: string): Promise<void> {
+      await deleteMessages(ctx, [...(seenIds.get(toEmail) ?? [])]);
+      seenIds.delete(toEmail);
+    },
+
+    async dispose(): Promise<void> {
+      await ctx.dispose();
+    },
+  };
 }

--- a/E2ETests/tests/helpers/mailpit.ts
+++ b/E2ETests/tests/helpers/mailpit.ts
@@ -2,7 +2,10 @@ import { APIRequestContext, request } from '@playwright/test';
 import type { Mailbox, MailboxMessage, WaitForMessageOptions } from './mailbox';
 
 /**
- * mailpit REST API のラッパ。
+ * mailpit REST API のラッパ（{@link Mailbox} の mailpit 実装）。
+ *
+ * 公開するのは createMailpitMailbox だけ。spec からは helpers/mailbox.ts の
+ * createMailbox() 越しに使い、受信口の違いを spec に持ち込まない。
  *
  * Account 申込・マジックリンクの確認/ログイントークンは「メール本文にしか存在しない」
  * （DB には SHA-256 ハッシュのみ保存）。E2E でフローを完走するため、mailpit が受信した
@@ -16,7 +19,7 @@ import type { Mailbox, MailboxMessage, WaitForMessageOptions } from './mailbox';
  */
 const MAILPIT_BASE = process.env.MAILPIT_BASE_URL || 'http://localhost:8025';
 
-export interface MailpitMessage {
+interface MailpitMessage {
   ID: string;
   /** プレーンテキスト本文 */
   Text: string;
@@ -35,7 +38,7 @@ export interface MailpitMessage {
  * @param opts.timeoutMs 最大待機時間（既定 20000ms）
  * @param opts.intervalMs ポーリング間隔（既定 500ms）
  */
-export async function waitForMessage(
+async function waitForMessage(
   request: APIRequestContext,
   toEmail: string,
   opts: { subjectIncludes?: string; timeoutMs?: number; intervalMs?: number } = {}
@@ -75,7 +78,7 @@ export async function waitForMessage(
  * 指定した ID のメッセージを削除する（テスト後の後始末）。
  * 他 spec のメールを消さないよう、必ず処理済みの ID のみを渡すこと。
  */
-export async function deleteMessages(request: APIRequestContext, ids: string[]): Promise<void> {
+async function deleteMessages(request: APIRequestContext, ids: string[]): Promise<void> {
   if (ids.length === 0) {
     return;
   }

--- a/E2ETests/tests/specs/account_magic_link_flow.spec.ts
+++ b/E2ETests/tests/specs/account_magic_link_flow.spec.ts
@@ -1,12 +1,11 @@
 import { test, expect, APIRequestContext, request } from '@playwright/test';
-import { waitForMessage, deleteMessages } from '../helpers/mailpit';
-import { extractToken } from '../helpers/mailbox';
+import { createMailbox, extractToken, Mailbox } from '../helpers/mailbox';
 
 /**
- * マジックリンクログインの E2E テスト（mailpit ベース）。
+ * マジックリンクログインの E2E テスト。
  *
  * 事前に申込 → confirm で Account を作成し、
- * request → メール（mailpit）→ リンク抽出 → verify → トークン + managed_orgs を検証。
+ * request → メール（受信口は Mailbox 抽象）→ リンク抽出 → verify → トークン + managed_orgs を検証。
  * さらに異常系（second-use / レート制限）も検証する。
  *
  * verify は認可コードではなくトークンを直接返す（管理コンソールは public client で
@@ -30,10 +29,8 @@ test.describe.serial('マジックリンクログインの E2E テスト', () =>
   const magicLinkSubject = 'ログインリンク';
 
   let apiAccounts: APIRequestContext;
-  let mailpitCtx: APIRequestContext;
+  let mailbox: Mailbox;
 
-  // 後始末で削除するメッセージ ID（他 spec のメールを消さないよう ID 指定で削除）。
-  const messageIds: string[] = [];
   // 消費テスト用に保持するログイントークン。
   let magicToken: string;
 
@@ -42,7 +39,7 @@ test.describe.serial('マジックリンクログインの E2E テスト', () =>
       ignoreHTTPSErrors: true,
       extraHTTPHeaders: { Host: accountsHost },
     });
-    mailpitCtx = await request.newContext();
+    mailbox = await createMailbox();
 
     // 前提: マジックリンク対象の Account を申込フローで作成する。
     const signupRes = await apiAccounts.post(`${baseUrl}/api/signup/request`, {
@@ -56,9 +53,8 @@ test.describe.serial('マジックリンクログインの E2E テスト', () =>
     });
     expect(signupRes.status()).toBe(202);
 
-    const confirmMail = await waitForMessage(mailpitCtx, email, { subjectIncludes: signupSubject });
-    messageIds.push(confirmMail.ID);
-    const confirmToken = extractToken(confirmMail.Text || confirmMail.HTML);
+    const confirmMail = await mailbox.waitForMessage(email, { subjectIncludes: signupSubject });
+    const confirmToken = extractToken(confirmMail.text || confirmMail.html);
 
     const confirmRes = await apiAccounts.post(`${baseUrl}/api/signup/confirm`, {
       data: { token: confirmToken },
@@ -67,9 +63,9 @@ test.describe.serial('マジックリンクログインの E2E テスト', () =>
   });
 
   test.afterAll(async () => {
-    await deleteMessages(mailpitCtx, messageIds);
-    await apiAccounts?.dispose();
-    await mailpitCtx?.dispose();
+    // 後始末は互いに独立させる（cleanup の失敗で dispose を落とさない）。
+    await Promise.allSettled([mailbox?.cleanup(email), apiAccounts?.dispose()]);
+    await mailbox?.dispose();
   });
 
   test('マジックリンク要求 → メール → verify → トークン + managed_orgs', async () => {
@@ -81,9 +77,8 @@ test.describe.serial('マジックリンクログインの E2E テスト', () =>
     // Email enumeration 対策により、常に 200 を返す。
     expect(reqRes.status()).toBe(200);
 
-    const mail = await waitForMessage(mailpitCtx, email, { subjectIncludes: magicLinkSubject });
-    messageIds.push(mail.ID);
-    magicToken = extractToken(mail.Text || mail.HTML);
+    const mail = await mailbox.waitForMessage(email, { subjectIncludes: magicLinkSubject });
+    magicToken = extractToken(mail.text || mail.html);
     expect(magicToken.length).toBeGreaterThan(10);
 
     const verifyRes = await apiAccounts.post(`${baseUrl}/api/account/magic-link/verify`, {

--- a/E2ETests/tests/specs/account_magic_link_flow.spec.ts
+++ b/E2ETests/tests/specs/account_magic_link_flow.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, APIRequestContext, request } from '@playwright/test';
-import { createMailbox, extractToken, Mailbox } from '../helpers/mailbox';
+import { createMailbox, extractTokenFromMessage, Mailbox } from '../helpers/mailbox';
 
 /**
  * マジックリンクログインの E2E テスト。
@@ -54,7 +54,7 @@ test.describe.serial('マジックリンクログインの E2E テスト', () =>
     expect(signupRes.status()).toBe(202);
 
     const confirmMail = await mailbox.waitForMessage(email, { subjectIncludes: signupSubject });
-    const confirmToken = extractToken(confirmMail.text || confirmMail.html);
+    const confirmToken = extractTokenFromMessage(confirmMail);
 
     const confirmRes = await apiAccounts.post(`${baseUrl}/api/signup/confirm`, {
       data: { token: confirmToken },
@@ -78,7 +78,7 @@ test.describe.serial('マジックリンクログインの E2E テスト', () =>
     expect(reqRes.status()).toBe(200);
 
     const mail = await mailbox.waitForMessage(email, { subjectIncludes: magicLinkSubject });
-    magicToken = extractToken(mail.text || mail.html);
+    magicToken = extractTokenFromMessage(mail);
     expect(magicToken.length).toBeGreaterThan(10);
 
     const verifyRes = await apiAccounts.post(`${baseUrl}/api/account/magic-link/verify`, {

--- a/E2ETests/tests/specs/account_magic_link_flow.spec.ts
+++ b/E2ETests/tests/specs/account_magic_link_flow.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, APIRequestContext, request } from '@playwright/test';
-import { waitForMessage, deleteMessages, extractToken } from '../helpers/mailpit';
+import { waitForMessage, deleteMessages } from '../helpers/mailpit';
+import { extractToken } from '../helpers/mailbox';
 
 /**
  * マジックリンクログインの E2E テスト（mailpit ベース）。

--- a/E2ETests/tests/specs/account_signup_flow.spec.ts
+++ b/E2ETests/tests/specs/account_signup_flow.spec.ts
@@ -1,12 +1,11 @@
 import { test, expect, BrowserContext, Page, APIRequestContext, request } from '@playwright/test';
-import { waitForMessage, deleteMessages } from '../helpers/mailpit';
-import { extractToken } from '../helpers/mailbox';
+import { createMailbox, extractToken, Mailbox } from '../helpers/mailbox';
 import { generatePkcePair } from '../helpers/pkce';
 
 /**
- * Account 申込フローの E2E テスト（mailpit ベース）。
+ * Account 申込フローの E2E テスト。
  *
- * 申込 → 確認メール（mailpit）→ トークン抽出 → /api/signup/confirm → Account 作成 ＋ 登録トークン発行 →
+ * 申込 → 確認メール（受信口は Mailbox 抽象）→ トークン抽出 → /api/signup/confirm → Account 作成 ＋ 登録トークン発行 →
  * パスキー登録（/passkey/register）→ パスキー認証（/passkey/authenticate）→ 認可コード →
  * /token（PKCE）→ managed_orgs 検証。
  *
@@ -51,14 +50,13 @@ test.describe.serial('Account 申込フローの E2E テスト', () => {
   const expectedOrgCode = productionSiteHost.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
 
   let apiAccounts: APIRequestContext; // Host=accounts を付与した API コンテキスト
-  let mailpitCtx: APIRequestContext; // mailpit REST 用（http）
+  let mailbox: Mailbox; // 確認メールの受信口（既定は mailpit）
   let context: BrowserContext;
   let page: Page;
 
   let confirmToken: string;
   let registrationToken: string;
   let authorizationCode: string;
-  const messageIds: string[] = [];
 
   // PKCE。authenticate/verify で認可コードに challenge を束縛し、/token で verifier を提示する。
   const { codeVerifier, codeChallenge } = generatePkcePair();
@@ -68,7 +66,7 @@ test.describe.serial('Account 申込フローの E2E テスト', () => {
       ignoreHTTPSErrors: true,
       extraHTTPHeaders: { Host: accountsHost },
     });
-    mailpitCtx = await request.newContext();
+    mailbox = await createMailbox();
 
     context = await browser.newContext({ ignoreHTTPSErrors: true });
     await context.credentials.install();
@@ -101,10 +99,14 @@ test.describe.serial('Account 申込フローの E2E テスト', () => {
   });
 
   test.afterAll(async () => {
-    await deleteMessages(mailpitCtx, messageIds);
-    await apiAccounts?.dispose();
-    await mailpitCtx?.dispose();
-    await context?.close();
+    // 後始末は互いに独立させる。cleanup はネットワーク越しになりうるので、
+    // ここが投げると以降の dispose / close が丸ごとスキップされ、リソースが残る。
+    await Promise.allSettled([
+      mailbox?.cleanup(email),
+      apiAccounts?.dispose(),
+      context?.close(),
+    ]);
+    await mailbox?.dispose();
   });
 
   test('申込リクエスト（202 Accepted）', async () => {
@@ -128,11 +130,10 @@ test.describe.serial('Account 申込フローの E2E テスト', () => {
   test('確認メール受信 → トークン抽出 → confirm（200・登録トークン発行）', async () => {
     test.setTimeout(30000);
 
-    const message = await waitForMessage(mailpitCtx, email, { subjectIncludes: 'お申し込み確認' });
-    messageIds.push(message.ID);
-    expect(message.Subject).toContain('お申し込み確認');
+    const message = await mailbox.waitForMessage(email, { subjectIncludes: 'お申し込み確認' });
+    expect(message.subject).toContain('お申し込み確認');
 
-    confirmToken = extractToken(message.Text || message.HTML);
+    confirmToken = extractToken(message.text || message.html);
     expect(confirmToken.length).toBeGreaterThan(10);
 
     const response = await apiAccounts.post(`${baseUrl}/api/signup/confirm`, {

--- a/E2ETests/tests/specs/account_signup_flow.spec.ts
+++ b/E2ETests/tests/specs/account_signup_flow.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, BrowserContext, Page, APIRequestContext, request } from '@playwright/test';
-import { createMailbox, extractToken, Mailbox } from '../helpers/mailbox';
+import { createMailbox, extractTokenFromMessage, Mailbox } from '../helpers/mailbox';
 import { generatePkcePair } from '../helpers/pkce';
 
 /**
@@ -133,7 +133,7 @@ test.describe.serial('Account 申込フローの E2E テスト', () => {
     const message = await mailbox.waitForMessage(email, { subjectIncludes: 'お申し込み確認' });
     expect(message.subject).toContain('お申し込み確認');
 
-    confirmToken = extractToken(message.text || message.html);
+    confirmToken = extractTokenFromMessage(message);
     expect(confirmToken.length).toBeGreaterThan(10);
 
     const response = await apiAccounts.post(`${baseUrl}/api/signup/confirm`, {

--- a/E2ETests/tests/specs/account_signup_flow.spec.ts
+++ b/E2ETests/tests/specs/account_signup_flow.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, BrowserContext, Page, APIRequestContext, request } from '@playwright/test';
-import { waitForMessage, extractToken, deleteMessages } from '../helpers/mailpit';
+import { waitForMessage, deleteMessages } from '../helpers/mailpit';
+import { extractToken } from '../helpers/mailbox';
 import { generatePkcePair } from '../helpers/pkce';
 
 /**

--- a/E2ETests/tests/specs/eccube_plugin_signup_login.spec.ts
+++ b/E2ETests/tests/specs/eccube_plugin_signup_login.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, APIRequestContext, BrowserContext, Page, request } from '@playwright/test';
 import { signupAndGetAccountToken, fetchSignupClient } from '../helpers/accounts';
-import { deleteMessages } from '../helpers/mailpit';
+import { createMailbox, Mailbox } from '../helpers/mailbox';
 import {
   EcCubeAdmin,
   eccube4Admin,
@@ -99,11 +99,9 @@ for (const variant of VARIANTS) {
     const email = `${expectedOrgCode}@e2e.ec-auth.io`;
 
     let apiAccounts: APIRequestContext;
-    let mailpitCtx: APIRequestContext;
+    let mailbox: Mailbox;
     let context: BrowserContext;
     let page: Page;
-
-    const messageIds: string[] = [];
 
     let accessToken: string;
     let clientId: string;
@@ -122,7 +120,7 @@ for (const variant of VARIANTS) {
         ignoreHTTPSErrors: true,
         extraHTTPHeaders: { Host: accountsHost },
       });
-      mailpitCtx = await request.newContext();
+      mailbox = await createMailbox();
 
       context = await browser.newContext({ ignoreHTTPSErrors: true });
       await context.credentials.install();
@@ -143,16 +141,16 @@ for (const variant of VARIANTS) {
     });
 
     test.afterAll(async () => {
-      await deleteMessages(mailpitCtx, messageIds);
+      await mailbox?.cleanup(email);
+      await mailbox?.dispose();
       await apiAccounts?.dispose();
-      await mailpitCtx?.dispose();
       await context?.close();
     });
 
     test('申込 → 確認 → Account トークン取得', async () => {
       test.setTimeout(120000);
 
-      const result = await signupAndGetAccountToken(apiAccounts, mailpitCtx, context, {
+      const result = await signupAndGetAccountToken(apiAccounts, mailbox, context, {
         baseUrl,
         accountsHost,
         accountsPageBaseUrl,
@@ -165,7 +163,6 @@ for (const variant of VARIANTS) {
       });
 
       accessToken = result.accessToken;
-      messageIds.push(result.messageId);
       expect(accessToken).toBeTruthy();
     });
 

--- a/E2ETests/tests/specs/eccube_plugin_signup_login.spec.ts
+++ b/E2ETests/tests/specs/eccube_plugin_signup_login.spec.ts
@@ -141,10 +141,9 @@ for (const variant of VARIANTS) {
     });
 
     test.afterAll(async () => {
-      await mailbox?.cleanup(email);
+      // 後始末は互いに独立させる（cleanup の失敗で dispose / close を落とさない）。
+      await Promise.allSettled([mailbox?.cleanup(email), apiAccounts?.dispose(), context?.close()]);
       await mailbox?.dispose();
-      await apiAccounts?.dispose();
-      await context?.close();
     });
 
     test('申込 → 確認 → Account トークン取得', async () => {

--- a/E2ETests/tests/specs/signup_client_b2b_login.spec.ts
+++ b/E2ETests/tests/specs/signup_client_b2b_login.spec.ts
@@ -129,11 +129,16 @@ test.describe.serial('申込で作られた Client での B2B パスキーログ
   });
 
   test.afterAll(async () => {
-    await mailbox?.cleanup(email);
+    // 後始末は互いに独立させる。cleanup はデプロイ済み環境ではネットワーク越し
+    // （Cloudflare Worker）になるため、ここが投げると以降の dispose / close が
+    // 丸ごとスキップされ、CI ワーカーにリソースが残る。
+    await Promise.allSettled([
+      mailbox?.cleanup(email),
+      apiAccounts?.dispose(),
+      apiTenant?.dispose(),
+      context?.close(),
+    ]);
     await mailbox?.dispose();
-    await apiAccounts?.dispose();
-    await apiTenant?.dispose();
-    await context?.close();
   });
 
   test('申込 → 確認 → Account トークン取得', async () => {

--- a/E2ETests/tests/specs/signup_client_b2b_login.spec.ts
+++ b/E2ETests/tests/specs/signup_client_b2b_login.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, APIRequestContext, BrowserContext, Page, request } from '
 import { randomUUID } from 'crypto';
 import { signupAndGetAccountToken, fetchSignupClient } from '../helpers/accounts';
 import { registerB2BPasskey, authenticateB2BPasskey } from '../helpers/b2b-passkey';
-import { deleteMessages } from '../helpers/mailpit';
+import { createMailbox, Mailbox } from '../helpers/mailbox';
 import { generatePkcePair } from '../helpers/pkce';
 
 /**
@@ -20,22 +20,39 @@ import { generatePkcePair } from '../helpers/pkce';
  *
  * プラグインの実構成に合わせて、2 つの経路を分けて再現する:
  *   - **ブラウザ**は店舗のホスト（= rp_id）で開く。WebAuthn が origin と rp_id の一致を
- *     要求するためで、ページ自体は origin を持ち込むためだけに使う（/healthz を開く）
- *   - **API 呼び出し**は Host: {tenant_name}.ec-auth.io で行う。プラグインは
+ *     要求するためで、ページ自体は origin を持ち込むためだけに使う（中身は stub）
+ *   - **API 呼び出し**は {tenant_name} のホスト宛に行う。プラグインは
  *     /platform/v1/client-resolve が返す https://{tenant_name}.ec-auth.io を保存して
- *     そこへ送るため（ClientResolveController:61）。この Host によって EcAuth 側の
+ *     そこへ送るため（ClientResolveController:61）。このホストによって EcAuth 側の
  *     グローバルクエリフィルタが顧客 Organization の行に一致する
  *
  * サイトホストに .test を使うのは、RFC 6761 の予約 TLD で公開解決されず、実在ドメインと
- * 衝突しないため。本番 DB に残ってもテストデータであることが明確になる。
+ * 衝突しないため。DB に残ってもテストデータであることが明確になる。
  * 申込 URL にポート 8081 を含めることで、redirect_uri にポートが引き継がれることも同時に検証する。
+ *
+ * ## 実行先の切り替え
+ *
+ * 既定はローカル Docker（1 つの IdP に Host ヘッダでテナントを解決させる）。
+ * E2E_TENANT_BASE_DOMAIN を設定すると **デプロイ済み環境モード** になり、テナント解決を
+ * Host ヘッダの差し替えではなく実ホスト名で行う（Cloudflare 配下では SNI と Host の
+ * 不一致を避ける必要があり、オリジンへの直アクセスも許可 IP で塞がれているため）。
+ * 本番向けの設定値は .github/workflows/production.yml の verify ジョブを参照。
  */
 test.describe.serial('申込で作られた Client での B2B パスキーログイン', () => {
+  // 設定されていればデプロイ済み環境モード（例: ec-auth.io）。
+  const tenantBaseDomain = process.env.E2E_TENANT_BASE_DOMAIN;
+  const remote = Boolean(tenantBaseDomain);
+
   const baseUrl = process.env.E2E_BASE_URL || 'https://localhost:8081';
-  const accountsHost = process.env.E2E_ACCOUNTS_HOST || 'accounts.ec-auth.io';
-  const accountsPageBaseUrl = process.env.E2E_ACCOUNTS_PAGE_URL || `https://${accountsHost}:8081`;
+  const accountsHost =
+    process.env.E2E_ACCOUNTS_HOST || (remote ? `stg-accounts.${tenantBaseDomain}` : 'accounts.ec-auth.io');
+  const accountsPageBaseUrl =
+    process.env.E2E_ACCOUNTS_PAGE_URL || (remote ? `https://${accountsHost}` : `https://${accountsHost}:8081`);
   const accountsClientId = process.env.ACCOUNTS_CLIENT_ID || 'ecauth-admin-console';
-  const accountsRedirectUri = process.env.ACCOUNTS_REDIRECT_URI || 'https://localhost:8081/auth/callback';
+  const accountsClientSecret = process.env.ACCOUNTS_CLIENT_SECRET || undefined;
+  const accountsRedirectUri =
+    process.env.ACCOUNTS_REDIRECT_URI ||
+    (remote ? `https://${accountsHost}/auth/callback` : 'https://localhost:8081/auth/callback');
 
   // run ごとに一意化して、前回 run の残存データとの衝突を避ける。
   const runSuffix = `${Date.now()}-${Math.floor(Math.random() * 1000)}`;
@@ -46,17 +63,17 @@ test.describe.serial('申込で作られた Client での B2B パスキーログ
   // Organization code は host から導出される（[^a-z0-9]+ → '-'）。
   const expectedOrgCode = siteHost.replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
 
-  let apiAccounts: APIRequestContext; // Host=accounts（申込 API とコンソールのトークン交換用）
-  // Host=<tenant_name>.ec-auth.io。プラグインのサーバー側呼び出しを模す。
-  // プラグインは /platform/v1/client-resolve が返す https://<tenant_name>.ec-auth.io を
-  // ecauth_base_url として保存し、以降の API をそこへ送る（ClientResolveController:61）。
-  // Host にテナントが載ることで EcAuth 側のクエリフィルタが顧客 Organization に一致する。
-  let apiTenant: APIRequestContext;
-  let mailpitCtx: APIRequestContext;
+  // 申込 API / トークン交換の宛先。ローカルは 1 つの IdP に Host ヘッダでテナントを解決させる。
+  const accountsApiBaseUrl = remote ? `https://${accountsHost}` : baseUrl;
+  // プラグインのサーバー側呼び出しの宛先。プラグインは /platform/v1/client-resolve が返す
+  // https://{tenant_name}.ec-auth.io を ecauth_base_url として保存し、以降の API をそこへ送る。
+  const tenantApiBaseUrl = remote ? `https://${expectedOrgCode}.${tenantBaseDomain}` : baseUrl;
+
+  let apiAccounts: APIRequestContext; // accounts テナント（申込 API とコンソールのトークン交換用）
+  let apiTenant: APIRequestContext; // 顧客テナント（プラグインのサーバー側呼び出しを模す）
+  let mailbox: Mailbox;
   let context: BrowserContext;
   let sitePage: Page;
-
-  const messageIds: string[] = [];
 
   // 申込で発行され、API 経由で取得する値。テスト側では一切組み立てない。
   let clientId: string;
@@ -70,16 +87,30 @@ test.describe.serial('申込で作られた Client での B2B パスキーログ
   let accessToken: string;
   let authorizationCode: string;
 
+  // この筋書きはリトライできない。申込は組織コードの重複を弾き
+  // （SignupService の organization_already_exists）、組織コードは収集時に確定する
+  // siteHost から導出されるため、リトライしても必ず同じコードになる。
+  // config の retries（CI では 2）のままだと、後段の失敗がリトライのたびに
+  // organization_already_exists に化けて本当の失敗理由が隠れる。
+  test.describe.configure({ retries: 0 });
+
   test.beforeAll(async ({ browser }) => {
+    // 作られた Organization はデプロイ済み環境では DB に残る（クリーンアップは EcAuth#487）。
+    // 後から特定できるよう、run ごとの識別子をログに残す。
+    console.log(
+      `[signup-smoke] mode=${remote ? 'remote' : 'local'} org_code=${expectedOrgCode} email=${email} ` +
+        `accounts=${accountsApiBaseUrl} tenant=${tenantApiBaseUrl}`
+    );
+
     apiAccounts = await request.newContext({
       ignoreHTTPSErrors: true,
-      extraHTTPHeaders: { Host: accountsHost },
+      ...(remote ? {} : { extraHTTPHeaders: { Host: accountsHost } }),
     });
     apiTenant = await request.newContext({
       ignoreHTTPSErrors: true,
-      extraHTTPHeaders: { Host: `${expectedOrgCode}.ec-auth.io` },
+      ...(remote ? {} : { extraHTTPHeaders: { Host: `${expectedOrgCode}.ec-auth.io` } }),
     });
-    mailpitCtx = await request.newContext();
+    mailbox = await createMailbox();
 
     context = await browser.newContext({ ignoreHTTPSErrors: true });
     await context.credentials.install();
@@ -88,24 +119,34 @@ test.describe.serial('申込で作られた Client での B2B パスキーログ
     await context.route(/\/mypage\//, (route) =>
       route.fulfill({ status: 200, contentType: 'text/html', body: '<html><body>mypage stub</body></html>' })
     );
+
+    // 疑似サイトのオリジンは WebAuthn の origin を持ち込むためだけに使うので、中身は要らない。
+    // 実体を持たせないことで実行先に依存しなくなる: .test は公開解決されず、
+    // デプロイ済み環境ではオリジンへの直アクセスも Cloudflare の許可 IP で塞がれている。
+    await context.route(`https://${siteHost}/**`, (route) =>
+      route.fulfill({ status: 200, contentType: 'text/html', body: '<html><body>shop origin stub</body></html>' })
+    );
   });
 
   test.afterAll(async () => {
-    await deleteMessages(mailpitCtx, messageIds);
+    await mailbox?.cleanup(email);
+    await mailbox?.dispose();
     await apiAccounts?.dispose();
     await apiTenant?.dispose();
-    await mailpitCtx?.dispose();
     await context?.close();
   });
 
   test('申込 → 確認 → Account トークン取得', async () => {
-    test.setTimeout(90000);
+    // デプロイ済み環境では SendGrid 送信 → Inbound Parse → Workers KV（結果整合）を
+    // 経るため、確認メールが読めるまでローカルより時間がかかる。
+    test.setTimeout(remote ? 300000 : 90000);
 
-    const result = await signupAndGetAccountToken(apiAccounts, mailpitCtx, context, {
-      baseUrl,
+    const result = await signupAndGetAccountToken(apiAccounts, mailbox, context, {
+      baseUrl: accountsApiBaseUrl,
       accountsHost,
       accountsPageBaseUrl,
       accountsClientId,
+      accountsClientSecret,
       accountsRedirectUri,
       email,
       organizationName: `E2E Plugin Org ${runSuffix}`,
@@ -114,12 +155,11 @@ test.describe.serial('申込で作られた Client での B2B パスキーログ
     });
 
     accessToken = result.accessToken;
-    messageIds.push(result.messageId);
     expect(accessToken).toBeTruthy();
   });
 
   test('マイページと同じ経路で client_id / client_secret を取得する', async () => {
-    const client = await fetchSignupClient(apiAccounts, baseUrl, accessToken, expectedOrgCode);
+    const client = await fetchSignupClient(apiAccounts, accountsApiBaseUrl, accessToken, expectedOrgCode);
 
     clientId = client.clientId;
     clientSecret = client.clientSecret;
@@ -139,14 +179,12 @@ test.describe.serial('申込で作られた Client での B2B パスキーログ
   test('サイトのオリジンでパスキーを登録する', async () => {
     test.setTimeout(60000);
 
-    // WebAuthn は rp_id と origin の一致を要求する。申込サイトのホストで IdP を開き、
-    // プラグインが動くのと同じ origin からセレモニーを実行する。
-    // /healthz は 200 を返し、テナントにも静的ファイル配信設定にも依存しない。
+    // WebAuthn は rp_id と origin の一致を要求する。申込サイトのホストでページを開き、
+    // プラグインが動くのと同じ origin からセレモニーを実行する（中身は beforeAll の stub）。
     sitePage = await context.newPage();
-    const response = await sitePage.goto(`https://${siteHost}:8081/healthz`);
-    expect(response?.status(), 'サイトホストで IdP に到達できません').toBe(200);
+    await sitePage.goto(`https://${siteHost}/`);
 
-    const result = await registerB2BPasskey({ api: apiTenant, apiBaseUrl: baseUrl, page: sitePage }, {
+    const result = await registerB2BPasskey({ api: apiTenant, apiBaseUrl: tenantApiBaseUrl, page: sitePage }, {
       clientId,
       clientSecret,
       // rp_id もテスト側で組み立てず、申込サイトのホストをそのまま使う。
@@ -166,7 +204,7 @@ test.describe.serial('申込で作られた Client での B2B パスキーログ
     test.setTimeout(60000);
 
     const state = `e2e-b2b-${runSuffix}`;
-    const result = await authenticateB2BPasskey({ api: apiTenant, apiBaseUrl: baseUrl, page: sitePage }, {
+    const result = await authenticateB2BPasskey({ api: apiTenant, apiBaseUrl: tenantApiBaseUrl, page: sitePage }, {
       clientId,
       rpId: siteHost,
       // API から取得した登録済みの値をそのまま使う。組み立てない。
@@ -187,7 +225,7 @@ test.describe.serial('申込で作られた Client での B2B パスキーログ
 
   test('認可コードをトークンに交換できる', async () => {
     // トークン交換もプラグインと同じくテナントのホスト宛に行う。
-    const response = await apiTenant.post(`${baseUrl}/v1/token`, {
+    const response = await apiTenant.post(`${tenantApiBaseUrl}/v1/token`, {
       form: {
         client_id: clientId,
         client_secret: clientSecret,

--- a/E2ETests/tests/specs/website_signup_flow.spec.ts
+++ b/E2ETests/tests/specs/website_signup_flow.spec.ts
@@ -1,6 +1,5 @@
-import { test, expect, BrowserContext, Page, APIRequestContext, request } from '@playwright/test';
-import { waitForMessage, deleteMessages } from '../helpers/mailpit';
-import { extractToken } from '../helpers/mailbox';
+import { test, expect, BrowserContext, Page } from '@playwright/test';
+import { createMailbox, extractToken, Mailbox } from '../helpers/mailbox';
 
 /**
  * ecauth-website（ec-auth.io）のフロントを実バックエンドに通すフル結合 E2E。
@@ -49,17 +48,16 @@ test.describe.serial('ecauth-website フロント × EcAuth 実バックエン�
   const productionSiteHost = `web-${runSuffix}.example.com`;
   const expectedOrgCode = productionSiteHost.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
 
-  let mailpitCtx: APIRequestContext;
+  let mailbox: Mailbox;
   let context: BrowserContext;
   let page: Page;
 
   let confirmToken: string;
-  const messageIds: string[] = [];
 
   test.beforeAll(async ({ browser }) => {
     // 本 spec は全経路をブラウザ（フロント）から通すため、API 直叩き用のコンテキストは持たない。
-    // mailpit だけは REST でメール本文を読む必要がある。
-    mailpitCtx = await request.newContext();
+    // 確認メールの本文だけは受信口から読む必要がある。
+    mailbox = await createMailbox();
 
     context = await browser.newContext({ ignoreHTTPSErrors: true });
     await context.credentials.install();
@@ -94,9 +92,9 @@ test.describe.serial('ecauth-website フロント × EcAuth 実バックエン�
   });
 
   test.afterAll(async () => {
-    await deleteMessages(mailpitCtx, messageIds);
-    await mailpitCtx?.dispose();
-    await context?.close();
+    // 後始末は互いに独立させる（cleanup の失敗で dispose / close を落とさない）。
+    await Promise.allSettled([mailbox?.cleanup(email), context?.close()]);
+    await mailbox?.dispose();
   });
 
   test('申込フォーム（/signup/）から実 API に申し込め、確認メールの URL がフロントを指す', async () => {
@@ -115,11 +113,10 @@ test.describe.serial('ecauth-website フロント × EcAuth 実バックエン�
     await expect(status).toHaveClass(/ok/, { timeout: 15000 });
     await expect(status).toContainText('確認メールを送信しました');
 
-    const message = await waitForMessage(mailpitCtx, email, { subjectIncludes: 'お申し込み確認' });
-    messageIds.push(message.ID);
+    const message = await mailbox.waitForMessage(email, { subjectIncludes: 'お申し込み確認' });
 
     // Signup:ConfirmBaseUrl がフロントに向いていること（バックエンド→フロントの URL 契約）。
-    const body = message.Text || message.HTML;
+    const body = message.text || message.html;
     expect(body).toContain(`${websiteBase}/signup/confirm?token=`);
 
     confirmToken = extractToken(body);
@@ -250,11 +247,10 @@ test.describe.serial('ecauth-website フロント × EcAuth 実バックエン�
     await page.click('#submit-btn');
     await expect(page.locator('#status')).toHaveClass(/ok/, { timeout: 15000 });
 
-    const mail = await waitForMessage(mailpitCtx, email, { subjectIncludes: 'ログインリンク' });
-    messageIds.push(mail.ID);
+    const mail = await mailbox.waitForMessage(email, { subjectIncludes: 'ログインリンク' });
 
     // MagicLink:BaseUrl がフロントに向いていること。
-    const body = mail.Text || mail.HTML;
+    const body = mail.text || mail.html;
     expect(body).toContain(`${websiteBase}/signin/magic-link?token=`);
     const magicToken = extractToken(body);
 

--- a/E2ETests/tests/specs/website_signup_flow.spec.ts
+++ b/E2ETests/tests/specs/website_signup_flow.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, BrowserContext, Page, APIRequestContext, request } from '@playwright/test';
-import { waitForMessage, extractToken, deleteMessages } from '../helpers/mailpit';
+import { waitForMessage, deleteMessages } from '../helpers/mailpit';
+import { extractToken } from '../helpers/mailbox';
 
 /**
  * ecauth-website（ec-auth.io）のフロントを実バックエンドに通すフル結合 E2E。


### PR DESCRIPTION
## 背景

EcAuth#481（申込が登録する初期値とプラグインが送る値のズレ）は、E2E の抜け漏れで本番に出た。
PR #489 でその経路は CI に入ったが、CI が守るのは **コードの整合性** だけで、
**デプロイ済み環境の設定が実際の認証フローと噛み合っているか** は誰も検証していない。

`PlatformApi:BaseDomain`、テナント解決、`Signup__ConfirmBaseUrl__*`、SendGrid 送信 —
どれも環境ごとの設定であり、CI では踏めない。ここを本番デプロイ後の verify で埋める。

## 変更

### 1. 確認メールの受信口を抽象化する（`tests/helpers/mailbox.ts`）

| 環境 | `E2E_MAILBOX_KIND` | 実装 |
|---|---|---|
| ローカル / CI | `mailpit`（既定） | `helpers/mailpit.ts` |
| production | `e2e-mailbox` | `helpers/e2e-mailbox.ts`（Cloudflare Worker） |

後始末が「ID の配列」ではなく `cleanup(宛先)` なのは、Worker 側が宛先単位でしか削除できないため
（1 メッセージ 1 キーで保存し ID を返さない）。mailpit 実装は全 spec 共有インスタンスを壊さないよう、
**自分が読んだ ID だけ** を覚えて消す。

Workers KV は結果整合なので、`e2e-mailbox` の既定タイムアウトは 180 秒（mailpit は 20 秒）。

### 2. `signup_client_b2b_login.spec.ts` を実行先に依存しない形にする

- `E2E_TENANT_BASE_DOMAIN` を設定すると **実ホスト名** でテナントを解決する。
  Cloudflare 配下では SNI と Host の不一致が使えず、オリジンへの直アクセスも
  許可 IP で塞がれている（`environments/production/main.tf` の `cloudflare_ip_restrictions`）。
- 疑似サイトのオリジンは `context.route` で stub。`.test` は公開解決されないため実体を持たせない。
- accounts の callback も stub。本番では実在のホストを指すため、SPA が同じ code を
  別の `code_verifier` で交換しに行くのを防ぐ。
- **`retries: 0` を明示**。申込は組織コードの重複を弾くので、リトライすると後段の失敗が
  `organization_already_exists` に化けて本当の原因が隠れる（#489 の EC-CUBE 版と同じ理由）。

### 3. 管理コンソール Client が confidential でも通るようにする

`STG_ACCOUNTS_CLIENT_PUBLIC` は設定されていない（`production/main.tf:339-342` にキーが無い）ため、
stg-accounts の Client は confidential。PKCE だけだと「client_secretが正しくありません。」で落ちる。
`accountsClientSecret` を指定したときだけトークン交換に添える。**本番の設定は変えない。**

### 4. `production.yml` / `staging.yml` に `action=verify-only` を追加

migrate / build / deploy を skip して `verify` だけを回す入口。
ecauth-infrastructure の apply 後に外から叩くためのもの（EcAuth/ecauth-infrastructure#136）。

## 決めごと

| 事項 | 決め |
|---|---|
| 申込先テナント | `stg-accounts`。本物の顧客が入る `accounts` は汚さない |
| 対象 spec | 軽量版（`signup_client_b2b_login`）のみ。EC-CUBE 実物版はイメージビルドで 10 分前後かかり、本番 DB に残る Organization も run あたり 2 倍になるため CI 側に任せる |
| staging | **入れられない**。`AccountsOrganizationSeeder.cs:17` のとおり Account 機能は本番のみで、`environments/staging/main.tf` に `ACCOUNTS_*` / `STG_ACCOUNTS_*` が無い。つまり申込 API 自体が存在しない |

## 既知の副作用

このスモークは本番 DB に Organization / Client / B2BUser / パスキーを **1 run あたり 1 組** 残す。
クリーンアップは #487 で未着手。それまでは識別子（`e2e-{timestamp}-{rand}-test`）を手掛かりに手で消す。
識別子は Playwright 出力の先頭 `[signup-smoke]` 行と `verify` ジョブの Step Summary に出る。

## 検証

- [x] `signup_client_b2b_login.spec.ts` ローカル 5 passed（route stub / mailbox 抽象の回帰確認）
- [x] `account_signup_flow` + `account_magic_link_flow` ローカル 8 passed（`extractToken` 移動の回帰確認）
- [x] `eccube_plugin_signup_login.spec.ts` ローカル 12 passed（4系 / 2系、mailbox 抽象の回帰確認）
- [x] 3 ワークフローの YAML パース
- [ ] **本番に対する `action=verify-only` の手動実行** — マージ前にこのブランチを ref にして 1 回実行する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 本番・ステージング環境で、デプロイを行わず検証のみ実行できるようになりました。
  - 本番環境で、申込からメール確認、B2Bパスキー認証までを自動検証するスモークテストを追加しました。
  - 環境に応じたメール受信方式に対応し、確認メールの処理を安定化しました。

- **改善**
  - 検証結果をジョブの概要とログで確認できるようになりました。
  - 本番環境でのテナント解決や認可フローを含む申込検証の信頼性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## 残留データの特定（#487 までの暫定手順）

削除 SQL は**あえて載せない**。`OnDelete` は `Cascade` と `Restrict` が混在しており
（`EcAuthDbContextModelSnapshot.cs`）、`organization` の単純削除では Restrict の FK に阻まれる。
手書きの削除順を未検証のまま本番向けに配ると事故る。削除は #487 のコマンドに任せる。

それまでは、この読み取り専用クエリで「何が残ったか」を把握する。

```sql
-- E2E スモークが作った Organization と Client を一覧する
SELECT o.id AS org_id, o.code, o.created_at,
       c.id AS client_id, c.client_id, c.allowed_rp_ids
FROM   dbo.organization o
LEFT   JOIN dbo.client c ON c.organization_id = o.id
WHERE  o.code LIKE 'e2e-%-test'
ORDER  BY o.created_at DESC;
```

`o.code` は `e2e-{timestamp}-{rand}-test` の形。個々の run の識別子は
`verify` ジョブの Step Summary に出る `[signup-smoke]` 行にも記録される。
