### PR TITLE
feat: 同じドメインでもテスト用の Organization を作れるようにする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,6 +191,30 @@ E2E でこれを一体にして「ブラウザから直接 API を叩く」と�
 保てば既定テナントに解決される。Playwright 側は `playwright.config.ts` の
 `--host-resolver-rules` に `MAP *.test 127.0.0.1` を入れて解決させる。
 
+#### 申込が作る Organization と組織コードの導出
+
+申込は入力された URL ごとに独立した Organization を作る（最大 2 件）。組織コードは
+そのままテナント名になり、プラグインが接続する `https://{tenant}.ec-auth.io` に現れる。
+
+| サイト | 組織コード | `IsSandbox` |
+|---|---|---|
+| 本番 | ホスト名から導出（`shop.example.jp` → `shop-example-jp`） | `false` |
+| テスト | 導出結果 + **`-sandbox`**（`stg.example.jp` → `stg-example-jp-sandbox`） | `true` |
+
+導出は lowercase → 先頭 `www.` 除去 → 英数以外の連続を `-` に畳む（`SignupService.DeriveOrganizationCode`）。
+
+**サンドボックスに必ず `-sandbox` が付く理由**は、本番と同じドメイン（あるいは `www.` の
+有無だけが違うドメイン）でもテスト Org を作れるようにするため。付けないと導出後コードが
+本番と衝突し、テスト環境を別ドメインで持たない顧客は検証にも本番 Org を使うしかなくなる。
+副次的に、接続先 URL を見ただけで本番かサンドボックスかが判別できる。
+
+同一ドメインで両方作った場合、2 つの Client は `allowed_rp_ids` も `redirect_uri` も同じ値に
+なりうるが問題は起きない。プラグインは自分の `client_id` から `/platform/v1/client-resolve` で
+テナントを引くため、資格情報を差し替えるだけで本番 / サンドボックスを行き来できる。
+
+組織コードは DNS ラベル 1 つ分なので 63 文字を超えられない（`MaxOrganizationCodeLength`）。
+超える申込は `invalid_site_url` で弾く。
+
 #### `wwwroot/b2b-passkey-test.html` の配信条件
 
 静的ファイル配信は **`app.Environment.IsProduction()` のときだけ**テナント限定になる

--- a/IdentityProvider.Test/Services/SignupServiceTests.cs
+++ b/IdentityProvider.Test/Services/SignupServiceTests.cs
@@ -341,6 +341,77 @@ namespace IdentityProvider.Test.Services
             Assert.Equal(422, ex.StatusCode);
         }
 
