### PR TITLE
feat: マイページから redirect_uri / allowed_rp_ids を更新できるようにする

### DIFF
--- a/E2ETests/tests/helpers/accounts.ts
+++ b/E2ETests/tests/helpers/accounts.ts
@@ -58,6 +58,8 @@ export interface SignupClient {
   organizationCode: string;
   /** 申込時に登録された redirect_uri。プラグインが送る値と完全一致する必要がある */
   redirectUris: string[];
+  /** 申込時に登録された allowed_rp_ids。ブラウザの origin と一致していなければ登録・認証が通らない */
+  allowedRpIds: string[];
 }
 
 /**
@@ -202,6 +204,7 @@ export async function fetchSignupClient(
     client_id: string;
     organization_code: string;
     redirect_uris: string[];
+    allowed_rp_ids: string[];
   }>;
 
   const client = clients.find((c) => c.organization_code === organizationCode);
@@ -227,6 +230,7 @@ export async function fetchSignupClient(
     clientSecret: (await revealResponse.json()).client_secret as string,
     organizationCode: client.organization_code,
     redirectUris: client.redirect_uris,
+    allowedRpIds: client.allowed_rp_ids ?? [],
   };
 }
 

--- a/E2ETests/tests/specs/eccube_plugin_signup_login.spec.ts
+++ b/E2ETests/tests/specs/eccube_plugin_signup_login.spec.ts
@@ -178,6 +178,9 @@ for (const variant of VARIANTS) {
       // プラグインは redirect_uri を自分で組み立てて送るため、テスト側が値を渡す余地が無く、
       // 一致しているかどうかは後段のパスキーログインが通るかどうかで現れる。
       expect(client.redirectUris).toContain(`${shopBaseUrl}${variant.callbackPath}`);
+      // rp_id も同じ理由で突き合わせる。プラグインはリクエストのホストから rp_id を作るため、
+      // 申込が登録した allowed_rp_ids に店舗のホストが含まれていなければ登録・認証が弾かれる。
+      expect(client.allowedRpIds).toContain(shopHost);
     });
 
     test('プラグイン設定に client_id / client_secret だけを入力して保存する', async () => {

--- a/E2ETests/tests/specs/signup_client_b2b_login.spec.ts
+++ b/E2ETests/tests/specs/signup_client_b2b_login.spec.ts
@@ -78,7 +78,9 @@ test.describe.serial('申込で作られた Client での B2B パスキーログ
   // 申込で発行され、API 経由で取得する値。テスト側では一切組み立てない。
   let clientId: string;
   let clientSecret: string;
+  let clientDbId: number;
   let registeredRedirectUri: string;
+  let registeredRpId: string;
 
   const b2bSubject = randomUUID();
   const externalId = `e2e-admin-${runSuffix}`;
@@ -166,6 +168,7 @@ test.describe.serial('申込で作られた Client での B2B パスキーログ
   test('マイページと同じ経路で client_id / client_secret を取得する', async () => {
     const client = await fetchSignupClient(apiAccounts, accountsApiBaseUrl, accessToken, expectedOrgCode);
 
+    clientDbId = client.id;
     clientId = client.clientId;
     clientSecret = client.clientSecret;
     expect(clientSecret).toBeTruthy();
@@ -178,7 +181,13 @@ test.describe.serial('申込で作られた Client での B2B パスキーログ
     // 暫定のトップ URL は登録しない（余分な許可を残さない）。
     expect(client.redirectUris).not.toContain(`https://${siteHost}:8081/`);
 
+    // rp_id 側も同じ突き合わせを行う。ブラウザが動く origin（= siteHost）が
+    // allowed_rp_ids に無ければ、options の時点でサーバーに弾かれる。
+    // 申込 URL は www 無しなので、登録されるのはこの 1 件だけ（www 付きなら除去版も入る）。
+    expect(client.allowedRpIds).toEqual([siteHost]);
+
     registeredRedirectUri = client.redirectUris.find((u) => u.endsWith('/ecauth/callback'))!;
+    registeredRpId = client.allowedRpIds[0];
   });
 
   test('サイトのオリジンでパスキーを登録する', async () => {
@@ -192,9 +201,10 @@ test.describe.serial('申込で作られた Client での B2B パスキーログ
     const result = await registerB2BPasskey({ api: apiTenant, apiBaseUrl: tenantApiBaseUrl, page: sitePage }, {
       clientId,
       clientSecret,
-      // rp_id もテスト側で組み立てず、申込サイトのホストをそのまま使う。
-      // allowed_rp_ids に含まれていなければサーバー側で弾かれる。
-      rpId: siteHost,
+      // rp_id もテスト側で組み立てず、API から取得した登録済みの値をそのまま使う。
+      // ブラウザは https://{siteHost} で開いているので、登録値がそことズレていれば
+      // WebAuthn の origin 検証で落ちる。
+      rpId: registeredRpId,
       b2bSubject,
       externalId,
       displayName: 'E2E Admin',
@@ -211,8 +221,8 @@ test.describe.serial('申込で作られた Client での B2B パスキーログ
     const state = `e2e-b2b-${runSuffix}`;
     const result = await authenticateB2BPasskey({ api: apiTenant, apiBaseUrl: tenantApiBaseUrl, page: sitePage }, {
       clientId,
-      rpId: siteHost,
-      // API から取得した登録済みの値をそのまま使う。組み立てない。
+      // redirect_uri / rp_id とも API から取得した登録済みの値をそのまま使う。組み立てない。
+      rpId: registeredRpId,
       redirectUri: registeredRedirectUri,
       b2bSubject,
       state,
@@ -252,5 +262,52 @@ test.describe.serial('申込で作られた Client での B2B パスキーログ
 
     const idPayload = JSON.parse(Buffer.from(body.id_token.split('.')[1], 'base64url').toString());
     expect(idPayload.sub).toBe(b2bSubject);
+  });
+
+  /**
+   * 申込の初期値が実利用と合わなかった場合（EcAuth#481 が起きた状況）に、顧客がマイページから
+   * 自分で直せることを検証する。ここが無いと復旧手段がサポート経由の DB 直接操作しかない。
+   */
+  test('マイページから redirect_uri / allowed_rp_ids を更新でき、更新後の値で認証が通る', async () => {
+    test.setTimeout(60000);
+
+    const headers = { Authorization: `Bearer ${accessToken}` };
+    // サブディレクトリへ移設した想定の新しいコールバック URL。
+    const updatedRedirectUri = `https://${siteHost}:8081/shop/ecauth/callback`;
+
+    const uriResponse = await apiAccounts.post(
+      `${accountsApiBaseUrl}/v1/account/clients/${clientDbId}/redirect-uris`,
+      { headers, data: { redirect_uris: [updatedRedirectUri] } }
+    );
+    expect(uriResponse.status(), await uriResponse.text()).toBe(200);
+    expect((await uriResponse.json()).redirect_uris).toEqual([updatedRedirectUri]);
+
+    // rp_id は登録済みパスキーが束縛されているので消さず、www 付きを足すだけにする。
+    const rpIdResponse = await apiAccounts.post(
+      `${accountsApiBaseUrl}/v1/account/clients/${clientDbId}/allowed-rp-ids`,
+      { headers, data: { allowed_rp_ids: [registeredRpId, `www.${registeredRpId}`] } }
+    );
+    expect(rpIdResponse.status(), await rpIdResponse.text()).toBe(200);
+
+    // マイページを開き直したときに見える値としても反映されていること。
+    const refreshed = await fetchSignupClient(apiAccounts, accountsApiBaseUrl, accessToken, expectedOrgCode);
+    expect(refreshed.redirectUris).toEqual([updatedRedirectUri]);
+    expect(refreshed.allowedRpIds).toEqual([registeredRpId, `www.${registeredRpId}`]);
+
+    // 更新後の redirect_uri で認証が通る = 完全一致検証が新しい値を見ている。
+    // 逆に旧値はもう通らない（全置換なので許可リストから消えている）。
+    const state = `e2e-b2b-updated-${runSuffix}`;
+    const result = await authenticateB2BPasskey({ api: apiTenant, apiBaseUrl: tenantApiBaseUrl, page: sitePage }, {
+      clientId,
+      rpId: registeredRpId,
+      redirectUri: updatedRedirectUri,
+      b2bSubject,
+      state,
+      codeChallenge,
+    });
+
+    const redirectUrl = new URL(result.redirect_url);
+    expect(`${redirectUrl.origin}${redirectUrl.pathname}`).toBe(updatedRedirectUri);
+    expect(redirectUrl.searchParams.get('code')).toBeTruthy();
   });
 });

