### PR TITLE
test(e2e): マイページの設定編集 UI を実バックエンドに通す

### DIFF
--- a/E2ETests/tests/specs/website_signup_flow.spec.ts
+++ b/E2ETests/tests/specs/website_signup_flow.spec.ts
@@ -15,6 +15,7 @@ import { createMailbox, extractToken, Mailbox } from '../helpers/mailbox';
  *     → /mypage/ から PKCE で認可開始 → accounts で実パスキー認証 → 認可コード
  *     → /auth/callback が /v1/token でトークン交換（public client・PKCE）
  *     → /v1/account/clients で Client 一覧、secret の reveal / 再生成
+ *     → マイページの編集 UI から redirect_uri / allowed_rp_ids を実 API で全置換
  *     → リカバリ（マジックリンク）でも同じマイページに着地する
  *
  * 前提（CI では playwright.yml が用意する）:
@@ -232,6 +233,116 @@ test.describe.serial('ecauth-website フロント × EcAuth 実バックエン�
     const regenerated = (await secretRow.locator('code').textContent())?.trim() ?? '';
     expect(regenerated.length).toBeGreaterThan(10);
     expect(regenerated).not.toBe(revealed);
+  });
+
+  /**
+   * マイページの Client 設定セクション（ecauth-website の mypage.js が data-section で出す）。
+   */
+  function settingsSection(key: 'redirect_uris' | 'allowed_rp_ids') {
+    return page
+      .locator('.client-item')
+      .filter({ hasText: expectedOrgCode })
+      .locator(`.ci-settings[data-section="${key}"]`);
+  }
+
+  /**
+   * 編集 UI（EcAuth/ecauth-website#19）を含まない ref を配信している場合に、そのケースだけ
+   * 明示理由付きでスキップする。CI は既定で ecauth-website のデフォルトブランチを checkout
+   * するため、website 側が未マージの間はセクションごと存在しない。
+   */
+  async function skipUnlessSettingsUi() {
+    const present = await settingsSection('redirect_uris').count();
+    test.skip(
+      present === 0,
+      'ecauth-website の ref に Client 設定の編集 UI がありません（EcAuth/ecauth-website#19 未マージ）。'
+        + ' workflow_dispatch の website_ref に該当ブランチを指定すると検証できます。'
+    );
+  }
+
+  /** 畳まれていれば開いて返す（reload すると details は閉じた状態に戻る）。 */
+  async function openSettings(key: 'redirect_uris' | 'allowed_rp_ids') {
+    const section = settingsSection(key);
+    await expect(section).toHaveCount(1, { timeout: 15000 });
+    if (!(await section.locator('.row-list').isVisible())) {
+      await section.locator('summary').click();
+    }
+    await expect(section.locator('.row-list')).toBeVisible();
+    return section;
+  }
+
+  /** 設定セクションの入力欄の値を表示順に取り出す。 */
+  function inputValuesOf(section: ReturnType<typeof settingsSection>): Promise<string[]> {
+    return section.locator('.row-input').evaluateAll((els) => els.map((e) => (e as HTMLInputElement).value));
+  }
+
+  test('マイページの編集 UI から redirect_uri を追加でき、実 API 側に残る', async () => {
+    test.setTimeout(45000);
+    await skipUnlessSettingsUi();
+
+    const section = await openSettings('redirect_uris');
+
+    // 申込が作る初期値は EC-CUBE 4 系のコールバック URL。プラグインが authenticate/verify に
+    // 送る値と一致していることを、API 直叩きではなく画面越しに確認する。
+    expect(await inputValuesOf(section)).toEqual([`https://${productionSiteHost}/ecauth/callback`]);
+
+    const added = `https://${productionSiteHost}/shop/ecauth/callback`;
+    await section.locator('.row-add').click();
+    await section.locator('.row-input').nth(1).fill(added);
+    await section.getByRole('button', { name: '保存' }).click();
+
+    await expect(section.locator('[data-status="section"]')).toHaveClass(/ok/, { timeout: 15000 });
+    await expect(section.locator('.ci-count')).toHaveText('2 件');
+
+    // 画面の状態ではなく、取り直した一覧で永続化を確認する。
+    await page.reload();
+    const reloaded = await openSettings('redirect_uris');
+    // redirect_uri の取得に ORDER BY は無いため、順序ではなく集合で比較する。
+    expect((await inputValuesOf(reloaded)).slice().sort()).toEqual(
+      [`https://${productionSiteHost}/ecauth/callback`, added].sort()
+    );
+  });
+
+  test('RP ID の編集は確認ダイアログを経て保存され、サーバ側で正規化される', async () => {
+    test.setTimeout(45000);
+    await skipUnlessSettingsUi();
+
+    const section = await openSettings('allowed_rp_ids');
+    expect(await inputValuesOf(section)).toEqual([productionSiteHost]);
+
+    // 大文字で入れてもサーバが小文字（Punycode）に正規化して返す。
+    page.once('dialog', (dialog) => dialog.accept());
+    await section.locator('.row-input').nth(0).fill(productionSiteHost.toUpperCase());
+    await section.getByRole('button', { name: '保存' }).click();
+
+    await expect(section.locator('[data-status="section"]')).toHaveClass(/ok/, { timeout: 15000 });
+    expect(await inputValuesOf(section)).toEqual([productionSiteHost]);
+
+    await page.reload();
+    const reloaded = await openSettings('allowed_rp_ids');
+    expect(await inputValuesOf(reloaded)).toEqual([productionSiteHost]);
+  });
+
+  test('実 API の 422 が入力値を含まない理由付きでフロントに表示される', async () => {
+    test.setTimeout(45000);
+    await skipUnlessSettingsUi();
+
+    const section = await openSettings('redirect_uris');
+
+    // https 必須。サーバは入力値をエラーに載せず「N 件目」という位置だけを返す
+    // （redirect_uri は user:pass@ を含みうるため）。フロントの行番号と対応することまで見る。
+    await section.locator('.row-input').nth(0).fill(`http://${productionSiteHost}/ecauth/callback`);
+    await section.getByRole('button', { name: '保存' }).click();
+
+    const status = section.locator('[data-status="section"]');
+    await expect(status).toHaveClass(/err/, { timeout: 15000 });
+    await expect(status).toContainText('1 件目');
+    await expect(status).toContainText('https://');
+    // 入力値そのものは反映されない（ログ・エラーレポートに資格情報を残さないため）。
+    await expect(status).not.toContainText(productionSiteHost);
+
+    // 失敗しても入力は保持され、直して再送できる状態のままであること。
+    expect(await inputValuesOf(section)).toContain(`http://${productionSiteHost}/ecauth/callback`);
+    await section.getByRole('button', { name: '取り消し' }).click();
   });
 
   test('リカバリ: /signin/ からマジックリンクを要求し、マイページに着地する', async () => {

--- a/E2ETests/tests/specs/website_signup_flow.spec.ts
+++ b/E2ETests/tests/specs/website_signup_flow.spec.ts
@@ -21,6 +21,9 @@ import { createMailbox, extractToken, Mailbox } from '../helpers/mailbox';
  * 前提（CI では playwright.yml が用意する）:
  *   - IdentityProvider が https://localhost:8081 で稼働し、accounts.ec-auth.io に解決すること
  *   - ecauth-website を hugo server --tlsAuto で E2E_WEBSITE_BASE_URL に配信していること
+ *     （配信する ref に Client 設定の編集 UI が含まれること。無い場合は skip せず**失敗**させる。
+ *       DOM の有無で skip すると、削除・セレクタ変更・描画失敗という本来検出すべき回帰まで
+ *       「機能が無いだけ」と誤認し、CI が緑のまま通ってしまうため）
  *   - サーバ側が以下を website のオリジンに向けて配線していること
  *       Signup__AllowedOrigins__0 / Frontend__BaseUrl /
  *       Signup__ConfirmBaseUrl__accounts / MagicLink__BaseUrl__accounts / ACCOUNTS_REDIRECT_URI
@@ -245,20 +248,6 @@ test.describe.serial('ecauth-website フロント × EcAuth 実バックエン�
       .locator(`.ci-settings[data-section="${key}"]`);
   }
 
-  /**
-   * 編集 UI（EcAuth/ecauth-website#19）を含まない ref を配信している場合に、そのケースだけ
-   * 明示理由付きでスキップする。CI は既定で ecauth-website のデフォルトブランチを checkout
-   * するため、website 側が未マージの間はセクションごと存在しない。
-   */
-  async function skipUnlessSettingsUi() {
-    const present = await settingsSection('redirect_uris').count();
-    test.skip(
-      present === 0,
-      'ecauth-website の ref に Client 設定の編集 UI がありません（EcAuth/ecauth-website#19 未マージ）。'
-        + ' workflow_dispatch の website_ref に該当ブランチを指定すると検証できます。'
-    );
-  }
-
   /** 畳まれていれば開いて返す（reload すると details は閉じた状態に戻る）。 */
   async function openSettings(key: 'redirect_uris' | 'allowed_rp_ids') {
     const section = settingsSection(key);
@@ -275,9 +264,23 @@ test.describe.serial('ecauth-website フロント × EcAuth 実バックエン�
     return section.locator('.row-input').evaluateAll((els) => els.map((e) => (e as HTMLInputElement).value));
   }
 
+  /*
+   * 以下の初期値アサーションは、期待値を productionSiteHost から**意図的に**組み立てている。
+   *
+   * CLAUDE.md の「redirect_uri / rp_id をテスト側で組み立てない」が禁じているのは
+   * authenticate/verify に**送る値**（セレモニーの入力）であって、期待値ではない。
+   * 期待値まで登録値に置き換えると「UI が API の返した値を表示している」ことしか見なくなり、
+   * どんな誤った初期値が登録されていても通る恒真式になる — それは EcAuth#481 そのもの。
+   *
+   * 参照実装 signup_client_b2b_login.spec.ts も同じ使い分けをしている:
+   *   :180 / :187  期待値は siteHost から組み立てて登録値と突き合わせる（回帰検出）
+   *   :207 / :225  セレモニーに渡すのは API から取った registeredRpId / registeredRedirectUri
+   * 画面に出ている値は mypage.js が GET /v1/account/clients を描画したものなので、
+   * 「登録値を使う」側の要請はブラウザ経由で既に満たされている。
+   */
+
   test('マイページの編集 UI から redirect_uri を追加でき、実 API 側に残る', async () => {
     test.setTimeout(45000);
-    await skipUnlessSettingsUi();
 
     const section = await openSettings('redirect_uris');
 
@@ -304,7 +307,6 @@ test.describe.serial('ecauth-website フロント × EcAuth 実バックエン�
 
   test('RP ID の編集は確認ダイアログを経て保存され、サーバ側で正規化される', async () => {
     test.setTimeout(45000);
-    await skipUnlessSettingsUi();
 
     const section = await openSettings('allowed_rp_ids');
     expect(await inputValuesOf(section)).toEqual([productionSiteHost]);
@@ -324,7 +326,6 @@ test.describe.serial('ecauth-website フロント × EcAuth 実バックエン�
 
   test('実 API の 422 が入力値を含まない理由付きでフロントに表示される', async () => {
     test.setTimeout(45000);
-    await skipUnlessSettingsUi();
 
     const section = await openSettings('redirect_uris');
 


### PR DESCRIPTION
## 概要

マイページの **redirect_uri / RP ID 編集 UI**（EcAuth/ecauth-website#19、[ecauth-website#22](https://github.com/EcAuth/ecauth-website/pull/22) — **マージ済み**）を、`website_signup_flow.spec.ts` で**実バックエンドに通します**。

ecauth-website 側の E2E は API を `page.route()` でスタブするため高速に回りますが、**実 API との契約齟齬・実 CORS** は検出できません。その層は従来どおり本 spec が担当します。

本番コードの変更はありません（差分は `E2ETests/` の 1 ファイルのみ）。

## 追加したケース

| ケース | 何を固定するか |
|---|---|
| 編集 UI から redirect_uri を追加でき、実 API 側に残る | 申込が作る初期値が EC-CUBE 4 系のコールバック URL であることを**画面越しに**確認し、追加 → 保存 → reload で永続化まで見る |
| RP ID の編集は確認ダイアログを経て保存され、サーバ側で正規化される | 大文字入力が実サーバで小文字に正規化されて返ること |
| 実 API の 422 が入力値を含まない理由付きで表示される | 「1 件目」という**位置**で返り、かつ入力値そのものは含まれないこと（ログ・エラーレポートに資格情報を残さない仕様の end-to-end 確認） |

## この spec が実際に不具合を捕まえたこと

ローカル検証の初回実行で、期待どおり実 CORS の失敗を検出しました。

```
[console.error] Access to fetch at 'https://accounts.ec-auth.io:8081/v1/account/clients/1010/redirect-uris'
  from origin 'https://ec-auth.io:1313' has been blocked by CORS policy:
  Response to preflight request doesn't pass access control check:
  No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

原因は起動中のコンテナが #495 マージ前のイメージで、エンドポイント自体が存在しなかったこと（ルート未一致の 404 には CORS ミドルウェアがヘッダを付けない）。イメージを再ビルドしたうえで preflight が通ることを確認しています。

```
$ curl -k -i -X OPTIONS 'https://localhost:8081/v1/account/clients/1/redirect-uris' \
    -H 'Origin: https://ec-auth.io:1313' -H 'Access-Control-Request-Method: POST' \
    -H 'Access-Control-Request-Headers: content-type,authorization'
HTTP/2 204
access-control-allow-headers: content-type,authorization
access-control-allow-methods: GET,POST,OPTIONS
access-control-allow-origin: https://ec-auth.io:1313
```

スタブ前提のフロント単体スイートでは原理的に見えない層です。

## レビュー対応（561a3e9）

当初は「編集 UI が未マージの ref なら該当 3 ケースだけ skip する」DOM ベースのガードを入れていましたが、指摘（[#discussion_r3697961160](https://github.com/EcAuth/EcAuth/pull/497#discussion_r3697961160) / [#discussion_r3697965702](https://github.com/EcAuth/EcAuth/pull/497#discussion_r3697965702)）を受けて**削除**しました。

- DOM の有無では「ref が古い」と「セレクタ変更・削除・描画失敗」を区別できず、後者が起きても **CI は緑のまま 3 件が skipped と報告されるだけ**になる
- `locator.count()` は自動待機しないため、描画が遅れると存在しても false skip しうる（最悪の失敗モードは同じく「緑のままスキップ」）
- 依存（ecauth-website#22）がマージされた今、UI の不在はまさに本スイートが検出すべき回帰

これによりマージ順序が人間の記憶ではなく CI で担保されます。

## ローカル検証

`.github/workflows/playwright.yml` の "Configure frontend wiring" と同じ配線でローカル Docker + hugo server を立てて実行しました。

**編集 UI を含む ref**

```
11 passed (5.8s)
```

**編集 UI を含まない ref（回帰を模擬）— skip ではなく失敗すること**

```
  ✘   7 マイページの編集 UI から redirect_uri を追加でき、実 API 側に残る (15.1s)
    Error: expect(locator).toHaveCount(expected) failed
    > 254 |     await expect(section).toHaveCount(1, { timeout: 15000 });
  1 failed
  6 passed (17.9s)
```

検証後、ローカルの Docker 配線は dev の既定値に戻してあります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)