+        /// <summary>
+        /// ドメインの占有判定は接尾辞を除いた導出コードで行う。site.Code をそのまま比較すると、
+        /// サンドボックス側だけコードが変わったせいで「登録済みドメインを拒否する」保証が
+        /// 失われ、他人のドメインを自分のテストサイトとして登録できてしまう。
+        /// </summary>
+        [Theory]
+        // 旧規則（接尾辞なし）で登録済みのサンドボックス Org。移行しないので必ず残る。
+        [InlineData("stg-example-jp", true)]
+        // 本番として登録済みのドメイン。別アカウントがテストサイトとして横取りできてはいけない。
+        [InlineData("stg-example-jp", false)]
+        // 新規則で登録済みのサンドボックス Org。
+        [InlineData("stg-example-jp-sandbox", true)]
+        public async Task RequestAsync_TestSiteDomainAlreadyTaken_ThrowsOrganizationAlreadyExists(
+            string existingCode, bool existingIsSandbox)
+        {
+            var tenantService = CreateTenantService();
+            using var context = CreateContextWithAccountsOrg(tenantService);
+            context.Organizations.Add(new Organization
+            {
+                Id = 2,
+                Code = existingCode,
+                Name = "Existing",
+                TenantName = existingCode,
+                IsSandbox = existingIsSandbox
+            });
+            await context.SaveChangesAsync();
+
+            var service = CreateService(context, tenantService, out _, out _);
+
+            // 別アカウントが同じドメインをテストサイトとして申し込む。
+            var input = ValidInput() with
+            {
+                Email = "another@example.com",
+                ProductionSiteUrl = null,
+                TestSiteUrl = "https://stg.example.jp"
+            };
+
+            var ex = await Assert.ThrowsAsync<SignupValidationException>(() => service.RequestAsync(input));
+            Assert.Equal("organization_already_exists", ex.Error);
+            Assert.Equal("test_site_url", ex.Field);
+            Assert.False(await context.SignupRequests.IgnoreQueryFilters().AnyAsync());
+        }
+
+        [Fact]
+        public async Task RequestAsync_ProductionDomainAlreadyTakenBySandbox_ThrowsOrganizationAlreadyExists()
+        {
+            var tenantService = CreateTenantService();
+            using var context = CreateContextWithAccountsOrg(tenantService);
+            // 逆方向: 旧規則のサンドボックス Org が居るドメインを本番として申し込む。
+            context.Organizations.Add(new Organization
+            {
+                Id = 2,
+                Code = "stg-example-jp",
+                Name = "Existing sandbox",
+                TenantName = "stg-example-jp",
+                IsSandbox = true
+            });
+            await context.SaveChangesAsync();
+
+            var service = CreateService(context, tenantService, out _, out _);
+            var input = ValidInput() with
+            {
+                Email = "another@example.com",
+                ProductionSiteUrl = "https://stg.example.jp"
+            };
+
+            var ex = await Assert.ThrowsAsync<SignupValidationException>(() => service.RequestAsync(input));
+            Assert.Equal("organization_already_exists", ex.Error);
+            Assert.Equal("production_site_url", ex.Field);
+        }
+
         [Theory]
         // www. の有無だけが違うドメイン（導出後は同じ shop-example-jp になる）
         [InlineData("https://shop.example.jp", "https://www.shop.example.jp")]

--- a/IdentityProvider.Test/Services/SignupServiceTests.cs
+++ b/IdentityProvider.Test/Services/SignupServiceTests.cs
@@ -125,6 +125,13 @@ namespace IdentityProvider.Test.Services
             return ExtractTokenFromConfirmUrl(capturedUrl!);
         }
 
+        // SignupService の DNS ラベル上限（MaxOrganizationCodeLength）。
+        private const int MaxOrganizationCodeLength = 63;
+
+        // 導出後がちょうど MaxOrganizationCodeLength になるホスト。
+        // "a" * 60 + ".jp" -> "a" * 60 + "-jp" = 63 文字。
+        private static readonly string MaxLengthHost = new string('a', 60) + ".jp";
+
         private static SignupInput ValidInput() => new()
         {
             Email = "owner@example.com",
@@ -364,21 +371,25 @@ namespace IdentityProvider.Test.Services
             Assert.Contains(customerOrgs, o => o.Code == "shop-example-jp-sandbox" && o.IsSandbox);
         }
 
+        /// <summary>
+        /// 組織コードはテナント名になり <c>{tenant}.ec-auth.io</c> の 1 ラベルを構成するため、
+        /// DNS のラベル上限（63）を超えると Org は作れてもそのサブドメインに到達できない。
+        /// 導出後ちょうど 63 文字になるホストを使い、<c>-sandbox</c> の 8 文字**だけ**で
+        /// 上限を超えることを固定する（本番として申し込めば通ることは下のテストで確認する）。
+        /// テスト URL に別のサブドメインを足すと、その分で先に上限を超えてしまい、
+        /// 接尾辞を消してもテストが通る＝接尾辞の寄与を検証できなくなる。
+        /// </summary>
         [Fact]