--- a/IdentityProvider.Test/Controllers/AccountControllerTests.cs
+++ b/IdentityProvider.Test/Controllers/AccountControllerTests.cs
@@ -327,6 +327,52 @@ namespace IdentityProvider.Test.Controllers
             Assert.Equal(new[] { "https://shop1.example.jp/ecauth/callback" }, await StoredRedirectUris(10));
         }
 
+        [Theory]
+        // userinfo は https でも http でも弾かれるが、通る分岐が違う（前者は userinfo チェック、
+        // 後者は scheme チェック）。どちらの経路でもパスワードがレスポンスに出ないこと。
+        [InlineData("https://alice:hunter2@shop1.example.jp/cb")]
+        [InlineData("http://alice:hunter2@shop1.example.jp/cb")]
+        public async Task UpdateRedirectUris_UserInfo_DoesNotEchoCredentials(string uri)
+        {
+            await SeedOrgWithClient(1, "shop1", false, 10, "client-prod", "secret");
+            AuthenticateAsOwnerOf((1, "shop1"));
+
+            var result = await _controller.UpdateRedirectUris(10, new AccountController.RedirectUrisDto
+            {
+                RedirectUris = new List<string> { uri }
+            });
+
+            var unprocessable = Assert.IsType<UnprocessableEntityObjectResult>(result);
+            var description = (string)GetProp(unprocessable.Value!, "error_description");
+            // レスポンスはブラウザのエラーレポートやプロキシのログに残るため、入力値は載せない。
+            Assert.DoesNotContain("hunter2", description);
+            Assert.DoesNotContain("alice", description);
+            // どの入力欄かは位置で伝える
+            Assert.Contains("1 件目", description);
+        }
+
+        [Fact]
+        public async Task UpdateRedirectUris_TooLongAfterPunycode_Returns422()
+        {
+            await SeedOrgWithClient(1, "shop1", false, 10, "client-prod", "secret");
+            AuthenticateAsOwnerOf((1, "shop1"));
+
+            // IDN は Punycode 化で伸びる。入力はちょうど上限（2048）に収まるが、
+            // ホストが xn-- 形式になることで保存値は上限を超える。
+            var prefix = "https://日本語商店.example.jp/";
+            var uri = prefix + new string('a', 2048 - prefix.Length);
+            Assert.Equal(2048, uri.Length);
+
+            var result = await _controller.UpdateRedirectUris(10, new AccountController.RedirectUrisDto
+            {
+                RedirectUris = new List<string> { uri }
+            });
+
+            var unprocessable = Assert.IsType<UnprocessableEntityObjectResult>(result);
+            Assert.Contains("正規化後", (string)GetProp(unprocessable.Value!, "error_description"));
+            Assert.Empty(await StoredRedirectUris(10));
+        }
+
         [Fact]
         public async Task UpdateRedirectUris_EmptyList_Returns422()
         {

--- a/IdentityProvider.Test/Controllers/AccountControllerTests.cs
+++ b/IdentityProvider.Test/Controllers/AccountControllerTests.cs
@@ -58,7 +58,9 @@ namespace IdentityProvider.Test.Controllers
                 });
         }
 
-        private async Task SeedOrgWithClient(int orgId, string code, bool isSandbox, int clientDbId, string clientId, string secret)
+        private async Task SeedOrgWithClient(
+            int orgId, string code, bool isSandbox, int clientDbId, string clientId, string secret,
+            string[]? redirectUris = null, string[]? allowedRpIds = null)
         {
             _context.Organizations.Add(new Organization
             {
@@ -76,16 +78,41 @@ namespace IdentityProvider.Test.Controllers
                 ClientId = clientId,
                 ClientSecret = secret, // PlaintextSecretProtector 使用のため平文パススルー
                 AppName = code + " App",
-                OrganizationId = orgId
+                OrganizationId = orgId,
+                AllowedRpIds = (allowedRpIds ?? Array.Empty<string>()).ToList()
             });
+            foreach (var uri in redirectUris ?? Array.Empty<string>())
+            {
+                _context.RedirectUris.Add(new RedirectUri { ClientId = clientDbId, Uri = uri });
+            }
             await _context.SaveChangesAsync();
         }
+
+        /// <summary>管理対象 Organization を 1 件だけ持つ Account として認証済みの状態にする。</summary>
+        private void AuthenticateAsOwnerOf(params (int OrgId, string Code)[] orgs)
+        {
+            _mockAccountService.Setup(x => x.GetManagedOrganizationsAsync(AccountSubject))
+                .ReturnsAsync(orgs
+                    .Select(o => new IAccountService.ManagedOrganization(o.OrgId, o.Code, "owner"))
+                    .ToList());
+            SetupValidAccountToken();
+            SetBearer(AccountToken);
+        }
+
+        private async Task<List<string>> StoredRedirectUris(int clientDbId) =>
+            await _context.RedirectUris
+                .IgnoreQueryFilters()
+                .Where(r => r.ClientId == clientDbId)
+                .Select(r => r.Uri)
+                .ToListAsync();
 
         [Fact]
         public async Task GetClients_ValidAccountToken_ReturnsManagedClientsOnly()
         {
             // Arrange: org1(本番)/org2(テスト) は管理対象、org3 は非管理
-            await SeedOrgWithClient(1, "shop1", false, 10, "client-prod", "secret-prod");
+            await SeedOrgWithClient(1, "shop1", false, 10, "client-prod", "secret-prod",
+                redirectUris: new[] { "https://shop1.example.jp/ecauth/callback" },
+                allowedRpIds: new[] { "shop1.example.jp" });
             await SeedOrgWithClient(2, "shop1-test", true, 20, "client-test", "secret-test");
             await SeedOrgWithClient(3, "other", false, 30, "client-other", "secret-other");
 
@@ -114,6 +141,9 @@ namespace IdentityProvider.Test.Controllers
             Assert.Null(prod.GetType().GetProperty("client_secret"));
             Assert.True((bool)GetProp(prod, "has_secret"));
             Assert.False((bool)GetProp(prod, "is_sandbox"));
+            // マイページの編集 UI が現在値を出せるよう、一覧に allowed_rp_ids も含める
+            Assert.Equal(new[] { "https://shop1.example.jp/ecauth/callback" }, (string[])GetProp(prod, "redirect_uris"));
+            Assert.Equal(new[] { "shop1.example.jp" }, (string[])GetProp(prod, "allowed_rp_ids"));
         }
 
         [Fact]
