### PR TITLE
fix: 結合 E2E で入ったプラグインのバージョンを成功時にも記録する

### DIFF
--- a/.github/workflows/eccube_plugin_e2e.yml
+++ b/.github/workflows/eccube_plugin_e2e.yml
@@ -187,6 +187,22 @@ jobs:
           GITHUB_USERNAME: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.ORG_PAT || secrets.PACKAGES_READ_TOKEN }}
 
+      # 入ったプラグインの出どころとバージョンを **成功時にも** 残す。
+      # install_source=package-api で回す目的は「オーナーズストアが実際に配布する版が
+      # 動くか」を確かめることなので、その版が何だったかが記録に残らないと目的を果たせない。
+      # 失敗時のログ回収（Collect logs on failure）だけでは、成功した run で捨ててしまう。
+      - name: Record installed plugin version
+        if: ${{ !cancelled() }}
+        run: |
+          {
+            echo "### インストールされたプラグイン"
+            echo '```'
+            ./E2ETests/scripts/eccube-e2e.sh logs --no-log-prefix ec-cube4 2>/dev/null \
+              | grep -iE 'Installing EcAuthLogin43|already installed|ecauthlogin43 \(' \
+              || echo '(該当ログなし)'
+            echo '```'
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+
       - name: Run EC-CUBE plugin E2E
         run: ./E2ETests/scripts/eccube-e2e.sh test tests/specs/eccube_plugin_signup_login.spec.ts --reporter=list
 


### PR DESCRIPTION
## 背景

v1.0.1 承認後に `install_source=package-api` で検証実行された
[runs/30605353250](https://github.com/EcAuth/EcAuth/actions/runs/30605353250) を確認したところ、
**「どのバージョンが入ったか」が run から追えない** ことが分かりました。

ログから確認できたのはここまでです:

- `Load EC-CUBE verification key from 1Password` ステップが実行された → 入力は `package-api`
- `ECCUBE_AUTHENTICATION_KEY` が populate された（マスク済み）
- `ECAUTH_PLUGIN_VERSION` は空（latest）
- `12 passed (22.3s)`

インストール自体が成功したことは確実です。`docker-entrypoint.sh` は `set -eo pipefail` で、
`eccube:composer:require` → `plugin:enable` → `cache:warmup` を `exec "$@"`（Apache 起動）より
**前**に実行するため、失敗すれば Apache が上がらず `/admin/login` の起動待ちでステップごと落ちます。
この分岐にローカルソースへのフォールバックもありません。

ただし **バージョンは分かりません**。コンテナログの回収が `Collect logs on failure` だけで、
成功した run では捨てているためです。検証キー経由で回す目的が
「オーナーズストアが実際に配布する版が動くか」の確認である以上、これは目的を果たせていません。

## 変更

`up` の直後に ec-cube4 のコンテナログからインストール元とバージョンを抜き出し、
Step Summary に残します。composer の出力がそのまま根拠になります。

手元のログで抽出結果を確認済み:

```
Installing EcAuthLogin43 from /plugin (local source)...
[52.8MiB/0.56s]   - Locking ec-cube/ecauthlogin43 (1.0.1)
[55.2MiB/0.60s]   - Installing ec-cube/ecauthlogin43 (1.0.1): Symlinking from /plugin
```

package-api 経由なら `from package-api (version: latest)` と、実際に解決されたバージョンが出ます。

## 関連

`docker-entrypoint.sh` 側にも問題があり、別 PR で対応します（EcAuth/ec-cube4-ecauth）。
`bin/console eccube:plugin:list` は **EC-CUBE 4.3 に存在しないコマンド** で、
導入済み判定と最終のバージョン記録がどちらも空振りしています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * EC-CUBEプラグインのE2Eテスト結果に、インストール済みプラグインの出どころとバージョン情報が記録されるようになりました。
  * 実行結果のジョブサマリーから、テスト環境のプラグイン情報を確認できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->