-        public async Task RequestAsync_HostTooLongForDnsLabel_ThrowsInvalidSiteUrl()
+        public async Task RequestAsync_SandboxSuffixExceedsDnsLabelLimit_ThrowsInvalidSiteUrl()
         {
             var tenantService = CreateTenantService();
             using var context = CreateContextWithAccountsOrg(tenantService);
             var service = CreateService(context, tenantService, out _, out _);
 
-            // 組織コードはテナント名になり {tenant}.ec-auth.io の 1 ラベルを構成する。
-            // DNS のラベル上限（63）を超えると Org は作れてもそのサブドメインに到達できない。
-            // -sandbox 分だけ本番より先に上限へ当たるため、サンドボックス側で検出される。
-            var host = new string('a', 60) + ".jp"; // 導出後 63 文字（本番はぎりぎり通る）
             var input = ValidInput() with
             {
-                ProductionSiteUrl = $"https://{host}",
-                TestSiteUrl = $"https://stg.{host}"
+                ProductionSiteUrl = null,
+                TestSiteUrl = $"https://{MaxLengthHost}"
             };
 
             var ex = await Assert.ThrowsAsync<SignupValidationException>(() => service.RequestAsync(input));
@@ -386,6 +397,31 @@ namespace IdentityProvider.Test.Services
             Assert.Equal(422, ex.StatusCode);
             Assert.Equal("test_site_url", ex.Field);
             Assert.False(await context.SignupRequests.IgnoreQueryFilters().AnyAsync());
+        }
+
+        [Fact]
+        public async Task RequestAsync_HostAtDnsLabelLimit_IsAcceptedAsProduction()
+        {
+            var tenantService = CreateTenantService();
+            using var context = CreateContextWithAccountsOrg(tenantService);
+            var service = CreateService(context, tenantService, out var emailMock, out _);
+
+            // 上のテストと同じホスト。本番には接尾辞が付かないので 63 文字ちょうどで通る。
+            // これがあることで、上のテストの失敗が -sandbox に由来すると言い切れる。
+            var input = ValidInput() with
+            {
+                ProductionSiteUrl = $"https://{MaxLengthHost}",
+                TestSiteUrl = null
+            };
+
+            var token = await RequestAndCaptureTokenAsync(service, emailMock, input);
+            await service.ConfirmAsync(token);
+
+            var customerOrg = await context.Organizations
+                .IgnoreQueryFilters()
+                .SingleAsync(o => o.Code != Tenant);
+            Assert.Equal(MaxOrganizationCodeLength, customerOrg.Code.Length);
+            Assert.False(customerOrg.IsSandbox);
         }
 
         // ---- 組織コード導出 ----

--- a/IdentityProvider.Test/Services/SignupServiceTests.cs
+++ b/IdentityProvider.Test/Services/SignupServiceTests.cs
@@ -334,26 +334,58 @@ namespace IdentityProvider.Test.Services
             Assert.Equal(422, ex.StatusCode);
         }
 
+        [Theory]
+        // www. の有無だけが違うドメイン（導出後は同じ shop-example-jp になる）
+        [InlineData("https://shop.example.jp", "https://www.shop.example.jp")]
+        // 完全に同じ URL。テスト環境を別ドメインで持てない顧客がサンドボックスを得る経路。
+        [InlineData("https://shop.example.jp", "https://shop.example.jp")]
+        // 同一ホストのサブディレクトリ運用。redirect_uri も別になるので併存できる。
+        [InlineData("https://shop.example.jp", "https://shop.example.jp/stg/")]
+        public async Task ConfirmAsync_TestSiteOnSameDomain_CreatesSandboxOrganization(
+            string productionUrl, string testUrl)
+        {
+            var tenantService = CreateTenantService();
+            using var context = CreateContextWithAccountsOrg(tenantService);
+            var service = CreateService(context, tenantService, out var emailMock, out _);
+
+            var input = ValidInput() with { ProductionSiteUrl = productionUrl, TestSiteUrl = testUrl };
+            var token = await RequestAndCaptureTokenAsync(service, emailMock, input);
+            await service.ConfirmAsync(token);
+
+            // 以前はテスト Org を黙って作らずに済ませており、テスト環境を別ドメインで持たない
+            // 顧客は検証にも本番 Org を使うしかなかった（EcAuth#482 の問題 2）。
+            // サンドボックス Org には -sandbox が付くので、同じドメインでも両方作れる。
+            var customerOrgs = await context.Organizations
+                .IgnoreQueryFilters()
+                .Where(o => o.Code != Tenant)
+                .ToListAsync();
+            Assert.Equal(2, customerOrgs.Count);
+            Assert.Contains(customerOrgs, o => o.Code == "shop-example-jp" && !o.IsSandbox);
+            Assert.Contains(customerOrgs, o => o.Code == "shop-example-jp-sandbox" && o.IsSandbox);
+        }
+
         [Fact]