@@ -219,6 +249,281 @@ namespace IdentityProvider.Test.Controllers
             SetBearer(null);
 
             var result = await _controller.RevealSecret(10);
+
+            Assert.IsType<UnauthorizedObjectResult>(result);
+        }
+
+        // ---- redirect_uris の更新 ----
+
+        [Fact]
+        public async Task UpdateRedirectUris_OwnedClient_ReplacesWholeList()
+        {
+            await SeedOrgWithClient(1, "shop1", false, 10, "client-prod", "secret",
+                redirectUris: new[] { "https://shop1.example.jp/", "https://shop1.example.jp/old" });
+            AuthenticateAsOwnerOf((1, "shop1"));
+
+            var result = await _controller.UpdateRedirectUris(10, new AccountController.RedirectUrisDto
+            {
+                RedirectUris = new List<string> { "https://shop1.example.jp/ecauth/callback" }
+            });
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            var returned = (string[])GetProp(ok.Value!, "redirect_uris");
+            Assert.Equal(new[] { "https://shop1.example.jp/ecauth/callback" }, returned);
+            // 古い 2 件は残らない（追加ではなく全置換）
+            Assert.Equal(new[] { "https://shop1.example.jp/ecauth/callback" }, await StoredRedirectUris(10));
+        }
+
+        [Fact]
+        public async Task UpdateRedirectUris_NormalizesAuthorityButKeepsPathCase()
+        {
+            await SeedOrgWithClient(1, "shop1", false, 10, "client-prod", "secret");
+            AuthenticateAsOwnerOf((1, "shop1"));
+
+            var result = await _controller.UpdateRedirectUris(10, new AccountController.RedirectUrisDto
+            {
+                RedirectUris = new List<string>
+                {
+                    // ホストは大文字小文字を区別しないので畳む。IDN は Punycode（ブラウザが送る Host と揃える）。
+                    "https://SHOP1.Example.JP/EcAuth/Callback",
+                    "https://日本語.example.jp:8443/ecauth/callback",
+                    // 既定ポートの明示は authority から落ちる
+                    "https://shop1.example.jp:443/EcAuth/Callback"
+                }
+            });
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            var returned = (string[])GetProp(ok.Value!, "redirect_uris");
+            // 1 件目と 3 件目は正規化後に同一になるので重複排除される。パスの大文字は保つ
+            // （authenticate/verify は序数完全一致で比較するため、勝手に畳むと一致しなくなる）。
+            Assert.Equal(new[]
+            {
+                "https://shop1.example.jp/EcAuth/Callback",
+                "https://xn--wgv71a119e.example.jp:8443/ecauth/callback"
+            }, returned);
+        }
+
+        [Theory]
+        [InlineData("http://shop1.example.jp/ecauth/callback")] // https 必須
+        [InlineData("https://shop1.example.jp/callback#frag")]  // フラグメント禁止（RFC 6749 3.1.2）
+        [InlineData("https://user:pass@shop1.example.jp/cb")]   // userinfo 禁止
+        [InlineData("/ecauth/callback")]                        // 相対 URL
+        [InlineData("not a url")]
+        public async Task UpdateRedirectUris_InvalidUri_Returns422AndKeepsExisting(string uri)
+        {
+            await SeedOrgWithClient(1, "shop1", false, 10, "client-prod", "secret",
+                redirectUris: new[] { "https://shop1.example.jp/ecauth/callback" });
+            AuthenticateAsOwnerOf((1, "shop1"));
+
+            var result = await _controller.UpdateRedirectUris(10, new AccountController.RedirectUrisDto
+            {
+                RedirectUris = new List<string> { uri }
+            });
+
+            var unprocessable = Assert.IsType<UnprocessableEntityObjectResult>(result);
+            Assert.Equal("invalid_redirect_uri", (string)GetProp(unprocessable.Value!, "error"));
+            Assert.Equal("redirect_uris", (string)GetProp(unprocessable.Value!, "field"));
+            // 既存値は壊さない
+            Assert.Equal(new[] { "https://shop1.example.jp/ecauth/callback" }, await StoredRedirectUris(10));
+        }
+
+        [Fact]
+        public async Task UpdateRedirectUris_EmptyList_Returns422()
+        {
+            await SeedOrgWithClient(1, "shop1", false, 10, "client-prod", "secret",
+                redirectUris: new[] { "https://shop1.example.jp/ecauth/callback" });
+            AuthenticateAsOwnerOf((1, "shop1"));
+
+            // 空文字だけのリストは「実質空」として扱い、認証不能な状態への更新を拒否する
+            var result = await _controller.UpdateRedirectUris(10, new AccountController.RedirectUrisDto
+            {
+                RedirectUris = new List<string> { "", "   " }
+            });
+
+            Assert.IsType<UnprocessableEntityObjectResult>(result);
+            Assert.Single(await StoredRedirectUris(10));
+        }
+
+        [Fact]
+        public async Task UpdateRedirectUris_NullBody_Returns422()
+        {
+            await SeedOrgWithClient(1, "shop1", false, 10, "client-prod", "secret");
+            AuthenticateAsOwnerOf((1, "shop1"));
+
+            var result = await _controller.UpdateRedirectUris(10, null);
+
+            var unprocessable = Assert.IsType<UnprocessableEntityObjectResult>(result);
+            Assert.Equal("invalid_request", (string)GetProp(unprocessable.Value!, "error"));
+        }
+
+        [Fact]
+        public async Task UpdateRedirectUris_NotOwnedClient_ReturnsNotFound()
+        {
+            await SeedOrgWithClient(1, "shop1", false, 10, "client-prod", "secret");
+            await SeedOrgWithClient(3, "other", false, 30, "client-other", "secret",
+                redirectUris: new[] { "https://other.example.jp/ecauth/callback" });
+            AuthenticateAsOwnerOf((1, "shop1"));
+
+            var result = await _controller.UpdateRedirectUris(30, new AccountController.RedirectUrisDto
+            {
+                RedirectUris = new List<string> { "https://attacker.example.com/steal" }
+            });
+
+            Assert.IsType<NotFoundObjectResult>(result);
+            Assert.Equal(new[] { "https://other.example.jp/ecauth/callback" }, await StoredRedirectUris(30));
+        }
+
+        [Fact]
+        public async Task UpdateRedirectUris_NoToken_ReturnsUnauthorized()
+        {
+            await SeedOrgWithClient(1, "shop1", false, 10, "client-prod", "secret");
+            SetBearer(null);
+
+            var result = await _controller.UpdateRedirectUris(10, new AccountController.RedirectUrisDto
+            {
+                RedirectUris = new List<string> { "https://shop1.example.jp/ecauth/callback" }
+            });
+
+            Assert.IsType<UnauthorizedObjectResult>(result);
+        }
+
+        // ---- allowed_rp_ids の更新 ----
+
+        [Fact]
+        public async Task UpdateAllowedRpIds_OwnedClient_ReplacesWholeListAndPersists()
+        {
+            await SeedOrgWithClient(1, "shop1", false, 10, "client-prod", "secret",
+                allowedRpIds: new[] { "old.example.jp" });
+            AuthenticateAsOwnerOf((1, "shop1"));
+
+            var result = await _controller.UpdateAllowedRpIds(10, new AccountController.AllowedRpIdsDto
+            {
+                AllowedRpIds = new List<string> { "shop1.example.jp", "www.shop1.example.jp" }
+            });
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal(new[] { "shop1.example.jp", "www.shop1.example.jp" },
+                (string[])GetProp(ok.Value!, "allowed_rp_ids"));
+
+            // AllowedRpIds の getter は毎回新しいリストを返すため、リストごと再代入しないと
+            // AllowedRpIdsJson に反映されない。DB から読み直して永続化を確認する。
+            var stored = await _context.Clients.IgnoreQueryFilters().FirstAsync(c => c.Id == 10);
+            Assert.Equal(new[] { "shop1.example.jp", "www.shop1.example.jp" }, stored.AllowedRpIds);
+            Assert.DoesNotContain("old.example.jp", stored.AllowedRpIds);
+        }
+
+        [Fact]
+        public async Task UpdateAllowedRpIds_NormalizesCaseIdnAndDeduplicates()
+        {
+            await SeedOrgWithClient(1, "shop1", false, 10, "client-prod", "secret");
+            AuthenticateAsOwnerOf((1, "shop1"));
+
+            var result = await _controller.UpdateAllowedRpIds(10, new AccountController.AllowedRpIdsDto
+            {
+                AllowedRpIds = new List<string> { "Shop1.Example.JP", "shop1.example.jp", "日本語.example.jp", "localhost" }
+            });
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal(
+                new[] { "shop1.example.jp", "xn--wgv71a119e.example.jp", "localhost" },
+                (string[])GetProp(ok.Value!, "allowed_rp_ids"));
+        }
+
+        [Theory]
+        [InlineData("https://shop1.example.jp")] // スキーム付き
+        [InlineData("shop1.example.jp:443")]     // ポート付き
+        [InlineData("shop1.example.jp/admin")]   // パス付き
+        [InlineData("192.0.2.10")]               // IPv4
+        [InlineData("[2001:db8::1]")]            // IPv6
+        [InlineData("shop1..example.jp")]        // 空ラベル
+        [InlineData("shop1.example.jp.")]        // 末尾ドット（FQDN 表記）
+        public async Task UpdateAllowedRpIds_InvalidRpId_Returns422AndKeepsExisting(string rpId)
+        {
+            await SeedOrgWithClient(1, "shop1", false, 10, "client-prod", "secret",
+                allowedRpIds: new[] { "shop1.example.jp" });
+            AuthenticateAsOwnerOf((1, "shop1"));
+
+            var result = await _controller.UpdateAllowedRpIds(10, new AccountController.AllowedRpIdsDto
+            {
+                AllowedRpIds = new List<string> { rpId }
+            });
+
+            var unprocessable = Assert.IsType<UnprocessableEntityObjectResult>(result);
+            Assert.Equal("invalid_rp_id", (string)GetProp(unprocessable.Value!, "error"));
+            Assert.Equal("allowed_rp_ids", (string)GetProp(unprocessable.Value!, "field"));
+
+            var stored = await _context.Clients.IgnoreQueryFilters().FirstAsync(c => c.Id == 10);
+            Assert.Equal(new[] { "shop1.example.jp" }, stored.AllowedRpIds);
+        }
+
+        [Fact]
+        public async Task UpdateAllowedRpIds_EmptyList_Returns422()
+        {
+            await SeedOrgWithClient(1, "shop1", false, 10, "client-prod", "secret",
+                allowedRpIds: new[] { "shop1.example.jp" });
+            AuthenticateAsOwnerOf((1, "shop1"));
+
+            var result = await _controller.UpdateAllowedRpIds(10, new AccountController.AllowedRpIdsDto
+            {
+                AllowedRpIds = new List<string>()
+            });
+
+            Assert.IsType<UnprocessableEntityObjectResult>(result);
+            var stored = await _context.Clients.IgnoreQueryFilters().FirstAsync(c => c.Id == 10);
+            Assert.Equal(new[] { "shop1.example.jp" }, stored.AllowedRpIds);
+        }
+
+        [Fact]
+        public async Task UpdateAllowedRpIds_TooLongForColumn_Returns422()
+        {
+            await SeedOrgWithClient(1, "shop1", false, 10, "client-prod", "secret",
+                allowedRpIds: new[] { "shop1.example.jp" });
+            AuthenticateAsOwnerOf((1, "shop1"));
+
+            // allowed_rp_ids カラムは MaxLength(2000)。件数上限（20）以内でも
+            // シリアライズ後に溢れうるので、長さ側でも弾けることを確認する。
+            // 1 ラベルは DNS の 63 文字上限に収める（超えると Punycode 変換で弾かれ、別の理由で 422 になる）。
+            var label = new string('a', 60);
+            var rpIds = Enumerable.Range(0, 20).Select(i => $"{label}.{label}.n{i}.example.jp").ToList();
+
+            var result = await _controller.UpdateAllowedRpIds(10, new AccountController.AllowedRpIdsDto
+            {
+                AllowedRpIds = rpIds
+            });
+
+            Assert.IsType<UnprocessableEntityObjectResult>(result);
+            var stored = await _context.Clients.IgnoreQueryFilters().FirstAsync(c => c.Id == 10);
+            Assert.Equal(new[] { "shop1.example.jp" }, stored.AllowedRpIds);
+        }
+
+        [Fact]
+        public async Task UpdateAllowedRpIds_NotOwnedClient_ReturnsNotFound()
+        {
+            await SeedOrgWithClient(1, "shop1", false, 10, "client-prod", "secret");
+            await SeedOrgWithClient(3, "other", false, 30, "client-other", "secret",
+                allowedRpIds: new[] { "other.example.jp" });
+            AuthenticateAsOwnerOf((1, "shop1"));
+
+            var result = await _controller.UpdateAllowedRpIds(30, new AccountController.AllowedRpIdsDto
+            {
+                AllowedRpIds = new List<string> { "attacker.example.com" }
+            });
+
+            Assert.IsType<NotFoundObjectResult>(result);
+            var stored = await _context.Clients.IgnoreQueryFilters().FirstAsync(c => c.Id == 30);
+            Assert.Equal(new[] { "other.example.jp" }, stored.AllowedRpIds);
+        }
+
+        [Fact]
+        public async Task UpdateAllowedRpIds_NoToken_ReturnsUnauthorized()
+        {
+            await SeedOrgWithClient(1, "shop1", false, 10, "client-prod", "secret");
+            SetBearer(null);
+
+            var result = await _controller.UpdateAllowedRpIds(10, new AccountController.AllowedRpIdsDto
+            {
+                AllowedRpIds = new List<string> { "shop1.example.jp" }
+            });
 
             Assert.IsType<UnauthorizedObjectResult>(result);
         }

