### PR TITLE
fix: 認証メールで SendGrid のトラッキングを無効化する

### DIFF
--- a/IdentityProvider/Services/SendGridEmailService.cs
+++ b/IdentityProvider/Services/SendGridEmailService.cs
@@ -56,6 +56,7 @@ namespace IdentityProvider.Services
             var from = new EmailAddress(fromEmail, fromName);
             var to = new EmailAddress(toEmail);
             var message = MailHelper.CreateSingleEmail(from, to, content.Subject, content.PlainText, content.Html);
+            DisableTracking(message);
 
             var response = await client.SendEmailAsync(message, ct);
 
@@ -111,6 +112,7 @@ namespace IdentityProvider.Services
             var from = new EmailAddress(fromEmail, fromName);
             var to = new EmailAddress(toEmail);
             var message = MailHelper.CreateSingleEmail(from, to, content.Subject, content.PlainText, content.Html);
+            DisableTracking(message);
 
             var response = await client.SendEmailAsync(message, ct);
 
@@ -132,6 +134,33 @@ namespace IdentityProvider.Services
         /// ログ出力用にメールアドレスをマスクする。ローカル部の先頭 1 文字のみ残し、
         /// 残りを伏字にしたうえでドメインを保持する（例: <c>owner@example.com</c> → <c>o****@example.com</c>）。
         /// </summary>
+        /// <summary>
+        /// クリック / 開封トラッキングを明示的に無効化する。
+        /// <para>
+        /// このサービスが送るのは申込確認とマジックリンク、すなわち **認証トークンを含むメール**
+        /// だけである。SendGrid はアカウント既定でクリックトラッキングが有効なことが多く、
+        /// 有効だと本文中の URL が <c>https://&lt;id&gt;.ct.sendgrid.net/ls/click?upn=...</c> に
+        /// 書き換えられる。結果として:
+        /// </para>
+        /// <list type="bullet">
+        ///   <item>認証トークンが SendGrid のリダイレクタを経由し、クリックログに記録される</item>
+        ///   <item>受信者に見えるドメインが ec-auth.io ではなくなり、フィッシングと見分けにくくなる</item>
+        ///   <item>メールセキュリティ製品のリンク先読みがトークンを消費しうる</item>
+        /// </list>
+        /// <para>
+        /// トラッキングの利得（開封率・クリック率）はこの用途では不要なので、送信ごとに切る。
+        /// アカウント側の既定に依存しないよう、コードで明示する。
+        /// </para>
+        /// </summary>
+        private static void DisableTracking(SendGridMessage message)
+        {
+            message.TrackingSettings = new TrackingSettings
+            {
+                ClickTracking = new ClickTracking { Enable = false, EnableText = false },
+                OpenTracking = new OpenTracking { Enable = false },
+            };
+        }
+
         private static string MaskEmail(string? email)
         {
             if (string.IsNullOrWhiteSpace(email))


### PR DESCRIPTION
## 背景

本番の申込スモーク（EcAuth/EcAuth#491）の初回実行で発覚しました。
メール自体は 34.3 秒で受信できているのに、本文から確認トークンを取り出せませんでした。

原因を切り分けるため、**本番に申込リクエストだけを送って**（`confirm` はしないので
Organization は作られません）実際に届いたメールを確認しました。トークン値は伏せています:

```
subject: 【EcAuth】お申し込み確認のお願い
from:    EcAuth <noreply@ec-auth.io>

--- text ---
  https://u108901452.ct.sendgrid.net/ls/click?upn=<REDACTED>      ← token= が消えている

--- html ---
  https://u108901452.ct.sendgrid.net/ls/click?upn=<REDACTED>      ← <a href> も書き換え
  https://<...>.ec-auth.io/signup/confirm?token=<REDACTED>        ← リンクでない生テキストだけ残る
  https://u108901452.ct.sendgrid.net/wf/open?upn=<REDACTED>       ← 開封ピクセル
```

SendGrid のクリックトラッキングがアカウント既定で有効になっており、
`SendGridEmailService` は `TrackingSettings` を設定していないため、そのまま効いていました。

## なぜ直すべきか

このサービスが送るのは**申込確認とマジックリンクだけ**、つまり**認証トークンを含むメール**だけです。

- **認証トークンが SendGrid のリダイレクタを経由**し、クリックログに記録される。
  マジックリンクのトークンはアカウントへのアクセスを与える bearer credential なので、
  第三者のログに残ることは望ましくない
- **受信者に見えるドメインが `ec-auth.io` ではなくなる**。認証メールでこれはフィッシングと
  見分けにくく、教育上も不利
- **メールセキュリティ製品のリンク先読み**がトークンを消費しうる

開封率・クリック率の分析はこの用途では使っていません（リポジトリ内に消費側もありません）。

## 変更

送信ごとにクリック / 開封トラッキングを明示的に無効化します。アカウント側の既定に依存させません。

```csharp
message.TrackingSettings = new TrackingSettings
{
    ClickTracking = new ClickTracking { Enable = false, EnableText = false },
    OpenTracking = new OpenTracking { Enable = false },
};
```

申込確認・マジックリンクの両方に適用します。

## 検証

- [x] `dotnet build IdentityProvider/IdentityProvider.csproj` → 0 エラー（警告は既存のもののみ）
- [ ] 本番デプロイ後に、届いたメールの本文が `https://<...>.ec-auth.io/signup/confirm?token=` を
      直接含むこと（**未検証**。この修正は本番デプロイで初めて効きます）

## 関連

EcAuth/EcAuth#491 側では、**どちらの本文に生 URL が残るかに依存しない**トークン抽出
（`extractTokenFromMessage`: text → html の順に試す）を入れてあります。この PR がデプロイ
されれば text から素直に取れますが、E2E をメール配送の実装詳細に結びつけないため、
両方を残すのが妥当と考えています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)