-        public async Task RequestAsync_ProductionAndTestDeriveSameCode_ThrowsDuplicateSite()
+        public async Task RequestAsync_HostTooLongForDnsLabel_ThrowsInvalidSiteUrl()
         {
             var tenantService = CreateTenantService();
             using var context = CreateContextWithAccountsOrg(tenantService);
             var service = CreateService(context, tenantService, out _, out _);
 
-            // www.shop.example.jp と shop.example.jp はいずれも shop-example-jp に導出される。
+            // 組織コードはテナント名になり {tenant}.ec-auth.io の 1 ラベルを構成する。
+            // DNS のラベル上限（63）を超えると Org は作れてもそのサブドメインに到達できない。
+            // -sandbox 分だけ本番より先に上限へ当たるため、サンドボックス側で検出される。
+            var host = new string('a', 60) + ".jp"; // 導出後 63 文字（本番はぎりぎり通る）
             var input = ValidInput() with
             {
-                ProductionSiteUrl = "https://shop.example.jp",
-                TestSiteUrl = "https://www.shop.example.jp"
+                ProductionSiteUrl = $"https://{host}",
+                TestSiteUrl = $"https://stg.{host}"
             };
 
-            // 同一コードに導出されるため、テスト Org は追加されず単一 Org として扱われる。
-            // 重複検知は EnsureOrganizationCodesAvailableAsync の seenCodes でも担保するが、
-            // ここでは導出後コード比較によりテスト Org が作られないこと（=本番のみ）を確認する。
-            await service.RequestAsync(input);
-            var stored = await context.SignupRequests.IgnoreQueryFilters().FirstAsync();
-            Assert.NotNull(stored);
+            var ex = await Assert.ThrowsAsync<SignupValidationException>(() => service.RequestAsync(input));
+            Assert.Equal("invalid_site_url", ex.Error);
+            Assert.Equal(422, ex.StatusCode);
+            Assert.Equal("test_site_url", ex.Field);
+            Assert.False(await context.SignupRequests.IgnoreQueryFilters().AnyAsync());
         }
 
         // ---- 組織コード導出 ----
@@ -472,58 +504,32 @@ namespace IdentityProvider.Test.Services
                 .ToListAsync();
             Assert.Equal(2, customerOrgs.Count);
             Assert.Contains(customerOrgs, o => o.Code == "shop-example-jp" && !o.IsSandbox);
-            Assert.Contains(customerOrgs, o => o.Code == "test-example-jp" && o.IsSandbox);
+            // ホストが分かれていてもサンドボックス側には -sandbox が付く。テナント名だけで
+            // 本番かサンドボックスかが判別でき、プラグインの接続先 URL にもそれが現れる。
+            Assert.Contains(customerOrgs, o => o.Code == "test-example-jp-sandbox" && o.IsSandbox);
         }
 
         [Fact]