--- a/IdentityProvider/Controllers/AccountController.cs
+++ b/IdentityProvider/Controllers/AccountController.cs
@@ -1,5 +1,8 @@
+using System.Globalization;
 using System.Net.Http.Headers;
 using System.Security.Cryptography;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Asp.Versioning;
 using IdentityProvider.Filters;
 using IdentityProvider.Models;
@@ -29,6 +32,23 @@ namespace IdentityProvider.Controllers
     [NoStore]
     public class AccountController : ControllerBase
     {
+        /// <summary>redirect_uri の登録上限。EC-CUBE 1 サイトあたり数件で足りる想定の安全弁。</summary>
+        private const int MaxRedirectUris = 20;
+
+        /// <summary>redirect_uri 1 件の最大長。ブラウザ・プロキシが安全に扱える範囲に合わせる。</summary>
+        private const int MaxRedirectUriLength = 2048;
+
+        /// <summary>RP ID の登録上限。</summary>
+        private const int MaxAllowedRpIds = 20;
+
+        /// <summary>RP ID 1 件の最大長（RFC 1035 のドメイン名上限）。</summary>
+        private const int MaxRpIdLength = 253;
+
+        /// <summary>
+        /// <c>Client.AllowedRpIdsJson</c> の <c>[MaxLength(2000)]</c> に合わせたシリアライズ後の上限。
+        /// </summary>
+        private const int MaxAllowedRpIdsJsonLength = 2000;
+
         private readonly EcAuthDbContext _context;
         private readonly ITokenService _tokenService;
         private readonly IAccountService _accountService;
@@ -101,7 +121,8 @@ namespace IdentityProvider.Controllers
                     is_sandbox = c.Organization?.IsSandbox ?? false,
                     organization_code = c.Organization?.Code,
                     organization_name = c.Organization?.Name,
-                    redirect_uris = c.RedirectUris.Select(r => r.Uri).ToArray()
+                    redirect_uris = c.RedirectUris.Select(r => r.Uri).ToArray(),
+                    allowed_rp_ids = c.AllowedRpIds.ToArray()
                 });
             }
 
@@ -165,6 +186,326 @@ namespace IdentityProvider.Controllers
                 client_id = client.ClientId,
                 client_secret = revealed
             });
+        }
+
+        /// <summary>
+        /// POST /v1/account/clients/{id}/redirect-uris
+        /// 指定 Client の redirect_uri をリストごと全置換する。
+        ///
+        /// PUT ではなく POST なのは、CORS ポリシー <c>SignupApiCors</c> が GET / POST / OPTIONS
+        /// 限定のため（Program.cs）。プリフライトで PUT / DELETE を通す設定変更をせずに済むよう、
+        /// 部分更新ではなくリスト全置換のセマンティクスで組む。
+        /// </summary>
+        [HttpPost("clients/{id:int}/redirect-uris")]
+        public async Task<IActionResult> UpdateRedirectUris(int id, [FromBody] RedirectUrisDto? body)
+        {
+            var (client, subject, failure) = await ResolveOwnedClientAsync(id, "update redirect_uris");
+            if (failure != null)
+            {
+                return failure;
+            }
+
+            var (uris, invalid) = NormalizeRedirectUris(body?.RedirectUris);
+            if (invalid != null)
+            {
+                return invalid;
+            }
+
+            // 全置換。既存行を消してから入れ直す（RedirectUri は Client 従属で他から参照されない）。
+            var existing = await _context.RedirectUris
+                .IgnoreQueryFilters()
+                .Where(r => r.ClientId == client!.Id)
+                .ToListAsync();
+            _context.RedirectUris.RemoveRange(existing);
+
+            var now = DateTimeOffset.UtcNow;
+            foreach (var uri in uris!)
+            {
+                _context.RedirectUris.Add(new RedirectUri
+                {
+                    ClientId = client!.Id,
+                    Uri = uri,
+                    CreatedAt = now,
+                    UpdatedAt = now
+                });
+            }
+
+            client!.UpdatedAt = now;
+            await _context.SaveChangesAsync();
+
+            _logger.LogInformation(
+                "redirect_uris replaced for client {ClientId} by account {Subject} (count {Count})",
+                client.ClientId, subject, uris.Count);
+
+            return Ok(new
+            {
+                id = client.Id,
+                client_id = client.ClientId,
+                redirect_uris = uris.ToArray()
+            });
+        }
+
+        /// <summary>
+        /// POST /v1/account/clients/{id}/allowed-rp-ids
+        /// 指定 Client の allowed_rp_ids をリストごと全置換する。POST を使う理由は
+        /// <see cref="UpdateRedirectUris"/> と同じ。
+        ///
+        /// 自分が管理していないドメインを RP ID に入れても攻撃には使えない（WebAuthn は
+        /// origin と RP ID の一致を要求するため、そのドメインの origin でページを配信できない
+        /// 限りセレモニーが成立せず、作られる資格情報も自 Organization に閉じる）ため、
+        /// 所有権の確認は課さない。ただし変更は監査ログに残す。
+        /// </summary>
+        [HttpPost("clients/{id:int}/allowed-rp-ids")]
+        public async Task<IActionResult> UpdateAllowedRpIds(int id, [FromBody] AllowedRpIdsDto? body)
+        {
+            var (client, subject, failure) = await ResolveOwnedClientAsync(id, "update allowed_rp_ids");
+            if (failure != null)
+            {
+                return failure;
+            }
+
+            var (rpIds, invalid) = NormalizeAllowedRpIds(body?.AllowedRpIds);
+            if (invalid != null)
+            {
+                return invalid;
+            }
+
+            // getter は毎回新しいリストを返すため Add では永続化されない。リストごと再代入する。
+            client!.AllowedRpIds = rpIds!;
+            client.UpdatedAt = DateTimeOffset.UtcNow;
+            await _context.SaveChangesAsync();
+
+            _logger.LogInformation(
+                "allowed_rp_ids replaced for client {ClientId} by account {Subject} (count {Count})",
+                client.ClientId, subject, rpIds!.Count);
+
+            return Ok(new
+            {
+                id = client.Id,
+                client_id = client.ClientId,
+                allowed_rp_ids = rpIds.ToArray()
+            });
+        }
+
+        // ---- 入力の正規化・検証 ----
+
+        /// <summary>
+        /// redirect_uri のリストを検証・正規化する。空要素は捨て、重複は先勝ちで畳む。
+        ///
+        /// authenticate/verify は登録値と**序数完全一致**で比較する（B2BPasskeyController）。
+        /// 一方 EC-CUBE プラグインが組み立てる URL のホストは Host ヘッダ由来で常に小文字なので、
+        /// scheme とホストだけ小文字＋Punycode に寄せ、パス・クエリは入力のまま残す
+        /// （パスは大文字小文字を区別するため勝手に畳まない）。
+        /// </summary>
+        private (List<string>? Uris, IActionResult? Failure) NormalizeRedirectUris(List<string>? input)
+        {
+            if (input == null)
+            {
+                return (null, InvalidInput("invalid_request", "redirect_uris を配列で指定してください。", "redirect_uris"));
+            }
+
+            var result = new List<string>();
+            foreach (var raw in input)
+            {
+                var trimmed = raw?.Trim();
+                if (string.IsNullOrEmpty(trimmed))
+                {
+                    continue;
+                }
+
+                if (trimmed.Length > MaxRedirectUriLength)
+                {
+                    return (null, InvalidInput(
+                        "invalid_redirect_uri",
+                        $"redirect_uri が長すぎます（{MaxRedirectUriLength} 文字以内）。",
+                        "redirect_uris"));
+                }
+
+                if (!Uri.TryCreate(trimmed, UriKind.Absolute, out var uri)
+                    || !string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
+                    || string.IsNullOrEmpty(uri.Host))
+                {
+                    return (null, InvalidInput(
+                        "invalid_redirect_uri",
+                        $"redirect_uri は https:// で始まる正しい URL を指定してください: {trimmed}",
+                        "redirect_uris"));
+                }
+
+                // RFC 6749 Section 3.1.2: リダイレクト先にフラグメントは含められない。
+                if (!string.IsNullOrEmpty(uri.Fragment))
+                {
+                    return (null, InvalidInput(
+                        "invalid_redirect_uri",
+                        $"redirect_uri にフラグメント（#）は指定できません: {trimmed}",
+                        "redirect_uris"));
+                }
+
+                // userinfo 付き URL は表示上のホストを偽装できるため受け付けない。
+                if (!string.IsNullOrEmpty(uri.UserInfo))
+                {
+                    return (null, InvalidInput(
+                        "invalid_redirect_uri",
+                        $"redirect_uri にユーザー情報（user:pass@）は指定できません: {trimmed}",
+                        "redirect_uris"));
+                }
+
+                var authority = uri.IsDefaultPort
+                    ? uri.IdnHost.ToLowerInvariant()
+                    : $"{uri.IdnHost.ToLowerInvariant()}:{uri.Port}";
+                var normalized = $"https://{authority}{uri.PathAndQuery}";
+
+                if (!result.Contains(normalized, StringComparer.Ordinal))
+                {
+                    result.Add(normalized);
+                }
+            }
+
+            if (result.Count == 0)
+            {
+                return (null, InvalidInput(
+                    "invalid_redirect_uri",
+                    "redirect_uri を 1 件以上指定してください。空にすると認証が完了できなくなります。",
+                    "redirect_uris"));
+            }
+
+            if (result.Count > MaxRedirectUris)
+            {
+                return (null, InvalidInput(
+                    "invalid_redirect_uri",
+                    $"redirect_uri は {MaxRedirectUris} 件までです。",
+                    "redirect_uris"));
+            }
+
+            return (result, null);
+        }
+
+        /// <summary>
+        /// allowed_rp_ids のリストを検証・正規化する。空要素は捨て、重複は先勝ちで畳む。
+        ///
+        /// RP ID は WebAuthn の valid domain string（登録可能ドメイン名）でなければならない。
+        /// スキーム・ポート・パスを含む文字列や IP アドレスは <c>navigator.credentials.*</c> の
+        /// 時点で必ず失敗するため、保存前に弾いて設定ミスを即時に返す。
+        /// </summary>
+        private (List<string>? RpIds, IActionResult? Failure) NormalizeAllowedRpIds(List<string>? input)
+        {
+            if (input == null)
+            {
+                return (null, InvalidInput("invalid_request", "allowed_rp_ids を配列で指定してください。", "allowed_rp_ids"));
+            }
+
+            var result = new List<string>();
+            foreach (var raw in input)
+            {
+                var trimmed = raw?.Trim();
+                if (string.IsNullOrEmpty(trimmed))
+                {
+                    continue;
+                }
+
+                var normalized = NormalizeRpId(trimmed);
+                if (normalized == null)
+                {
+                    return (null, InvalidInput(
+                        "invalid_rp_id",
+                        $"RP ID はドメイン名だけを指定してください（スキーム・ポート・パス・IP アドレスは不可）: {trimmed}",
+                        "allowed_rp_ids"));
+                }
+
+                if (!result.Contains(normalized, StringComparer.Ordinal))
+                {
+                    result.Add(normalized);
+                }
+            }
+
+            if (result.Count == 0)
+            {
+                return (null, InvalidInput(
+                    "invalid_rp_id",
+                    "RP ID を 1 件以上指定してください。空にするとパスキーが使えなくなります。",
+                    "allowed_rp_ids"));
+            }
+
+            if (result.Count > MaxAllowedRpIds)
+            {
+                return (null, InvalidInput(
+                    "invalid_rp_id",
+                    $"RP ID は {MaxAllowedRpIds} 件までです。",
+                    "allowed_rp_ids"));
+            }
+
+            // 保存先カラムの上限を超えると SQL Server 側で失敗するため、シリアライズ後の長さで確認する。
+            if (JsonSerializer.Serialize(result).Length > MaxAllowedRpIdsJsonLength)
+            {
+                return (null, InvalidInput(
+                    "invalid_rp_id",
+                    "RP ID の合計が長すぎます。件数を減らしてください。",
+                    "allowed_rp_ids"));
+            }
+
+            return (result, null);
+        }
+
+        /// <summary>
+        /// RP ID を小文字 Punycode に正規化する。valid domain string でなければ null を返す。
+        /// ブラウザが送る Host ヘッダは Punycode なので、IDN は ASCII に寄せてから保存する
+        /// （<c>SignupService</c> が初期値を作るときと同じ扱い）。
+        /// </summary>
+        private static string? NormalizeRpId(string value)
+        {
+            if (value.Length > MaxRpIdLength)
+            {
+                return null;
+            }
+
+            string ascii;
+            try
+            {
+                ascii = new IdnMapping().GetAscii(value).ToLowerInvariant();
+            }
+            catch (ArgumentException)
+            {
+                // IdnMapping は空ラベル・不正文字・長すぎるラベルで ArgumentException を投げる。
+                return null;
+            }
+
+            // 末尾ドット（絶対 FQDN 表記）とラベルの空要素は WebAuthn の RP ID として使えない。
+            if (ascii.StartsWith('.') || ascii.EndsWith('.') || ascii.Contains(".."))
+            {
+                return null;
+            }
+
+            // Dns 以外（IPv4 / IPv6 / 解釈不能）はすべて拒否する。
+            // "example.jp:443" や "https://example.jp" は Unknown になるのでここで落ちる。
+            return Uri.CheckHostName(ascii) == UriHostNameType.Dns ? ascii : null;
+        }
+
+        /// <summary>入力エラーを申込 API と同じ形（error / error_description / field）で返す。</summary>
+        private IActionResult InvalidInput(string error, string description, string field)
+        {
+            return UnprocessableEntity(new
+            {
+                error,
+                error_description = description,
+                field
+            });
+        }
+
+        /// <summary>
+        /// <c>POST /v1/account/clients/{id}/redirect-uris</c> のリクエストボディ（snake_case）。
+        /// </summary>
+        public sealed class RedirectUrisDto
+        {
+            [JsonPropertyName("redirect_uris")]
+            public List<string>? RedirectUris { get; set; }
+        }
+
+        /// <summary>
+        /// <c>POST /v1/account/clients/{id}/allowed-rp-ids</c> のリクエストボディ（snake_case）。
+        /// </summary>
+        public sealed class AllowedRpIdsDto
+        {
+            [JsonPropertyName("allowed_rp_ids")]
+            public List<string>? AllowedRpIds { get; set; }
         }
 
         /// <summary>