-        public async Task ConfirmAsync_ProductionAndTestSameHost_CreatesOnlyProduction()
+        public async Task ConfirmAsync_TestSiteOnly_CreatesSandboxOrganization()
         {
             var tenantService = CreateTenantService();
             using var context = CreateContextWithAccountsOrg(tenantService);
             var service = CreateService(context, tenantService, out var emailMock, out _);
 
+            // 本番 URL 無しでテストサイトだけ申し込むケースでも接尾辞は付く（規則を分岐させない）。
             var input = ValidInput() with
             {
-                ProductionSiteUrl = "https://shop.example.jp",
-                TestSiteUrl = "https://shop.example.jp"
+                ProductionSiteUrl = null,
+                TestSiteUrl = "https://test.example.jp"
             };
             var token = await RequestAndCaptureTokenAsync(service, emailMock, input);
-
             await service.ConfirmAsync(token);
 
-            var customerOrgs = await context.Organizations
+            var customerOrg = await context.Organizations
                 .IgnoreQueryFilters()
-                .Where(o => o.Code != Tenant)
-                .ToListAsync();
-            Assert.Single(customerOrgs);
-            Assert.False(customerOrgs[0].IsSandbox);
-        }
-
-        [Fact]
-        public async Task ConfirmAsync_ProductionAndTestDeriveSameCode_CreatesOnlyProduction()
-        {
-            var tenantService = CreateTenantService();
-            using var context = CreateContextWithAccountsOrg(tenantService);
-            var service = CreateService(context, tenantService, out var emailMock, out _);
-
-            // www.shop.example.jp(test) と shop.example.jp(prod) はいずれも shop-example-jp に導出される。
-            // 生ホスト名は異なるが導出後コードが同一のためテスト Org は作らない。
-            var input = ValidInput() with
-            {
-                ProductionSiteUrl = "https://shop.example.jp",
-                TestSiteUrl = "https://www.shop.example.jp"
-            };
-            var token = await RequestAndCaptureTokenAsync(service, emailMock, input);
-
-            await service.ConfirmAsync(token);
-
-            var customerOrgs = await context.Organizations
-                .IgnoreQueryFilters()
-                .Where(o => o.Code != Tenant)
-                .ToListAsync();
-            Assert.Single(customerOrgs);
-            Assert.Equal("shop-example-jp", customerOrgs[0].Code);
-            Assert.False(customerOrgs[0].IsSandbox);
+                .SingleAsync(o => o.Code != Tenant);
+            Assert.Equal("test-example-jp-sandbox", customerOrg.Code);
+            Assert.True(customerOrg.IsSandbox);
         }
 
         // ---- ConfirmAsync: Client の初期値（redirect_uri / allowed_rp_ids）----
@@ -722,7 +728,7 @@ namespace IdentityProvider.Test.Services
                 .ToListAsync();
 
             var production = clients.Single(c => c.Organization!.Code == "shop-example-jp");
-            var sandbox = clients.Single(c => c.Organization!.Code == "test-example-jp");
+            var sandbox = clients.Single(c => c.Organization!.Code == "test-example-jp-sandbox");
             Assert.Equal("https://shop.example.jp/ecauth/callback.php", production.RedirectUris!.Single().Uri);
             Assert.Equal("https://test.example.jp/store/ecauth/callback.php", sandbox.RedirectUris!.Single().Uri);
         }

--- a/IdentityProvider/Services/SignupService.cs
+++ b/IdentityProvider/Services/SignupService.cs
@@ -23,6 +23,14 @@ namespace IdentityProvider.Services
         // 組織コード導出: 英数字以外の連続を 1 つの "-" に畳み込むための正規表現。
         private static readonly Regex NonAlphanumericRun = new("[^a-z0-9]+", RegexOptions.Compiled);
 
+        // サンドボックス（テストサイト）Org の組織コードに付ける接尾辞。
+        private const string SandboxCodeSuffix = "-sandbox";
+
+        // 組織コードはそのままテナント名になり {tenant}.ec-auth.io の 1 ラベルを構成する。
+        // DNS のラベル上限は 63 オクテット（RFC 1035）。超えると Org は作れてもその
+        // サブドメインに到達できず、プラグインの接続先が解決不能になる。
+        private const int MaxOrganizationCodeLength = 63;
+
         // 確認 URL 設定キーのテナント部を環境変数名に使える形へ正規化する正規表現。
         // 環境変数名はハイフンを含められない（Azure Linux App Service が 400 で拒否）ため、
         // [A-Za-z0-9_] 以外を "_" に置換する（例: "stg-accounts" -> "stg_accounts"）。
@@ -453,29 +461,20 @@ namespace IdentityProvider.Services
 
             var sites = new List<SiteEntry>();
 
-            string? productionCode = null;
             if (productionSite != null)
             {
-                productionCode = DeriveOrganizationCode(productionSite.Host);
                 sites.Add(new SiteEntry(
-                    productionCode, productionSite.Host, productionSite.BaseUrl,
+                    DeriveOrganizationCode(productionSite.Host, isSandbox: false),
+                    productionSite.Host, productionSite.BaseUrl,
                     IsSandbox: false, "production_site_url"));
             }
 