--- a/IdentityProvider/Controllers/AccountController.cs
+++ b/IdentityProvider/Controllers/AccountController.cs
@@ -305,9 +305,13 @@ namespace IdentityProvider.Controllers
             }
 
             var result = new List<string>();
-            foreach (var raw in input)
+            for (var i = 0; i < input.Count; i++)
             {
-                var trimmed = raw?.Trim();
+                // 入力値そのものはエラーに載せない。redirect_uri は user:pass@ を含みうるので、
+                // 反映するとブラウザのエラーレポートやプロキシのログにパスワードが残る。
+                // 代わりに入力配列での位置（1 始まり）を返し、どの欄かは呼び出し側で分かるようにする。
+                var position = i + 1;
+                var trimmed = input[i]?.Trim();
                 if (string.IsNullOrEmpty(trimmed))
                 {
                     continue;
@@ -317,7 +321,7 @@ namespace IdentityProvider.Controllers
                 {
                     return (null, InvalidInput(
                         "invalid_redirect_uri",
-                        $"redirect_uri が長すぎます（{MaxRedirectUriLength} 文字以内）。",
+                        $"{position} 件目の redirect_uri が長すぎます（{MaxRedirectUriLength} 文字以内）。",
                         "redirect_uris"));
                 }
 
@@ -327,7 +331,7 @@ namespace IdentityProvider.Controllers
                 {
                     return (null, InvalidInput(
                         "invalid_redirect_uri",
-                        $"redirect_uri は https:// で始まる正しい URL を指定してください: {trimmed}",
+                        $"{position} 件目の redirect_uri は https:// で始まる正しい URL を指定してください。",
                         "redirect_uris"));
                 }
 
@@ -336,7 +340,7 @@ namespace IdentityProvider.Controllers
                 {
                     return (null, InvalidInput(
                         "invalid_redirect_uri",
-                        $"redirect_uri にフラグメント（#）は指定できません: {trimmed}",
+                        $"{position} 件目の redirect_uri にフラグメント（#）は指定できません。",
                         "redirect_uris"));
                 }
 
@@ -345,7 +349,7 @@ namespace IdentityProvider.Controllers
                 {
                     return (null, InvalidInput(
                         "invalid_redirect_uri",
-                        $"redirect_uri にユーザー情報（user:pass@）は指定できません: {trimmed}",
+                        $"{position} 件目の redirect_uri にユーザー情報（user:pass@）は指定できません。",
                         "redirect_uris"));
                 }
 
@@ -353,6 +357,16 @@ namespace IdentityProvider.Controllers
                     ? uri.IdnHost.ToLowerInvariant()
                     : $"{uri.IdnHost.ToLowerInvariant()}:{uri.Port}";
                 var normalized = $"https://{authority}{uri.PathAndQuery}";
+
+                // 保存されるのは正規化後の値。IDN の Punycode 化やパスのパーセントエンコードで
+                // 入力より伸びうるため、上限は正規化後にも当てる。
+                if (normalized.Length > MaxRedirectUriLength)
+                {
+                    return (null, InvalidInput(
+                        "invalid_redirect_uri",
+                        $"{position} 件目の redirect_uri が長すぎます（正規化後 {MaxRedirectUriLength} 文字以内）。",
+                        "redirect_uris"));
+                }
 
                 if (!result.Contains(normalized, StringComparer.Ordinal))
                 {
@@ -394,9 +408,12 @@ namespace IdentityProvider.Controllers
             }
 
             var result = new List<string>();
-            foreach (var raw in input)
+            for (var i = 0; i < input.Count; i++)
             {
-                var trimmed = raw?.Trim();
+                // redirect_uri 側と同じ理由で入力値は載せない（"user:pass@host" のような
+                // 資格情報を含む文字列もここに到達しうる）。位置だけを返す。
+                var position = i + 1;
+                var trimmed = input[i]?.Trim();
                 if (string.IsNullOrEmpty(trimmed))
                 {
                     continue;
@@ -407,7 +424,8 @@ namespace IdentityProvider.Controllers
                 {
                     return (null, InvalidInput(
                         "invalid_rp_id",
-                        $"RP ID はドメイン名だけを指定してください（スキーム・ポート・パス・IP アドレスは不可）: {trimmed}",
+                        $"{position} 件目の RP ID はドメイン名だけを指定してください"
+                            + "（スキーム・ポート・パス・IP アドレスは不可）。",
                         "allowed_rp_ids"));
                 }
 

--- a/IdentityProvider/Models/Client.cs
+++ b/IdentityProvider/Models/Client.cs
@@ -32,7 +32,9 @@ namespace IdentityProvider.Models
         public SubjectType SubjectType { get; set; } = SubjectType.B2C;
 
         public Organization? Organization { get; set; }
-        public ICollection<RedirectUri>? RedirectUris { get; } = new List<RedirectUri>();
+        // get-only + 初期化子のため null になりえない。null 許容にすると呼び出し側が
+        // 毎回 null チェックを強いられる（CS8604）ので、実態どおり非 null で宣言する。
+        public ICollection<RedirectUri> RedirectUris { get; } = new List<RedirectUri>();
         public ICollection<OpenIdProvider>? OpenIdProviders { get; } = new List<OpenIdProvider>();
 
         [Column("allowed_rp_ids")]


### PR DESCRIPTION
## 背景

[#482 の残タスク 1](https://github.com/EcAuth/EcAuth/issues/482)（旧 #481-B）。

#481 で申込 Client の**初期値**は実利用に合うよう直した（#486、本番デプロイ済み）が、
初期値がズレたときに**顧客が自分で直す手段**は無いままだった。`AccountController` は
`GET clients` / `POST clients/{id}/secret` / `POST clients/{id}/secret/reveal` のみで、
`GET clients` のレスポンスには `allowed_rp_ids` すら含まれていない。

復旧手段が DB の直接操作しかない状態を解消する。

## 変更

| エンドポイント | 内容 |
|---|---|
| `GET /v1/account/clients` | レスポンスに `allowed_rp_ids` を追加 |
| `POST /v1/account/clients/{id}/redirect-uris` | `{"redirect_uris": [...]}` を受けて**リスト全置換** |
| `POST /v1/account/clients/{id}/allowed-rp-ids` | `{"allowed_rp_ids": [...]}` を受けて**リスト全置換** |

### 設計上の決めごと

- **PUT / DELETE を使わない**。CORS ポリシー `SignupApiCors` が GET / POST / OPTIONS 限定
  （`Program.cs`）なので、部分更新ではなくリスト全置換の POST 2 本で組む。**CORS 設定の変更は不要**
- **認可は既存の `ResolveOwnedClientAsync` を流用**。存在しない Client と権限の無い Client を
  どちらも 404 に揃える。所有権チェックは**バリデーションより先**に走らせ、非管理 Client に対する
  入力検証の結果を漏らさない
- **エラー形式は申込 API と揃える**（422 + `{error, error_description, field}`）

### バリデーション

**redirect_uri**
- https 必須 / フラグメント禁止（RFC 6749 3.1.2）/ userinfo 禁止 / 相対 URL 拒否
- scheme とホストのみ小文字 Punycode に正規化し、**パスは入力のまま残す**。
  `authenticate/verify` は登録値と**序数完全一致**で比較する（`B2BPasskeyController.cs:584` の
  `List<string>.Contains`）ため、パスを勝手に畳むと一致しなくなる
- 1〜20 件、1 件 2048 文字まで

**allowed_rp_ids**
- WebAuthn の valid domain string のみ。スキーム付き・ポート付き・パス付き・IP アドレス・
  空ラベル・末尾ドットを拒否（`Uri.CheckHostName(...) == Dns`）
- IDN は Punycode に寄せる（ブラウザが送る Host ヘッダと揃える。`SignupService` の初期値生成と同じ扱い）
- 1〜20 件。`Client.AllowedRpIdsJson` は `[MaxLength(2000)]` なので**シリアライズ後の長さでも**検証する

**共通**: 空リストへの更新は拒否する。redirect_uri が空だと認証が完了できず、
allowed_rp_ids が空だとパスキーが使えなくなるため、自分で自分をロックアウトさせない。

### 実装上の罠

`Client.AllowedRpIds` の getter は毎回新しいリストを返すため `Add` では永続化されない。
リストごと再代入している（`B2BPasskeySeeder.cs:112,130` と同じ罠）。ユニットテストと
実 DB の両方で永続化を確認済み（下記）。

### RP ID の所有権を確認しない理由

自分が管理していないドメインを RP ID に入れても攻撃には使えない。WebAuthn は origin と RP ID の
一致を要求するため、そのドメインの origin でページを配信できない限りセレモニーが成立せず、
作られる資格情報も自 Organization に閉じる。コードにコメントとして残した上で、変更は監査ログに出している。

## E2E

`signup_client_b2b_login.spec.ts` を強化した。

- **rp_id も API から取得した登録済みの値を使う**ようにした。従来 `rpId: siteHost` とテスト側で
  組み立てていたが、これは CLAUDE.md の「`redirect_uri` / `rp_id` をテスト側で組み立てない」に
  反していた（`allowed_rp_ids` が API に出ていなかったため）
- 申込直後の `allowed_rp_ids` が期待どおり 1 件であることを固定
- **更新 → 一覧に反映 → 更新後の redirect_uri で認証が通る**まで通しで検証するテストを追加。
  #481 が起きた状況からの復旧手段が本当に機能することを確認する
- `eccube_plugin_signup_login.spec.ts` にも「登録された `allowed_rp_ids` に店舗ホストが含まれる」
  突き合わせを追加（プラグインは `Request::getHost()` から rp_id を作るため）

## 検証

**ユニットテスト**

```
成功!   -失敗:     0、合格:   735、スキップ:     0、合計:   735
```

`AccountControllerTests` に 21 件追加（全置換 / 正規化 / 重複排除 / 不正入力 7 パターン ×
redirect_uri と rp_id / 空リスト / 桁あふれ / 非所有 404 / 未認証 401）。

**ローカル Docker（実 SQL Server）での E2E**

```
✓ 申込 → 確認 → Account トークン取得 (2.8s)
✓ マイページと同じ経路で client_id / client_secret を取得する (125ms)
✓ サイトのオリジンでパスキーを登録する (109ms)
✓ 登録済み redirect_uri のままパスキー認証が通り、認可コードが返る (52ms)
✓ 認可コードをトークンに交換できる (24ms)
✓ マイページから redirect_uri / allowed_rp_ids を更新でき、更新後の値で認証が通る (114ms)
  6 passed (4.0s)
```

実行後の DB 実値（全置換が効き、`AllowedRpIdsJson` に永続化されている）:

```
code                       | allowed_rp_ids                                                  | uri
e2e-1785491277546-53-test  | ["e2e-1785491277546-53.test","www.e2e-1785491277546-53.test"]   | https://e2e-...-53.test:8081/shop/ecauth/callback
```

旧 `/ecauth/callback` の行は消えており（全置換）、`allowed_rp_ids` も 1 件 → 2 件に更新されている。

**ルーティングと認可（未認証で 401、404 ではない）**

```
POST /v1/account/clients/1/redirect-uris   → HTTP 401 {"error":"invalid_token",...}
POST /v1/account/clients/1/allowed-rp-ids  → HTTP 401 {"error":"invalid_token",...}
```

### 未検証・注記

- ローカルで `federate_authorization_code_flow.spec.ts` が 1 件失敗するが、**本変更とは無関係**。
  失敗箇所は Azure MockIdP へのブラウザ遷移で、ここから同じ認可リクエストを打つと MockIdP が
  401 を返す（ローカル環境側の未整備）。同一ベースコミット `69acb18` の CI（run 30608063954）では
  同 spec を含む 42 件が全 pass しており、本 PR はフェデレーション経路のコードに触れていない
- マイページ UI での操作は未確認（EcAuth/ecauth-website#19 が本 PR を前提に別途対応）

## 残タスク（#482 の他項目、本 PR のスコープ外）

- 残タスク 2: 許可 origin のポート追加（4430 / 8000）
- 残タスク 3: 申込のテスト Org サイレントスキップの通知、4 系プラグインの `error_description` 透過
- 画面側: EcAuth/ecauth-website#19 / #20

Refs #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * クライアントごとに、リダイレクトURIとWebAuthnの許可RP IDを取得・更新できるようになりました。
  * 更新時に形式検証、正規化、重複排除を行い、安全な値のみ登録できます。
  * クライアント一覧で許可RP IDを確認できるようになりました。
  * 不正な入力、権限のないクライアント、未認証の操作に対して適切なエラーを返します。
  * 更新内容は保存され、パスキー登録・認証に反映されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->