-            // テスト Org は、本番がない場合か、本番と「導出後の組織コード」が異なる場合のみ作成する。
-            // ホスト名は異なっても導出後コードが同一になるケース（例: www.shop.example.jp と
-            // shop.example.jp はいずれも shop-example-jp）があるため、生ホスト名ではなく
-            // 導出後コードで比較し、コード重複によるユニーク制約違反を防ぐ。
             if (testSite != null)
             {
-                var testCode = DeriveOrganizationCode(testSite.Host);
-                if (productionCode == null
-                    || !string.Equals(testCode, productionCode, StringComparison.OrdinalIgnoreCase))
-                {
-                    sites.Add(new SiteEntry(
-                        testCode, testSite.Host, testSite.BaseUrl,
-                        IsSandbox: true, "test_site_url"));
-                }
+                sites.Add(new SiteEntry(
+                    DeriveOrganizationCode(testSite.Host, isSandbox: true),
+                    testSite.Host, testSite.BaseUrl,
+                    IsSandbox: true, "test_site_url"));
             }
 
             return new SiteSet(
@@ -496,8 +495,23 @@ namespace IdentityProvider.Services
 
         private async Task EnsureOrganizationCodesAvailableAsync(SiteSet sites, CancellationToken ct, int statusCode = 422)
         {
-            // 同一リクエスト内で導出後の組織コードが衝突していないか検知する
-            // （本番・テストの URL が異なっても同じコードに導出されるケースを 422 で弾く）。
+            // 組織コードはテナント名（= {tenant}.ec-auth.io の 1 ラベル）になるため、
+            // DNS のラベル上限を超えるものは作らせない。作れても到達できないため。
+            foreach (var site in sites.Sites)
+            {
+                if (site.Code.Length > MaxOrganizationCodeLength)
+                {
+                    throw new SignupValidationException(
+                        "invalid_site_url",
+                        "サイト URL のドメインが長すぎます。より短いドメインでお申し込みください。",
+                        field: site.Field,
+                        statusCode: 422);
+                }
+            }
+
+            // 同一リクエスト内で導出後の組織コードが衝突していないか検知する。
+            // 本番とテストは接尾辞（-sandbox）で必ず分かれるため通常は発火しないが、
+            // 導出規則を将来変えたときに黙って 1 件に潰れるのを防ぐガードとして残す。
             var seenCodes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (var site in sites.Sites)
             {
@@ -505,7 +519,8 @@ namespace IdentityProvider.Services
                 {
                     throw new SignupValidationException(
                         "duplicate_site",
-                        "本番サイトとテストサイトが同一の組織コードに導出されます。異なるドメインでお申し込みください。",
+                        "本番サイトとテストサイトが同じ組織として扱われます。"
+                            + "テストサイトには別のドメインをご指定ください。",
                         field: site.Field,
                         statusCode: 422);
                 }
@@ -534,12 +549,26 @@ namespace IdentityProvider.Services
         /// ホスト名から組織コードを導出する。
         /// lowercase → 先頭 www. 除去 → サブドメイン保持 → 英数以外の連続を "-" に置換 → 前後の "-" を trim。
         /// 例: <c>shop.example.jp → shop-example-jp</c>。
+        ///
+        /// サンドボックス（テストサイト）の Org には必ず <c>-sandbox</c> を付ける。理由は 2 つある:
+        /// <list type="number">
+        ///   <item>
+        ///     本番と同じドメイン（あるいは <c>www.</c> の有無だけが違うドメイン）でもテスト Org を
+        ///     作れるようにするため。付けないと導出後コードが本番と衝突し、テスト環境を持たない
+        ///     顧客は検証にも本番 Org を使うしかなくなる（EcAuth#482 の問題 2）。
+        ///   </item>
+        ///   <item>
+        ///     組織コードはそのままテナント名になり、プラグインが接続する
+        ///     <c>https://{tenant}.ec-auth.io</c>（<c>ClientResolveController</c>）に現れる。
+        ///     接続先を見ただけで本番かサンドボックスかが分かる。
+        ///   </item>
+        /// </list>
         /// </summary>
-        private static string DeriveOrganizationCode(string host)
+        private static string DeriveOrganizationCode(string host, bool isSandbox)
         {
             var normalized = StripWwwPrefix(host.Trim().ToLowerInvariant());
             var code = NonAlphanumericRun.Replace(normalized, "-").Trim('-');
-            return code;
+            return isSandbox ? code + SandboxCodeSuffix : code;
         }
 
         /// <summary>

--- a/IdentityProvider/Services/SignupService.cs
+++ b/IdentityProvider/Services/SignupService.cs
@@ -526,11 +526,23 @@ namespace IdentityProvider.Services
                 }
             }
 
+            // ドメインの占有は「接尾辞を除いた導出コード」で判定する。site.Code をそのまま
+            // 比較すると、サンドボックス側だけコードが変わったせいで
+            //   - 旧規則（接尾辞なし）で登録済みのサンドボックス Org
+            //   - 本番として登録済みのドメイン
+            // を、別アカウントがテストサイトとして再登録できてしまう。
+            //
+            // 同一申込内での本番＋サンドボックス併存はこれでも壊れない。Organization の作成は
+            // このチェックより後（トランザクション内）で行うため、ペアの相方はまだ DB に無いため。
+            // 申込内の衝突判定は上の seenCodes が接尾辞込みのコードで行っており、そちらは併存を許す。
             foreach (var site in sites.Sites)
             {
+                var baseCode = DeriveOrganizationCode(site.Host, isSandbox: false);
+                var sandboxCode = baseCode + SandboxCodeSuffix;
+
                 var exists = await _context.Organizations
                     .IgnoreQueryFilters()
-                    .AnyAsync(o => o.Code == site.Code, ct);
+                    .AnyAsync(o => o.Code == baseCode || o.Code == sandboxCode, ct);
 
                 if (exists)
                 {


### PR DESCRIPTION
> **方針転換**: 当初この PR は「導出後コードが衝突する申込を 422 で弾く」実装でしたが、
> レビューで「テスト環境を別ドメインで持たない顧客が、検証にも本番 org を使うしかなくなる」
> という指摘を受け、**弾くのではなくサンドボックス org を作れるようにする**方向に変更しました。

## 背景

[#482 の残タスク 3 前半](https://github.com/EcAuth/EcAuth/issues/482)（issue 本文の「問題 2」）。

申込は入力された URL ごとに Organization を作りますが、導出後の組織コードが本番と一致すると
テスト Org を**黙って作らずに済ませていました**。

```
本番   https://shop.example.jp        → shop-example-jp
テスト https://www.shop.example.jp    → shop-example-jp  ← 衝突。黙って捨てられる
```

申込者は 2 サイト分申し込んだつもりで 1 つしか存在せず、**そのことを知らされません**。
さらに深刻なのは、**テスト環境を別ドメインで持たない顧客はサンドボックス Org を得る手段が無い**点です。
何か検証したくても本番 Org を使うしかなく、サイト追加 API もまだありません（#482 の「やること」）。

## 変更

サンドボックス Org の組織コードに**必ず `-sandbox` を付ける**。

| 本番 | テスト | 生成される Organization |
|---|---|---|
| `https://shop.example.jp` | `https://stg.example.jp` | `shop-example-jp` / `stg-example-jp-sandbox` |
| `https://shop.example.jp` | `https://www.shop.example.jp` | `shop-example-jp` / `shop-example-jp-sandbox` |
| `https://shop.example.jp` | `https://shop.example.jp`（同一 URL） | `shop-example-jp` / `shop-example-jp-sandbox` |
| `https://shop.example.jp` | `https://shop.example.jp/stg/` | `shop-example-jp` / `shop-example-jp-sandbox` |
| （なし） | `https://test.example.jp` | `test-example-jp-sandbox` |

### 衝突時だけでなく常に付ける理由

1. 規則を分岐させない（「なぜこの org だけ `-sandbox` が付くのか」を説明せずに済む）
2. 組織コードはそのままテナント名になり、プラグインが接続する `https://{tenant}.ec-auth.io`
   （`ClientResolveController.cs:61`）に現れる。**接続先を見ただけで本番かサンドボックスかが判別できる**

### 同一ドメインで両方作った場合

2 つの Client は `allowed_rp_ids` も `redirect_uri` も同じ値になりえますが、破綻しません。
プラグインは自分の `client_id` から `/platform/v1/client-resolve` でテナントを引くため、
**資格情報を差し替えるだけで本番 / サンドボックスを行き来できます**。
サブディレクトリ運用（`/stg/`）なら `redirect_uri` も分かれるので併存も可能です。

### DNS ラベル長の検証を追加

組織コードはテナント名 = `{tenant}.ec-auth.io` の**1 ラベル**になるため、DNS のラベル上限
（63 オクテット / RFC 1035）を超えると Org は作れてもそのサブドメインに到達できません。
`-sandbox` の分だけ上限に近づくので、超える申込を `invalid_site_url` で明示的に弾きます。
（従来は無検証で、超えた場合は到達不能な Org が黙って作られていました。）

### `duplicate_site` は残す

接尾辞により通常は到達しなくなりますが、導出規則を将来変えたときに黙って 1 件へ潰れるのを
防ぐガードとして残しています。

## 検証

**ユニットテスト**

```
成功!   -失敗:     0、合格:   713、スキップ:     0、合計:   713
```

- `ConfirmAsync_TestSiteOnSameDomain_CreatesSandboxOrganization`（Theory × 3）
  — `www.` 揺れ / 完全同一 URL / サブディレクトリの各ケースで 2 org 作られること
- `ConfirmAsync_TestSiteOnly_CreatesSandboxOrganization` — 本番 URL 無しでも接尾辞が付く
- `ConfirmAsync_ProductionAndTestDifferentHosts_CreatesTwoOrganizations` — ホストが分かれている
  従来ケースでもサンドボックス側に接尾辞が付く
- `RequestAsync_HostTooLongForDnsLabel_ThrowsInvalidSiteUrl` — 63 文字超を 422 で弾き、申込レコードも作らない

**ローカル Docker（実 SQL Server・申込 → 確認メール → confirm を通し）**

`www.` 揺れのケース:

```
code                       |tenant_name                |is_sandbox|uri                                            |allowed_rp_ids
shop-samedomain-jp         |shop-samedomain-jp         |0         |https://shop.samedomain.jp/ecauth/callback     |["shop.samedomain.jp"]
shop-samedomain-jp-sandbox |shop-samedomain-jp-sandbox |1         |https://www.shop.samedomain.jp/ecauth/callback |["www.shop.samedomain.jp","shop.samedomain.jp"]
```

本番とテストに**完全に同じ URL**を入れたケース（テスト環境を持たない顧客の経路）:

```
code                        |is_sandbox|client_id                                                  |uri
onlysite-example-jp         |0         |ec-onlysite-example-jp-58f83080d79d4edaae62280a39d08fa3    |https://onlysite.example.jp/ecauth/callback
onlysite-example-jp-sandbox |1         |ec-onlysite-example-jp-sandbox-cb2b552547574d32a04301b4a10 |https://onlysite.example.jp/ecauth/callback
```

`client_id` は別、`redirect_uri` は同じ。プラグイン側で資格情報を切り替えれば両方使えます。

### 互換性

**既存の Organization は変更しません**（新規申込のみ対象）。データ移行もありません。
これ以降に作られるサンドボックス org のテナント名が `-sandbox` 付きになるだけです。

### 未検証

- マイページ UI 上での見え方（`GET /v1/account/clients` は既に `is_sandbox` を返すので
  サイト側の対応は可能。EcAuth/ecauth-website#20 の範囲）
- E2E は申込に本番 URL のみを渡すため、この変更の影響を受けません。本番スモークで作られる
  Organization を run あたり 2 倍にしないため、テストサイトを足す変更は入れていません

Refs #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 申込時に、本番環境とテスト環境を区別した組織コードを自動生成します。
  - テスト環境の組織コードには `-sandbox` が付加されます。
  - テストサイトのみの申込でも、サンドボックス組織を作成できるようになりました。

- **バグ修正**
  - 組織コードが長すぎるURLを適切に拒否し、`invalid_site_url` エラーを表示します。
  - 本番・テストURLの組み合わせによる重複エラーを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->