### PR TITLE
feat(account): マイページからサイト（Organization）を追加・削除できるようにする

### DIFF
--- a/E2ETests/tests/helpers/accounts.ts
+++ b/E2ETests/tests/helpers/accounts.ts
@@ -41,6 +41,8 @@ export interface SignupOptions {
   organizationName: string;
   /** 申込するサイトの URL。ここから Organization code / rp_id / redirect_uri が導出される */
   productionSiteUrl: string;
+  /** テストサイトの URL（任意）。渡すとサンドボックス Org が本番の子として一緒に作られる。 */
+  testSiteUrl?: string;
   /** "2" | "4" | "other" */
   ecCubeVersion: string;
 }
@@ -97,6 +99,7 @@ export async function signupAndGetAccountToken(
       organization_name: options.organizationName,
       contact_name: 'E2E Tester',
       production_site_url: options.productionSiteUrl,
+      test_site_url: options.testSiteUrl,
       ec_cube_version: options.ecCubeVersion,
     },
   });

--- a/E2ETests/tests/specs/account_site_delete_concurrency.spec.ts
+++ b/E2ETests/tests/specs/account_site_delete_concurrency.spec.ts
@@ -1,0 +1,154 @@
+import { test, expect, APIRequestContext, BrowserContext, request } from '@playwright/test';
+import { signupAndGetAccountToken } from '../helpers/accounts';
+import { createMailbox, Mailbox } from '../helpers/mailbox';
+
+/**
+ * サンドボックス追加と、その親（本番サイト）の削除が競合しても、
+ * **論理削除済みの親を指す有効なサンドボックスが残らない**ことを検証する。
+ *
+ * ロックが無いと次のすれ違いが起きる:
+ *   1. 追加リクエストがトランザクション外のスナップショットで親を「有効」と判定する
+ *   2. 削除リクエストが親を論理削除する。このとき追加中のサンドボックスはまだコミットされて
+ *      いないため、削除側のカスケード対象に入らない
+ *   3. 追加がコミットされ、削除済みの親を指す有効なサンドボックスが残る
+ *
+ * 一度できてしまうと削除側が後から拾い直す経路は無く、`GET /v1/account/organizations` は
+ * 親のいないサンドボックスを返し続ける。AccountController は追加・削除の両方で同じ
+ * アカウント行を `UPDLOCK, HOLDLOCK` で取ることでこれを直列化している。
+ *
+ * ロックは実 SQL Server でしか効かない（InMemory はフォールバック）ため、この検証は E2E に置く。
+ */
+test.describe.serial('サンドボックス追加と親削除の競合', () => {
+  const tenantBaseDomain = process.env.E2E_TENANT_BASE_DOMAIN;
+  const remote = Boolean(tenantBaseDomain);
+
+  const baseUrl = process.env.E2E_BASE_URL || 'https://localhost:8081';
+  const accountsHost =
+    process.env.E2E_ACCOUNTS_HOST || (remote ? `stg-accounts.${tenantBaseDomain}` : 'accounts.ec-auth.io');
+  const accountsPageBaseUrl =
+    process.env.E2E_ACCOUNTS_PAGE_URL || (remote ? `https://${accountsHost}` : `https://${accountsHost}:8081`);
+  const accountsClientId = process.env.ACCOUNTS_CLIENT_ID || 'ecauth-admin-console';
+  const accountsClientSecret = process.env.ACCOUNTS_CLIENT_SECRET || undefined;
+  const accountsRedirectUri =
+    process.env.ACCOUNTS_REDIRECT_URI ||
+    (remote ? `https://${accountsHost}/auth/callback` : 'https://localhost:8081/auth/callback');
+
+  const runSuffix = `${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+  const siteHost = `e2e-race-${runSuffix}.test`;
+  const email = `e2e-race-${runSuffix}@e2e.ec-auth.io`;
+
+  const accountsApiBaseUrl = remote ? `https://${accountsHost}` : baseUrl;
+
+  // 競合はタイミング依存なので複数ラウンド試す。ロックが無い実装では、
+  // このいずれかのラウンドで孤立サンドボックスが生まれる。
+  const ROUNDS = 5;
+
+  let api: APIRequestContext;
+  let mailbox: Mailbox;
+  let context: BrowserContext;
+  let accessToken: string;
+
+  test.describe.configure({ retries: 0 });
+
+  const authHeaders = () => ({ Authorization: `Bearer ${accessToken}` });
+
+  type OrganizationSummary = {
+    id: number;
+    is_sandbox: boolean;
+    parent_organization_id: number | null;
+  };
+
+  const listOrganizations = async (): Promise<OrganizationSummary[]> => {
+    const response = await api.get(`${accountsApiBaseUrl}/v1/account/organizations`, {
+      headers: authHeaders(),
+    });
+    expect(response.status()).toBe(200);
+    return (await response.json()).organizations;
+  };
+
+  test.beforeAll(async ({ browser }) => {
+    console.log(`[delete-race] site=${siteHost} email=${email}`);
+
+    api = await request.newContext({
+      ignoreHTTPSErrors: true,
+      ...(remote ? {} : { extraHTTPHeaders: { Host: accountsHost } }),
+    });
+    mailbox = await createMailbox();
+
+    context = await browser.newContext({ ignoreHTTPSErrors: true });
+    await context.credentials.install();
+
+    await context.route(/\/mypage\//, (route) =>
+      route.fulfill({ status: 200, contentType: 'text/html', body: '<html><body>mypage stub</body></html>' })
+    );
+
+    const result = await signupAndGetAccountToken(api, mailbox, context, {
+      baseUrl: accountsApiBaseUrl,
+      accountsHost,
+      accountsPageBaseUrl,
+      accountsClientId,
+      accountsClientSecret,
+      accountsRedirectUri,
+      email,
+      organizationName: `E2E Delete Race ${runSuffix}`,
+      productionSiteUrl: `https://${siteHost}/`,
+      ecCubeVersion: '4',
+    });
+    accessToken = result.accessToken;
+  });
+
+  test.afterAll(async () => {
+    await Promise.allSettled([mailbox?.cleanup(email), api?.dispose(), context?.close()]);
+    await mailbox?.dispose();
+  });
+
+  test('サンドボックス追加と親削除を同時に投げても孤立サンドボックスが残らない', async () => {
+    for (let round = 0; round < ROUNDS; round++) {
+      // 各ラウンドで使い捨ての本番サイトを用意する（削除するため再利用できない）。
+      const created = await api.post(`${accountsApiBaseUrl}/v1/account/organizations`, {
+        headers: authHeaders(),
+        data: { site_url: `https://e2e-race-${runSuffix}-p${round}.test/` },
+      });
+      expect(created.status(), `round ${round}: 本番サイトの用意`).toBe(201);
+      const parentId = (await created.json()).id as number;
+
+      // サンドボックス追加と親削除を同時に投げる。
+      const [addResponse, deleteResponse] = await Promise.all([
+        api.post(`${accountsApiBaseUrl}/v1/account/organizations`, {
+          headers: authHeaders(),
+          data: {
+            site_url: `https://e2e-race-${runSuffix}-s${round}.test/`,
+            is_sandbox: true,
+            parent_organization_id: parentId,
+          },
+        }),
+        api.post(`${accountsApiBaseUrl}/v1/account/organizations/${parentId}/delete`, {
+          headers: authHeaders(),
+        }),
+      ]);
+
+      // どちらが先に処理されるかは決まらない。許されるのは次の 2 通りだけ:
+      //   - 追加が先: サンドボックスが作られ、削除がそれをカスケードで消す
+      //   - 削除が先: 追加が invalid_parent で弾かれる
+      const addStatus = addResponse.status();
+      expect([201, 422], `round ${round}: 追加のステータス=${addStatus}`).toContain(addStatus);
+      if (addStatus === 422) {
+        expect((await addResponse.json()).error).toBe('invalid_parent');
+      }
+      expect(deleteResponse.status(), `round ${round}: 削除のステータス`).toBe(200);
+
+      // 本題の不変条件: 一覧に出るサンドボックスは、必ず親も一覧に出ている
+      //（＝親が有効である）こと。孤立サンドボックスはここで検出される。
+      const organizations = await listOrganizations();
+      const visibleIds = new Set(organizations.map((o) => o.id));
+      const orphans = organizations.filter(
+        (o) => o.is_sandbox && (o.parent_organization_id === null || !visibleIds.has(o.parent_organization_id))
+      );
+
+      expect(
+        orphans,
+        `round ${round}: 削除済みの親を指すサンドボックスが残った: ${JSON.stringify(orphans)}`
+      ).toEqual([]);
+    }
+  });
+});

--- a/E2ETests/tests/specs/account_site_limit_concurrency.spec.ts
+++ b/E2ETests/tests/specs/account_site_limit_concurrency.spec.ts
@@ -1,0 +1,159 @@
+import { test, expect, APIRequestContext, BrowserContext, request } from '@playwright/test';
+import { signupAndGetAccountToken } from '../helpers/accounts';
+import { createMailbox, Mailbox } from '../helpers/mailbox';
+
+/**
+ * 本番サイト数の上限が、同一アカウントの並行リクエストでも破られないことを検証する。
+ *
+ * 「アカウントあたりの本番サイト数」は集計値で DB 制約として表現できない。既存の制約は
+ * どちらもこのケースを止められない:
+ *   - IX_organization_parent_organization_id_active は parent_organization_id が非 null の
+ *     行だけが対象で、本番 Org（null）は含まれない
+ *   - organization.Code のユニーク制約は、別ドメイン同士なら衝突しない
+ * したがって AccountController がトランザクション内で account 行に UPDLOCK/HOLDLOCK を掛けて
+ * 直列化するのが唯一の保護になる。
+ *
+ * この spec が E2E にあるのは、ロックが**実 SQL Server でしか効かない**ため。
+ * ユニットテストの InMemory プロバイダは生 SQL を実行できず、
+ * LoadMaxSitesForUpdateAsync は通常の読み取りにフォールバックする。
+ */
+test.describe.serial('本番サイト上限の並行リクエスト耐性', () => {
+  const tenantBaseDomain = process.env.E2E_TENANT_BASE_DOMAIN;
+  const remote = Boolean(tenantBaseDomain);
+
+  const baseUrl = process.env.E2E_BASE_URL || 'https://localhost:8081';
+  const accountsHost =
+    process.env.E2E_ACCOUNTS_HOST || (remote ? `stg-accounts.${tenantBaseDomain}` : 'accounts.ec-auth.io');
+  const accountsPageBaseUrl =
+    process.env.E2E_ACCOUNTS_PAGE_URL || (remote ? `https://${accountsHost}` : `https://${accountsHost}:8081`);
+  const accountsClientId = process.env.ACCOUNTS_CLIENT_ID || 'ecauth-admin-console';
+  const accountsClientSecret = process.env.ACCOUNTS_CLIENT_SECRET || undefined;
+  const accountsRedirectUri =
+    process.env.ACCOUNTS_REDIRECT_URI ||
+    (remote ? `https://${accountsHost}/auth/callback` : 'https://localhost:8081/auth/callback');
+
+  const runSuffix = `${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+  const siteHost = `e2e-limit-${runSuffix}.test`;
+  const email = `e2e-limit-${runSuffix}@e2e.ec-auth.io`;
+
+  const accountsApiBaseUrl = remote ? `https://${accountsHost}` : baseUrl;
+
+  // account.max_sites の既定値。DB を直接更新すれば変えられるが、E2E からは触らない。
+  const MAX_SITES = 10;
+  // 同時に投げるリクエスト数。上限ぴったりの状態から複数を並行させ、1 件も通らないことを見る。
+  const CONCURRENCY = 4;
+
+  let api: APIRequestContext;
+  let mailbox: Mailbox;
+  let context: BrowserContext;
+  let accessToken: string;
+
+  test.describe.configure({ retries: 0 });
+
+  const authHeaders = () => ({ Authorization: `Bearer ${accessToken}` });
+
+  const addProductionSite = (host: string) =>
+    api.post(`${accountsApiBaseUrl}/v1/account/organizations`, {
+      headers: authHeaders(),
+      data: { site_url: `https://${host}/` },
+    });
+
+  test.beforeAll(async ({ browser }) => {
+    console.log(`[site-limit] site=${siteHost} email=${email}`);
+
+    api = await request.newContext({
+      ignoreHTTPSErrors: true,
+      ...(remote ? {} : { extraHTTPHeaders: { Host: accountsHost } }),
+    });
+    mailbox = await createMailbox();
+
+    context = await browser.newContext({ ignoreHTTPSErrors: true });
+    await context.credentials.install();
+
+    await context.route(/\/mypage\//, (route) =>
+      route.fulfill({ status: 200, contentType: 'text/html', body: '<html><body>mypage stub</body></html>' })
+    );
+
+    const result = await signupAndGetAccountToken(api, mailbox, context, {
+      baseUrl: accountsApiBaseUrl,
+      accountsHost,
+      accountsPageBaseUrl,
+      accountsClientId,
+      accountsClientSecret,
+      accountsRedirectUri,
+      email,
+      organizationName: `E2E Site Limit ${runSuffix}`,
+      productionSiteUrl: `https://${siteHost}/`,
+      ecCubeVersion: '4',
+    });
+    accessToken = result.accessToken;
+  });
+
+  test.afterAll(async () => {
+    await Promise.allSettled([mailbox?.cleanup(email), api?.dispose(), context?.close()]);
+    await mailbox?.dispose();
+  });
+
+  test('上限ちょうどまで本番サイトを追加できる', async () => {
+    // 申込で 1 件できているので、残りを順番に埋める。
+    for (let i = 2; i <= MAX_SITES; i++) {
+      const response = await addProductionSite(`e2e-limit-${runSuffix}-${i}.test`);
+      expect(response.status(), `${i} 件目の追加`).toBe(201);
+    }
+
+    const list = await api.get(`${accountsApiBaseUrl}/v1/account/organizations`, { headers: authHeaders() });
+    const body = await list.json();
+    expect(body.production_site_count).toBe(MAX_SITES);
+    expect(body.max_sites).toBe(MAX_SITES);
+  });
+
+  test('上限到達後は並行リクエストでも 1 件も作られない', async () => {
+    // 別ドメインを同時に投げる。組織コードが互いに違うため unique 制約では止まらず、
+    // アカウント行のロックだけが上限を守る。
+    const responses = await Promise.all(
+      Array.from({ length: CONCURRENCY }, (_, i) =>
+        addProductionSite(`e2e-limit-${runSuffix}-race-${i}.test`)
+      )
+    );
+
+    const statuses = responses.map((r) => r.status());
+    expect(statuses.every((s) => s === 422), `statuses=${statuses.join(',')}`).toBe(true);
+
+    for (const response of responses) {
+      expect((await response.json()).error).toBe('site_limit_exceeded');
+    }
+
+    // 実際に増えていないことを DB 由来の一覧で確認する。
+    const list = await api.get(`${accountsApiBaseUrl}/v1/account/organizations`, { headers: authHeaders() });
+    expect((await list.json()).production_site_count).toBe(MAX_SITES);
+  });
+
+  test('1 枠空けると、並行リクエストのうち 1 件だけが成功する', async () => {
+    // ここが本題。ロックが無いと全リクエストが同じカウントを読み、複数が 201 になる。
+    const list = await api.get(`${accountsApiBaseUrl}/v1/account/organizations`, { headers: authHeaders() });
+    const organizations = (await list.json()).organizations as Array<{ id: number; is_sandbox: boolean }>;
+    const victim = organizations.filter((o) => !o.is_sandbox).at(-1)!;
+
+    const deleted = await api.post(
+      `${accountsApiBaseUrl}/v1/account/organizations/${victim.id}/delete`,
+      { headers: authHeaders() }
+    );
+    expect(deleted.status()).toBe(200);
+
+    const responses = await Promise.all(
+      Array.from({ length: CONCURRENCY }, (_, i) =>
+        addProductionSite(`e2e-limit-${runSuffix}-slot-${i}.test`)
+      )
+    );
+
+    const statuses = responses.map((r) => r.status());
+    const created = statuses.filter((s) => s === 201).length;
+    const rejected = statuses.filter((s) => s === 422).length;
+
+    expect(created, `statuses=${statuses.join(',')}`).toBe(1);
+    expect(rejected).toBe(CONCURRENCY - 1);
+
+    const after = await api.get(`${accountsApiBaseUrl}/v1/account/organizations`, { headers: authHeaders() });
+    expect((await after.json()).production_site_count).toBe(MAX_SITES);
+  });
+});

--- a/E2ETests/tests/specs/account_site_management.spec.ts
+++ b/E2ETests/tests/specs/account_site_management.spec.ts
@@ -1,0 +1,234 @@
+import { test, expect, APIRequestContext, BrowserContext, request } from '@playwright/test';
+import { signupAndGetAccountToken } from '../helpers/accounts';
+import { createMailbox, Mailbox } from '../helpers/mailbox';
+
+/**
+ * マイページからのサイト（Organization）追加・削除を、実バックエンドに対して通す（EcAuth#482）。
+ *
+ * 申込では本番・テストの片方しか登録しないケースがあり、後からもう一方を足す手段が
+ * 無かった。サイト = Organization は 1:1 なので「追加」は Organization の新規作成になる。
+ * ユニットテストは InMemory プロバイダで動くため、以下は実 DB でしか確かめられない:
+ *   - フィルター付きユニークインデックスによる「1 本番 1 テスト」の担保
+ *   - 論理削除しても組織コードが解放されないこと（unique 制約は削除済み行にも効く）
+ *   - 削除済みサイトの client_id が /platform/v1/client-resolve から引けなくなること
+ *
+ * 申込と同じく疑似サイトのホストには .test（RFC 6761 の予約 TLD）を使い、run ごとに
+ * 一意化して残存データとの衝突を避ける。
+ */
+test.describe.serial('マイページからのサイト追加・削除', () => {
+  const tenantBaseDomain = process.env.E2E_TENANT_BASE_DOMAIN;
+  const remote = Boolean(tenantBaseDomain);
+
+  const baseUrl = process.env.E2E_BASE_URL || 'https://localhost:8081';
+  const accountsHost =
+    process.env.E2E_ACCOUNTS_HOST || (remote ? `stg-accounts.${tenantBaseDomain}` : 'accounts.ec-auth.io');
+  const accountsPageBaseUrl =
+    process.env.E2E_ACCOUNTS_PAGE_URL || (remote ? `https://${accountsHost}` : `https://${accountsHost}:8081`);
+  const accountsClientId = process.env.ACCOUNTS_CLIENT_ID || 'ecauth-admin-console';
+  const accountsClientSecret = process.env.ACCOUNTS_CLIENT_SECRET || undefined;
+  const accountsRedirectUri =
+    process.env.ACCOUNTS_REDIRECT_URI ||
+    (remote ? `https://${accountsHost}/auth/callback` : 'https://localhost:8081/auth/callback');
+
+  const runSuffix = `${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+  const siteHost = `e2e-site-${runSuffix}.test`;
+  const addedSiteHost = `e2e-added-${runSuffix}.test`;
+  const productionSiteUrl = `https://${siteHost}/`;
+  const email = `e2e-site-${runSuffix}@e2e.ec-auth.io`;
+
+  const accountsApiBaseUrl = remote ? `https://${accountsHost}` : baseUrl;
+
+  let api: APIRequestContext;
+  let mailbox: Mailbox;
+  let context: BrowserContext;
+  let accessToken: string;
+
+  // 申込 Org の組織コードは host から導出されるためリトライしても同じになり、
+  // 2 回目は必ず organization_already_exists になる（本当の失敗理由が隠れる）。
+  test.describe.configure({ retries: 0 });
+
+  const authHeaders = () => ({ Authorization: `Bearer ${accessToken}` });
+
+  test.beforeAll(async ({ browser }) => {
+    console.log(`[site-management] site=${siteHost} added=${addedSiteHost} email=${email}`);
+
+    api = await request.newContext({
+      ignoreHTTPSErrors: true,
+      ...(remote ? {} : { extraHTTPHeaders: { Host: accountsHost } }),
+    });
+    mailbox = await createMailbox();
+
+    context = await browser.newContext({ ignoreHTTPSErrors: true });
+    await context.credentials.install();
+
+    await context.route(/\/mypage\//, (route) =>
+      route.fulfill({ status: 200, contentType: 'text/html', body: '<html><body>mypage stub</body></html>' })
+    );
+
+    const result = await signupAndGetAccountToken(api, mailbox, context, {
+      baseUrl: accountsApiBaseUrl,
+      accountsHost,
+      accountsPageBaseUrl,
+      accountsClientId,
+      accountsClientSecret,
+      accountsRedirectUri,
+      email,
+      organizationName: `E2E Site Management ${runSuffix}`,
+      productionSiteUrl,
+      ecCubeVersion: '4',
+    });
+    accessToken = result.accessToken;
+  });
+
+  test.afterAll(async () => {
+    await Promise.allSettled([mailbox?.cleanup(email), api?.dispose(), context?.close()]);
+    await mailbox?.dispose();
+  });
+
+  let productionOrgId: number;
+  let addedOrgId: number;
+  let sandboxOrgId: number;
+  let addedClientId: string;
+
+  test('申込直後は本番サイト 1 件が一覧に出る', async () => {
+    const response = await api.get(`${accountsApiBaseUrl}/v1/account/organizations`, {
+      headers: authHeaders(),
+    });
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+    expect(body.organizations).toHaveLength(1);
+    expect(body.production_site_count).toBe(1);
+    // 既定の上限。account.max_sites は DB 直更新で個別に変えられる。
+    expect(body.max_sites).toBe(10);
+
+    const [organization] = body.organizations;
+    expect(organization.is_sandbox).toBe(false);
+    expect(organization.parent_organization_id).toBeNull();
+    expect(organization.clients).toHaveLength(1);
+    productionOrgId = organization.id;
+  });
+
+  test('本番サイトを追加できる', async () => {
+    const response = await api.post(`${accountsApiBaseUrl}/v1/account/organizations`, {
+      headers: authHeaders(),
+      data: { site_url: `https://${addedSiteHost}/`, ec_cube_version: '4' },
+    });
+    expect(response.status()).toBe(201);
+
+    const body = await response.json();
+    expect(body.is_sandbox).toBe(false);
+    expect(body.code).toBe(addedSiteHost.replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, ''));
+    // 初期 redirect_uri は申込と同じ導出（EC-CUBE 4 系は /ecauth/callback）。
+    expect(body.client.redirect_uris).toEqual([`https://${addedSiteHost}/ecauth/callback`]);
+    expect(body.client.allowed_rp_ids).toContain(addedSiteHost);
+
+    addedOrgId = body.id;
+    addedClientId = body.client.client_id;
+  });
+
+  test('追加したサイトの client_id が client-resolve で解決できる', async () => {
+    // プラグインはこのエンドポイントが返す base_url を保存して以降の API 呼び出しに使う。
+    const response = await api.get(
+      `${baseUrl}/platform/v1/client-resolve?client_id=${encodeURIComponent(addedClientId)}`
+    );
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+    expect(body.tenant_name).toBe(addedSiteHost.replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, ''));
+  });
+
+  test('本番サイトと同じドメインでもテストサイトを追加できる', async () => {
+    // 組織コードは -sandbox 接尾辞で分かれるため、自分の本番 Org とは衝突しない。
+    const response = await api.post(`${accountsApiBaseUrl}/v1/account/organizations`, {
+      headers: authHeaders(),
+      data: {
+        site_url: `https://${addedSiteHost}/`,
+        is_sandbox: true,
+        parent_organization_id: addedOrgId,
+      },
+    });
+    expect(response.status()).toBe(201);
+
+    const body = await response.json();
+    expect(body.is_sandbox).toBe(true);
+    expect(body.code).toMatch(/-sandbox$/);
+    expect(body.parent_organization_id).toBe(addedOrgId);
+    sandboxOrgId = body.id;
+  });
+
+  test('1 本番あたりテストサイトは 1 件まで', async () => {
+    const response = await api.post(`${accountsApiBaseUrl}/v1/account/organizations`, {
+      headers: authHeaders(),
+      data: {
+        site_url: `https://e2e-second-${runSuffix}.test/`,
+        is_sandbox: true,
+        parent_organization_id: addedOrgId,
+      },
+    });
+    expect(response.status()).toBe(422);
+    expect((await response.json()).error).toBe('sandbox_already_exists');
+  });
+
+  test('管理外の Organization を親には指定できない', async () => {
+    const response = await api.post(`${accountsApiBaseUrl}/v1/account/organizations`, {
+      headers: authHeaders(),
+      data: {
+        site_url: `https://e2e-orphan-${runSuffix}.test/`,
+        is_sandbox: true,
+        // 申込・追加で払い出された Id とは無関係の値。存在しても管理外なら同じ扱い。
+        parent_organization_id: 999999,
+      },
+    });
+    expect(response.status()).toBe(422);
+    expect((await response.json()).error).toBe('invalid_parent');
+  });
+
+  test('本番サイトを削除すると配下のテストサイトも消える', async () => {
+    const response = await api.post(
+      `${accountsApiBaseUrl}/v1/account/organizations/${addedOrgId}/delete`,
+      { headers: authHeaders() }
+    );
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+    expect(body.deleted_organization_ids).toEqual(expect.arrayContaining([addedOrgId, sandboxOrgId]));
+
+    // 一覧からは消え、申込で作られた本番サイトだけが残る。
+    const list = await api.get(`${accountsApiBaseUrl}/v1/account/organizations`, { headers: authHeaders() });
+    const listBody = await list.json();
+    expect(listBody.organizations.map((o: { id: number }) => o.id)).toEqual([productionOrgId]);
+  });
+
+  test('削除したサイトの client_id は client-resolve から引けなくなる', async () => {
+    // プラグインが接続先 IdP を解決できなくなることが「削除したら止まる」の実効的な担保。
+    const response = await api.get(
+      `${baseUrl}/platform/v1/client-resolve?client_id=${encodeURIComponent(addedClientId)}`
+    );
+    expect(response.status()).toBe(404);
+  });
+
+  test('削除したドメインは再登録できない', async () => {
+    // 論理削除では組織コードを解放しない（課金集計で別サイトの利用期間が混ざるため）。
+    const response = await api.post(`${accountsApiBaseUrl}/v1/account/organizations`, {
+      headers: authHeaders(),
+      data: { site_url: `https://${addedSiteHost}/` },
+    });
+    expect(response.status()).toBe(422);
+    expect((await response.json()).error).toBe('organization_deleted');
+  });
+
+  test('削除で枠が空くので同じ本番に新しいテストサイトを作れる', async () => {
+    // 「サイト追加 → 動作確認 → 旧サイト削除」で付け替えるための前提。
+    const response = await api.post(`${accountsApiBaseUrl}/v1/account/organizations`, {
+      headers: authHeaders(),
+      data: {
+        site_url: `https://e2e-restg-${runSuffix}.test/`,
+        is_sandbox: true,
+        parent_organization_id: productionOrgId,
+      },
+    });
+    expect(response.status()).toBe(201);
+    expect((await response.json()).parent_organization_id).toBe(productionOrgId);
+  });
+});

--- a/E2ETests/tests/specs/account_site_management.spec.ts
+++ b/E2ETests/tests/specs/account_site_management.spec.ts
@@ -218,17 +218,41 @@ test.describe.serial('マイページからのサイト追加・削除', () => {
     expect((await response.json()).error).toBe('organization_deleted');
   });
 
-  test('削除で枠が空くので同じ本番に新しいテストサイトを作れる', async () => {
+  test('テストサイトを削除すると同じ本番の枠が空く', async () => {
     // 「サイト追加 → 動作確認 → 旧サイト削除」で付け替えるための前提。
-    const response = await api.post(`${accountsApiBaseUrl}/v1/account/organizations`, {
-      headers: authHeaders(),
-      data: {
-        site_url: `https://e2e-restg-${runSuffix}.test/`,
-        is_sandbox: true,
-        parent_organization_id: productionOrgId,
-      },
-    });
-    expect(response.status()).toBe(201);
-    expect((await response.json()).parent_organization_id).toBe(productionOrgId);
+    // 枠の解放を検証するには **同じ親** で「作る → 埋まっている → 消す → また作れる」を
+    // 通す必要がある。別の親に作るだけでは、枠が解放されない実装でも成功してしまう。
+    const addSandbox = (host: string) =>
+      api.post(`${accountsApiBaseUrl}/v1/account/organizations`, {
+        headers: authHeaders(),
+        data: {
+          site_url: `https://${host}.test/`,
+          is_sandbox: true,
+          parent_organization_id: productionOrgId,
+        },
+      });
+
+    // 1 件目は作れる。
+    const first = await addSandbox(`e2e-slot1-${runSuffix}`);
+    expect(first.status()).toBe(201);
+    const firstId = (await first.json()).id as number;
+
+    // 枠が埋まっている間は 2 件目を作れない。
+    const blocked = await addSandbox(`e2e-slot2-${runSuffix}`);
+    expect(blocked.status()).toBe(422);
+    expect((await blocked.json()).error).toBe('sandbox_already_exists');
+
+    // 1 件目を削除すると枠が空く。
+    const deleted = await api.post(
+      `${accountsApiBaseUrl}/v1/account/organizations/${firstId}/delete`,
+      { headers: authHeaders() }
+    );
+    expect(deleted.status()).toBe(200);
+
+    // 同じ親に作り直せる（フィルター付きユニークインデックスが deleted_at IS NULL を
+    // 条件に含めているため、論理削除済みの行は枠を占有しない）。
+    const again = await addSandbox(`e2e-slot3-${runSuffix}`);
+    expect(again.status()).toBe(201);
+    expect((await again.json()).parent_organization_id).toBe(productionOrgId);
   });
 });

--- a/E2ETests/tests/specs/account_test_only_signup.spec.ts
+++ b/E2ETests/tests/specs/account_test_only_signup.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect, APIRequestContext, request } from '@playwright/test';
+
+/**
+ * 申込は本番サイト URL を必須とする（EcAuth#482）。
+ *
+ * テストサイトだけの申込を許すと、紐づく本番の無いサンドボックス Org
+ * （parent_organization_id が null）ができる。このサンドボックスは
+ * 「1 本番あたりテストは 1 件」の判定（AccountController が ParentOrganizationId で
+ * 数える）に引っかからないため、後から本番を追加するとサンドボックスが 2 件並ぶ
+ * 状態を作れてしまう。孤立を後から親に紐づけ直す手段も無い。
+ *
+ * 申込フォーム側（ecauth-website の signup.html / signup.js）も本番必須に揃えてあるが、
+ * フォームを経由しない直接 POST を防ぐのは API 側のこの検証。
+ */
+test.describe('申込のサイト URL 必須条件', () => {
+  const tenantBaseDomain = process.env.E2E_TENANT_BASE_DOMAIN;
+  const remote = Boolean(tenantBaseDomain);
+
+  const baseUrl = process.env.E2E_BASE_URL || 'https://localhost:8081';
+  const accountsHost =
+    process.env.E2E_ACCOUNTS_HOST || (remote ? `stg-accounts.${tenantBaseDomain}` : 'accounts.ec-auth.io');
+  const accountsApiBaseUrl = remote ? `https://${accountsHost}` : baseUrl;
+
+  const runSuffix = `${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+
+  let api: APIRequestContext;
+
+  test.beforeAll(async () => {
+    api = await request.newContext({
+      ignoreHTTPSErrors: true,
+      ...(remote ? {} : { extraHTTPHeaders: { Host: accountsHost } }),
+    });
+  });
+
+  test.afterAll(async () => {
+    await api?.dispose();
+  });
+
+  const signupBody = (overrides: Record<string, unknown>) => ({
+    email: `e2e-required-${runSuffix}@e2e.ec-auth.io`,
+    organization_name: `E2E Required ${runSuffix}`,
+    contact_name: 'E2E Tester',
+    ec_cube_version: '4',
+    ...overrides,
+  });
+
+  test('テストサイト URL だけの申込は 422 で拒否される', async () => {
+    const response = await api.post(`${accountsApiBaseUrl}/api/signup/request`, {
+      data: signupBody({
+        production_site_url: null,
+        test_site_url: `https://e2e-testonly-${runSuffix}.test/`,
+      }),
+    });
+
+    expect(response.status()).toBe(422);
+    const body = await response.json();
+    expect(body.error).toBe('invalid_site_url');
+    // どの入力欄の問題かをフォームが赤くできるよう field を返す。
+    expect(body.field).toBe('production_site_url');
+  });
+
+  test('サイト URL を両方とも省いた申込も 422 で拒否される', async () => {
+    const response = await api.post(`${accountsApiBaseUrl}/api/signup/request`, {
+      data: signupBody({ production_site_url: null, test_site_url: null }),
+    });
+
+    expect(response.status()).toBe(422);
+    expect((await response.json()).error).toBe('invalid_site_url');
+  });
+});

--- a/IdentityProvider.Test/Controllers/AccountControllerTests.cs
+++ b/IdentityProvider.Test/Controllers/AccountControllerTests.cs
@@ -575,7 +575,6 @@ namespace IdentityProvider.Test.Controllers
             Assert.IsType<UnauthorizedObjectResult>(result);
         }
 
-        // 匿名オブジェクトのプロパティをリフレクションで取り出すヘルパー
         // ---- サイト（Organization）の一覧・追加・削除 ----
 
         private const int AccountsOrgId = 100;
@@ -869,6 +868,7 @@ namespace IdentityProvider.Test.Controllers
             Assert.Null((await ReloadOrganization(9)).DeletedAt);
         }
 
+        // 匿名オブジェクトのプロパティをリフレクションで取り出すヘルパー
         private static object GetProp(object obj, string name) =>
             obj.GetType().GetProperty(name)!.GetValue(obj)!;
 

--- a/IdentityProvider.Test/Controllers/AccountControllerTests.cs
+++ b/IdentityProvider.Test/Controllers/AccountControllerTests.cs
@@ -33,6 +33,7 @@ namespace IdentityProvider.Test.Controllers
                 _mockTokenService.Object,
                 _mockAccountService.Object,
                 new PlaintextSecretProtector(),
+                new OrganizationProvisioningService(_context, new PlaintextSecretProtector()),
                 new Mock<ILogger<AccountController>>().Object);
         }
 
@@ -575,6 +576,299 @@ namespace IdentityProvider.Test.Controllers
         }
 
         // 匿名オブジェクトのプロパティをリフレクションで取り出すヘルパー
+        // ---- サイト（Organization）の一覧・追加・削除 ----
+
+        private const int AccountsOrgId = 100;
+
+        /// <summary>受付テナント Org と、その配下の Account を作る。</summary>
+        private async Task SeedAccount(int maxSites = Account.DefaultMaxSites)
+        {
+            _context.Organizations.Add(new Organization
+            {
+                Id = AccountsOrgId,
+                Code = "accounts",
+                Name = "EcAuth Accounts",
+                TenantName = "accounts"
+            });
+            _context.Accounts.Add(new Account
+            {
+                Id = 1,
+                Subject = AccountSubject,
+                Email = "owner@example.jp",
+                OrganizationId = AccountsOrgId,
+                MaxSites = maxSites
+            });
+            await _context.SaveChangesAsync();
+        }
+
+        private async Task SeedOrganization(
+            int orgId, string code, bool isSandbox,
+            int? parentOrganizationId = null, DateTimeOffset? deletedAt = null)
+        {
+            _context.Organizations.Add(new Organization
+            {
+                Id = orgId,
+                Code = code,
+                Name = code,
+                TenantName = code,
+                IsSandbox = isSandbox,
+                ParentOrganizationId = parentOrganizationId,
+                DeletedAt = deletedAt
+            });
+            await _context.SaveChangesAsync();
+        }
+
+        private static List<object> GetOrganizationList(object? okValue)
+        {
+            var organizations = okValue!.GetType().GetProperty("organizations")!.GetValue(okValue)!;
+            return ((IEnumerable<object>)organizations).ToList();
+        }
+
+        private async Task<Organization> ReloadOrganization(int id) =>
+            await _context.Organizations.IgnoreQueryFilters().FirstAsync(o => o.Id == id);
+
+        [Fact]
+        public async Task GetOrganizations_ReturnsManagedSitesWithPairingAndLimit()
+        {
+            await SeedAccount(maxSites: 3);
+            await SeedOrgWithClient(1, "shop1", false, 10, "client-prod", "secret-prod");
+            await SeedOrganization(2, "shop1-sandbox", isSandbox: true, parentOrganizationId: 1);
+            await SeedOrganization(3, "other", isSandbox: false);
+
+            AuthenticateAsOwnerOf((1, "shop1"), (2, "shop1-sandbox"));
+
+            var result = await _controller.GetOrganizations();
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            var organizations = GetOrganizationList(ok.Value);
+            Assert.Equal(2, organizations.Count);
+            Assert.Equal(3, (int)GetProp(ok.Value!, "max_sites"));
+            // 本番のみを数える（サンドボックスは上限の対象外）。
+            Assert.Equal(1, (int)GetProp(ok.Value!, "production_site_count"));
+
+            var sandbox = organizations.Single(o => (bool)GetProp(o, "is_sandbox"));
+            Assert.Equal(1, (int?)GetProp(sandbox, "parent_organization_id"));
+
+            var production = organizations.Single(o => !(bool)GetProp(o, "is_sandbox"));
+            Assert.Null(production.GetType().GetProperty("parent_organization_id")!.GetValue(production));
+        }
+
+        [Fact]
+        public async Task CreateOrganization_ProductionAtLimit_ReturnsSiteLimitExceeded()
+        {
+            await SeedAccount(maxSites: 2);
+            await SeedOrganization(1, "shop1", isSandbox: false);
+            await SeedOrganization(2, "shop2", isSandbox: false);
+            AuthenticateAsOwnerOf((1, "shop1"), (2, "shop2"));
+
+            var result = await _controller.CreateOrganization(new AccountController.CreateOrganizationDto
+            {
+                SiteUrl = "https://shop3.example.jp"
+            });
+
+            var unprocessable = Assert.IsType<UnprocessableEntityObjectResult>(result);
+            Assert.Equal("site_limit_exceeded", (string)GetProp(unprocessable.Value!, "error"));
+            Assert.Empty(await _context.Organizations.IgnoreQueryFilters()
+                .Where(o => o.Code == "shop3-example-jp").ToListAsync());
+        }
+
+        [Fact]
+        public async Task CreateOrganization_SandboxDoesNotCountTowardProductionLimit()
+        {
+            await SeedAccount(maxSites: 1);
+            await SeedOrgWithClient(1, "shop1", false, 10, "client-prod", "secret-prod");
+            AuthenticateAsOwnerOf((1, "shop1"));
+
+            // 本番は上限いっぱいだが、テストサイトは別枠なので追加できる。
+            var result = await _controller.CreateOrganization(new AccountController.CreateOrganizationDto
+            {
+                SiteUrl = "https://stg.example.jp",
+                IsSandbox = true,
+                ParentOrganizationId = 1
+            });
+
+            var created = Assert.IsType<CreatedResult>(result);
+            Assert.True((bool)GetProp(created.Value!, "is_sandbox"));
+            Assert.Equal("stg-example-jp-sandbox", (string)GetProp(created.Value!, "code"));
+            Assert.Equal(1, (int?)GetProp(created.Value!, "parent_organization_id"));
+        }
+
+        [Fact]
+        public async Task CreateOrganization_SandboxWithSameDomainAsProduction_Succeeds()
+        {
+            await SeedAccount();
+            await SeedOrganization(1, "shop1-example-jp", isSandbox: false);
+            AuthenticateAsOwnerOf((1, "shop1-example-jp"));
+
+            // 自分が持つ本番 Org と同じドメイン。組織コードは -sandbox 接尾辞で分かれるため作れる。
+            var result = await _controller.CreateOrganization(new AccountController.CreateOrganizationDto
+            {
+                SiteUrl = "https://shop1.example.jp",
+                IsSandbox = true,
+                ParentOrganizationId = 1
+            });
+
+            var created = Assert.IsType<CreatedResult>(result);
+            Assert.Equal("shop1-example-jp-sandbox", (string)GetProp(created.Value!, "code"));
+        }
+
+        [Fact]
+        public async Task CreateOrganization_SandboxWithoutParent_ReturnsInvalidRequest()
+        {
+            await SeedAccount();
+            await SeedOrganization(1, "shop1", isSandbox: false);
+            AuthenticateAsOwnerOf((1, "shop1"));
+
+            var result = await _controller.CreateOrganization(new AccountController.CreateOrganizationDto
+            {
+                SiteUrl = "https://stg.example.jp",
+                IsSandbox = true
+            });
+
+            var unprocessable = Assert.IsType<UnprocessableEntityObjectResult>(result);
+            Assert.Equal("invalid_request", (string)GetProp(unprocessable.Value!, "error"));
+            Assert.Equal("parent_organization_id", (string)GetProp(unprocessable.Value!, "field"));
+        }
+
+        [Fact]
+        public async Task CreateOrganization_SandboxWhenParentAlreadyHasOne_ReturnsSandboxAlreadyExists()
+        {
+            await SeedAccount();
+            await SeedOrganization(1, "shop1", isSandbox: false);
+            await SeedOrganization(2, "shop1-sandbox", isSandbox: true, parentOrganizationId: 1);
+            AuthenticateAsOwnerOf((1, "shop1"), (2, "shop1-sandbox"));
+
+            var result = await _controller.CreateOrganization(new AccountController.CreateOrganizationDto
+            {
+                SiteUrl = "https://stg.example.jp",
+                IsSandbox = true,
+                ParentOrganizationId = 1
+            });
+
+            var unprocessable = Assert.IsType<UnprocessableEntityObjectResult>(result);
+            Assert.Equal("sandbox_already_exists", (string)GetProp(unprocessable.Value!, "error"));
+        }
+
+        [Fact]
+        public async Task CreateOrganization_ParentNotManaged_ReturnsInvalidParent()
+        {
+            await SeedAccount();
+            await SeedOrganization(1, "shop1", isSandbox: false);
+            await SeedOrganization(9, "someone-else", isSandbox: false);
+            AuthenticateAsOwnerOf((1, "shop1"));
+
+            var result = await _controller.CreateOrganization(new AccountController.CreateOrganizationDto
+            {
+                SiteUrl = "https://stg.example.jp",
+                IsSandbox = true,
+                ParentOrganizationId = 9
+            });
+
+            var unprocessable = Assert.IsType<UnprocessableEntityObjectResult>(result);
+            Assert.Equal("invalid_parent", (string)GetProp(unprocessable.Value!, "error"));
+        }
+
+        [Fact]
+        public async Task CreateOrganization_DeletedDomain_ReturnsOrganizationDeleted()
+        {
+            await SeedAccount();
+            // 別アカウントが使っていたドメインを削除済みにしておく。
+            await SeedOrganization(9, "shop9-example-jp", isSandbox: false, deletedAt: DateTimeOffset.UtcNow);
+            AuthenticateAsOwnerOf();
+
+            var result = await _controller.CreateOrganization(new AccountController.CreateOrganizationDto
+            {
+                SiteUrl = "https://shop9.example.jp"
+            });
+
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            Assert.Equal(422, objectResult.StatusCode);
+            Assert.Equal("organization_deleted", (string)GetProp(objectResult.Value!, "error"));
+        }
+
+        [Fact]
+        public async Task CreateOrganization_NewProduction_CreatesClientAndRsaKeyPair()
+        {
+            await SeedAccount();
+            AuthenticateAsOwnerOf();
+
+            var result = await _controller.CreateOrganization(new AccountController.CreateOrganizationDto
+            {
+                SiteUrl = "https://shop.example.jp",
+                EcCubeVersion = "2"
+            });
+
+            var created = Assert.IsType<CreatedResult>(result);
+            var organizationId = (int)GetProp(created.Value!, "id");
+
+            var organization = await ReloadOrganization(organizationId);
+            Assert.Equal("shop-example-jp", organization.Code);
+            Assert.Equal("shop-example-jp", organization.TenantName);
+            Assert.False(organization.IsSandbox);
+            Assert.Null(organization.DeletedAt);
+
+            // Client / RsaKeyPair / AccountOrganization が揃っていること。
+            var client = await _context.Clients.IgnoreQueryFilters()
+                .Include(c => c.RedirectUris)
+                .FirstAsync(c => c.OrganizationId == organizationId);
+            Assert.Equal(SubjectType.B2B, client.SubjectType);
+            // EC-CUBE 2 系は callback.php。
+            Assert.Equal("https://shop.example.jp/ecauth/callback.php", client.RedirectUris!.Single().Uri);
+            Assert.Contains("shop.example.jp", client.AllowedRpIds);
+            Assert.True(await _context.RsaKeyPairs.IgnoreQueryFilters()
+                .AnyAsync(k => k.OrganizationId == organizationId));
+            Assert.True(await _context.AccountOrganizations.IgnoreQueryFilters()
+                .AnyAsync(ao => ao.OrganizationId == organizationId && ao.AccountSubject == AccountSubject));
+        }
+
+        [Fact]
+        public async Task DeleteOrganization_Production_SoftDeletesItselfAndItsSandbox()
+        {
+            await SeedAccount();
+            await SeedOrganization(1, "shop1", isSandbox: false);
+            await SeedOrganization(2, "shop1-sandbox", isSandbox: true, parentOrganizationId: 1);
+            AuthenticateAsOwnerOf((1, "shop1"), (2, "shop1-sandbox"));
+
+            var result = await _controller.DeleteOrganization(1);
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            var deletedIds = (int[])GetProp(ok.Value!, "deleted_organization_ids");
+            Assert.Equal(new[] { 1, 2 }, deletedIds);
+
+            // 物理削除はしない。行は残り、deleted_at だけが入る。
+            Assert.NotNull((await ReloadOrganization(1)).DeletedAt);
+            Assert.NotNull((await ReloadOrganization(2)).DeletedAt);
+        }
+
+        [Fact]
+        public async Task DeleteOrganization_Sandbox_DoesNotTouchParent()
+        {
+            await SeedAccount();
+            await SeedOrganization(1, "shop1", isSandbox: false);
+            await SeedOrganization(2, "shop1-sandbox", isSandbox: true, parentOrganizationId: 1);
+            AuthenticateAsOwnerOf((1, "shop1"), (2, "shop1-sandbox"));
+
+            var result = await _controller.DeleteOrganization(2);
+
+            Assert.IsType<OkObjectResult>(result);
+            Assert.Null((await ReloadOrganization(1)).DeletedAt);
+            Assert.NotNull((await ReloadOrganization(2)).DeletedAt);
+        }
+
+        [Fact]
+        public async Task DeleteOrganization_NotManaged_ReturnsNotFound()
+        {
+            await SeedAccount();
+            await SeedOrganization(1, "shop1", isSandbox: false);
+            await SeedOrganization(9, "someone-else", isSandbox: false);
+            AuthenticateAsOwnerOf((1, "shop1"));
+
+            var result = await _controller.DeleteOrganization(9);
+
+            Assert.IsType<NotFoundObjectResult>(result);
+            Assert.Null((await ReloadOrganization(9)).DeletedAt);
+        }
+
         private static object GetProp(object obj, string name) =>
             obj.GetType().GetProperty(name)!.GetValue(obj)!;
 

--- a/IdentityProvider.Test/Controllers/Platform/ClientResolveControllerTests.cs
+++ b/IdentityProvider.Test/Controllers/Platform/ClientResolveControllerTests.cs
@@ -2,6 +2,7 @@ using IdentityProvider.Controllers.Platform;
 using IdentityProvider.Models;
 using IdentityProvider.Test.TestHelpers;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -149,6 +150,22 @@ namespace IdentityProvider.Test.Controllers.Platform
             var value = okResult.Value;
             var baseUrl = value!.GetType().GetProperty("base_url")!.GetValue(value)!.ToString();
             Assert.Equal("https://shop1.ec-auth.io", baseUrl);
+        }
+
+        [Fact]
+        public async Task Resolve_SoftDeletedOrganization_ReturnsNotFound()
+        {
+            // プラグインは接続先 IdP の base_url をこのエンドポイントから得るため、
+            // ここが 404 を返すことが「サイトを削除したら接続できなくなる」の担保になる。
+            var organization = await _context.Organizations
+                .IgnoreQueryFilters()
+                .FirstAsync(o => o.Id == 1);
+            organization.DeletedAt = DateTimeOffset.UtcNow;
+            await _context.SaveChangesAsync();
+
+            var result = await _controller.Resolve("test-client-id");
+
+            Assert.IsType<NotFoundObjectResult>(result);
         }
 
         public void Dispose()

--- a/IdentityProvider.Test/Services/AccountServiceTests.cs
+++ b/IdentityProvider.Test/Services/AccountServiceTests.cs
@@ -98,5 +98,37 @@ namespace IdentityProvider.Test.Services
 
             Assert.Empty(managed);
         }
+
+        [Fact]
+        public async Task GetManagedOrganizationsAsync_ExcludesSoftDeletedOrganizations()
+        {
+            // 削除済みサイトが managed_orgs に残ると、削除後もそのテナントのトークンが
+            // 発行できてしまう。IgnoreQueryFilters で引いている経路なので明示的に除外している。
+            var tenantService = new MockTenantService();
+            tenantService.SetTenant("accounts");
+            using var context = TestDbContextHelper.CreateInMemoryContext(tenantService: tenantService);
+
+            context.Organizations.AddRange(
+                new Organization { Id = 10, Code = "active-shop", Name = "Active", TenantName = "active-shop" },
+                new Organization
+                {
+                    Id = 11,
+                    Code = "deleted-shop",
+                    Name = "Deleted",
+                    TenantName = "deleted-shop",
+                    DeletedAt = DateTimeOffset.UtcNow
+                });
+            context.AccountOrganizations.AddRange(
+                new AccountOrganization { AccountSubject = "account-subject", OrganizationId = 10, Role = "owner" },
+                new AccountOrganization { AccountSubject = "account-subject", OrganizationId = 11, Role = "owner" });
+            await context.SaveChangesAsync();
+
+            var service = new AccountService(context, _logger);
+
+            var managed = await service.GetManagedOrganizationsAsync("account-subject");
+
+            var only = Assert.Single(managed);
+            Assert.Equal(10, only.OrganizationId);
+        }
     }
 }

--- a/IdentityProvider.Test/Services/OrganizationProvisioningServiceTests.cs
+++ b/IdentityProvider.Test/Services/OrganizationProvisioningServiceTests.cs
@@ -1,0 +1,207 @@
+using IdentityProvider.Exceptions;
+using IdentityProvider.Models;
+using IdentityProvider.Services;
+using IdentityProvider.Test.TestHelpers;
+using IdpUtilities.Security;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace IdentityProvider.Test.Services
+{
+    /// <summary>
+    /// 申込フローとマイページのサイト追加が共用するプロビジョニングロジックのテスト。
+    /// 組織コードの導出規則と、ドメイン占有・削除済みドメインの扱いを固定する。
+    /// </summary>
+    public class OrganizationProvisioningServiceTests
+    {
+        private static OrganizationProvisioningService CreateService(EcAuthDbContext context)
+            => new(context, new PlaintextSecretProtector());
+
+        [Theory]
+        [InlineData("https://shop.example.jp", false, "shop-example-jp")]
+        [InlineData("https://www.shop.example.jp", false, "shop-example-jp")]
+        [InlineData("https://shop.example.jp", true, "shop-example-jp-sandbox")]
+        [InlineData("https://stg.example.jp", true, "stg-example-jp-sandbox")]
+        public void BuildSite_DerivesOrganizationCode(string url, bool isSandbox, string expectedCode)
+        {
+            using var context = TestDbContextHelper.CreateInMemoryContext();
+            var service = CreateService(context);
+
+            var site = service.BuildSite(url, isSandbox, "site_url");
+
+            Assert.Equal(expectedCode, site.Code);
+            Assert.Equal(isSandbox, site.IsSandbox);
+        }
+
+        [Fact]
+        public void BuildSite_NonHttpsUrl_Throws()
+        {
+            using var context = TestDbContextHelper.CreateInMemoryContext();
+            var service = CreateService(context);
+
+            var ex = Assert.Throws<SignupValidationException>(
+                () => service.BuildSite("http://shop.example.jp", false, "site_url"));
+
+            Assert.Equal("invalid_site_url", ex.Error);
+        }
+
+        [Fact]
+        public async Task EnsureOrganizationCodesAvailableAsync_DomainOwnedByAnotherAccount_Throws()
+        {
+            using var context = TestDbContextHelper.CreateInMemoryContext();
+            context.Organizations.Add(new Organization
+            {
+                Id = 1,
+                Code = "shop-example-jp",
+                Name = "Shop",
+                TenantName = "shop-example-jp"
+            });
+            await context.SaveChangesAsync();
+
+            var service = CreateService(context);
+            var site = service.BuildSite("https://shop.example.jp", isSandbox: true, "site_url");
+
+            // 他アカウントが本番として押さえているドメインは、サンドボックスとしても登録できない。
+            var ex = await Assert.ThrowsAsync<SignupValidationException>(
+                () => service.EnsureOrganizationCodesAvailableAsync(new[] { site }, CancellationToken.None));
+
+            Assert.Equal("organization_already_exists", ex.Error);
+        }
+
+        [Fact]
+        public async Task EnsureOrganizationCodesAvailableAsync_DomainOwnedByCaller_Passes()
+        {
+            using var context = TestDbContextHelper.CreateInMemoryContext();
+            context.Organizations.Add(new Organization
+            {
+                Id = 1,
+                Code = "shop-example-jp",
+                Name = "Shop",
+                TenantName = "shop-example-jp"
+            });
+            await context.SaveChangesAsync();
+
+            var service = CreateService(context);
+            var site = service.BuildSite("https://shop.example.jp", isSandbox: true, "site_url");
+
+            // 自分の本番 Org と同じドメイン。組織コードは -sandbox で分かれるので通る。
+            await service.EnsureOrganizationCodesAvailableAsync(
+                new[] { site }, CancellationToken.None, ownedOrganizationIds: new[] { 1 });
+        }
+
+        [Fact]
+        public async Task EnsureOrganizationCodesAvailableAsync_SameCodeAsOwnOrganization_Throws()
+        {
+            using var context = TestDbContextHelper.CreateInMemoryContext();
+            context.Organizations.Add(new Organization
+            {
+                Id = 1,
+                Code = "shop-example-jp",
+                Name = "Shop",
+                TenantName = "shop-example-jp"
+            });
+            await context.SaveChangesAsync();
+
+            var service = CreateService(context);
+            var site = service.BuildSite("https://shop.example.jp", isSandbox: false, "site_url");
+
+            // 自分の Org でも、まったく同じ組織コードは作れない（unique 制約に触れる）。
+            var ex = await Assert.ThrowsAsync<SignupValidationException>(
+                () => service.EnsureOrganizationCodesAvailableAsync(
+                    new[] { site }, CancellationToken.None, ownedOrganizationIds: new[] { 1 }));
+
+            Assert.Equal("organization_already_exists", ex.Error);
+        }
+
+        [Fact]
+        public async Task EnsureOrganizationCodesAvailableAsync_DeletedDomain_ThrowsOrganizationDeleted()
+        {
+            using var context = TestDbContextHelper.CreateInMemoryContext();
+            context.Organizations.Add(new Organization
+            {
+                Id = 1,
+                Code = "shop-example-jp",
+                Name = "Shop",
+                TenantName = "shop-example-jp",
+                DeletedAt = DateTimeOffset.UtcNow
+            });
+            await context.SaveChangesAsync();
+
+            var service = CreateService(context);
+            var site = service.BuildSite("https://shop.example.jp", isSandbox: false, "site_url");
+
+            // 論理削除しても組織コードは解放しない（課金集計で期間が混ざるため）。
+            // 「他人が使っている」のとは理由が違うので、エラーコードで区別する。
+            var ex = await Assert.ThrowsAsync<SignupValidationException>(
+                () => service.EnsureOrganizationCodesAvailableAsync(
+                    new[] { site }, CancellationToken.None, ownedOrganizationIds: new[] { 1 }));
+
+            Assert.Equal("organization_deleted", ex.Error);
+        }
+
+        [Fact]
+        public async Task EnsureOrganizationCodesAvailableAsync_CodeTooLong_Throws()
+        {
+            using var context = TestDbContextHelper.CreateInMemoryContext();
+            var service = CreateService(context);
+
+            // 組織コードはテナント名（DNS ラベル 1 つ）になるため 63 文字を超えられない。
+            var longHost = new string('a', 60) + ".example.jp";
+            var site = service.BuildSite($"https://{longHost}", isSandbox: false, "site_url");
+
+            var ex = await Assert.ThrowsAsync<SignupValidationException>(
+                () => service.EnsureOrganizationCodesAvailableAsync(new[] { site }, CancellationToken.None));
+
+            Assert.Equal("invalid_site_url", ex.Error);
+        }
+
+        [Fact]
+        public async Task ProvisionAsync_CreatesOrganizationClientKeyPairAndMembership()
+        {
+            using var context = TestDbContextHelper.CreateInMemoryContext();
+            var service = CreateService(context);
+            var site = service.BuildSite("https://shop.example.jp/subdir/", isSandbox: false, "site_url");
+
+            var provisioned = await service.ProvisionAsync(
+                site, "Shop Inc.", "4", "account-subject", parentOrganizationId: null);
+
+            Assert.Equal("shop-example-jp", provisioned.Organization.Code);
+            Assert.Equal("shop-example-jp", provisioned.Organization.TenantName);
+            Assert.Null(provisioned.Organization.ParentOrganizationId);
+
+            var client = await context.Clients
+                .IgnoreQueryFilters()
+                .Include(c => c.RedirectUris)
+                .FirstAsync(c => c.OrganizationId == provisioned.Organization.Id);
+            // サブディレクトリインストールのベースパスを引き継ぐ。
+            Assert.Equal("https://shop.example.jp/subdir/ecauth/callback", client.RedirectUris!.Single().Uri);
+            Assert.StartsWith("ec-shop-example-jp-", client.ClientId);
+
+            Assert.True(await context.RsaKeyPairs.IgnoreQueryFilters()
+                .AnyAsync(k => k.OrganizationId == provisioned.Organization.Id));
+            Assert.True(await context.AccountOrganizations.IgnoreQueryFilters()
+                .AnyAsync(ao => ao.OrganizationId == provisioned.Organization.Id
+                    && ao.AccountSubject == "account-subject"
+                    && ao.Role == "owner"));
+        }
+
+        [Fact]
+        public async Task ProvisionAsync_Sandbox_LinksToParentOrganization()
+        {
+            using var context = TestDbContextHelper.CreateInMemoryContext();
+            var service = CreateService(context);
+
+            var production = await service.ProvisionAsync(
+                service.BuildSite("https://shop.example.jp", isSandbox: false, "site_url"),
+                "Shop Inc.", "4", "account-subject", parentOrganizationId: null);
+
+            var sandbox = await service.ProvisionAsync(
+                service.BuildSite("https://stg.example.jp", isSandbox: true, "site_url"),
+                "Shop Inc.", "4", "account-subject", parentOrganizationId: production.Organization.Id);
+
+            // 別ドメインのテストサイトでも本番に紐づく（組織コードからは導出できない関係）。
+            Assert.Equal("stg-example-jp-sandbox", sandbox.Organization.Code);
+            Assert.Equal(production.Organization.Id, sandbox.Organization.ParentOrganizationId);
+        }
+    }
+}

--- a/IdentityProvider.Test/Services/SignupServiceTests.cs
+++ b/IdentityProvider.Test/Services/SignupServiceTests.cs
@@ -371,10 +371,11 @@ namespace IdentityProvider.Test.Services
             var service = CreateService(context, tenantService, out _, out _);
 
             // 別アカウントが同じドメインをテストサイトとして申し込む。
+            // 本番サイトは必須なので、衝突しない別ドメインを本番に置いてテスト側だけを衝突させる。
             var input = ValidInput() with
             {
                 Email = "another@example.com",
-                ProductionSiteUrl = null,
+                ProductionSiteUrl = "https://another-shop.example.jp",
                 TestSiteUrl = "https://stg.example.jp"
             };
 
@@ -457,9 +458,10 @@ namespace IdentityProvider.Test.Services
             using var context = CreateContextWithAccountsOrg(tenantService);
             var service = CreateService(context, tenantService, out _, out _);
 
+            // 本番は上限に収まる短いドメイン。上限超過はテスト側の接尾辞だけが原因になる。
             var input = ValidInput() with
             {
-                ProductionSiteUrl = null,
+                ProductionSiteUrl = "https://shop.example.jp",
                 TestSiteUrl = $"https://{MaxLengthHost}"
             };
 
@@ -616,27 +618,57 @@ namespace IdentityProvider.Test.Services
             Assert.Contains(customerOrgs, o => o.Code == "test-example-jp-sandbox" && o.IsSandbox);
         }
 
+        /// <summary>
+        /// テストサイトだけの申込は受け付けない。許すと紐づく本番の無いサンドボックス Org
+        /// （parent_organization_id が null）ができ、「1 本番あたりテストは 1 件」の判定
+        /// （AccountController が ParentOrganizationId で数える）をすり抜けて、後から本番を
+        /// 追加したときにサンドボックスが 2 件並ぶ状態を作れてしまう。
+        /// </summary>
         [Fact]
-        public async Task ConfirmAsync_TestSiteOnly_CreatesSandboxOrganization()
+        public async Task RequestAsync_TestSiteOnly_ThrowsInvalidSiteUrl()
         {
             var tenantService = CreateTenantService();
             using var context = CreateContextWithAccountsOrg(tenantService);
-            var service = CreateService(context, tenantService, out var emailMock, out _);
+            var service = CreateService(context, tenantService, out _, out _);
 
-            // 本番 URL 無しでテストサイトだけ申し込むケースでも接尾辞は付く（規則を分岐させない）。
             var input = ValidInput() with
             {
                 ProductionSiteUrl = null,
                 TestSiteUrl = "https://test.example.jp"
             };
+
+            var ex = await Assert.ThrowsAsync<SignupValidationException>(() => service.RequestAsync(input));
+            Assert.Equal("invalid_site_url", ex.Error);
+            Assert.Equal("production_site_url", ex.Field);
+            Assert.False(await context.SignupRequests.IgnoreQueryFilters().AnyAsync());
+        }
+
+        [Fact]
+        public async Task ConfirmAsync_ProductionAndTestSite_LinksSandboxToProduction()
+        {
+            var tenantService = CreateTenantService();
+            using var context = CreateContextWithAccountsOrg(tenantService);
+            var service = CreateService(context, tenantService, out var emailMock, out _);
+
+            var input = ValidInput() with
+            {
+                ProductionSiteUrl = "https://shop.example.jp",
+                TestSiteUrl = "https://test.example.jp"
+            };
             var token = await RequestAndCaptureTokenAsync(service, emailMock, input);
             await service.ConfirmAsync(token);
 
-            var customerOrg = await context.Organizations
+            var production = await context.Organizations
                 .IgnoreQueryFilters()
-                .SingleAsync(o => o.Code != Tenant);
-            Assert.Equal("test-example-jp-sandbox", customerOrg.Code);
-            Assert.True(customerOrg.IsSandbox);
+                .SingleAsync(o => o.Code == "shop-example-jp");
+            var sandbox = await context.Organizations
+                .IgnoreQueryFilters()
+                .SingleAsync(o => o.Code == "test-example-jp-sandbox");
+
+            Assert.True(sandbox.IsSandbox);
+            Assert.Null(production.ParentOrganizationId);
+            // 申込時点で本番とテストが紐づくため、孤立サンドボックスは生まれない。
+            Assert.Equal(production.Id, sandbox.ParentOrganizationId);
         }
 
         // ---- ConfirmAsync: Client の初期値（redirect_uri / allowed_rp_ids）----

--- a/IdentityProvider.Test/Services/SignupServiceTests.cs
+++ b/IdentityProvider.Test/Services/SignupServiceTests.cs
@@ -909,6 +909,47 @@ namespace IdentityProvider.Test.Services
             Assert.Equal("token_expired", ex.Error);
         }
 
+        /// <summary>
+        /// 本番サイト URL 必須化（EcAuth#482）より前に保存された申込は、本番 URL を持たないまま
+        /// 確認待ちになっている可能性がある。再バリデーションに任せると「本番サイト URL を
+        /// 入力してください」が返るが、確認画面には入力欄が無いため利用者は何もできない。
+        /// 再申込しかないことが伝わる専用エラーに振り替えていることを固定する。
+        /// </summary>
+        [Fact]
+        public async Task ConfirmAsync_PendingRequestWithoutProductionUrl_ThrowsNeedsResubmission()
+        {
+            var tenantService = CreateTenantService();
+            using var context = CreateContextWithAccountsOrg(tenantService);
+            var service = CreateService(context, tenantService, out _, out _);
+
+            // RequestAsync は本番必須になったのでこの状態は作れない。デプロイ前に保存された
+            // 申込を再現するため、SignupRequest を直接投入する。
+            context.SignupRequests.Add(new SignupRequest
+            {
+                ConfirmTokenHash = HashToken("legacy-token"),
+                Email = "owner@example.com",
+                OrganizationName = "Example Shop",
+                ProductionSiteUrl = null,
+                TestSiteUrl = "https://test.example.jp",
+                EcCubeVersion = "4",
+                TenantName = Tenant,
+                ExpiresAt = DateTimeOffset.UtcNow.AddHours(1),
+                CreatedAt = DateTimeOffset.UtcNow.AddHours(-1)
+            });
+            await context.SaveChangesAsync();
+
+            var ex = await Assert.ThrowsAsync<SignupValidationException>(
+                () => service.ConfirmAsync("legacy-token"));
+
+            Assert.Equal("signup_needs_resubmission", ex.Error);
+            Assert.Equal(422, ex.StatusCode);
+            // 入力欄のある画面が無いため、指し示すのは token（＝この申込そのもの）。
+            Assert.Equal("token", ex.Field);
+            // Organization は作られず、申込も未確認のまま残る。
+            Assert.False(await context.Organizations.IgnoreQueryFilters().AnyAsync(o => o.Code != Tenant));
+            Assert.Null((await context.SignupRequests.IgnoreQueryFilters().SingleAsync()).ConfirmedAt);
+        }
+
         [Fact]
         public async Task ConfirmAsync_AlreadyConfirmedToken_Throws()
         {

--- a/IdentityProvider.Test/Services/SignupServiceTests.cs
+++ b/IdentityProvider.Test/Services/SignupServiceTests.cs
@@ -104,8 +104,8 @@ namespace IdentityProvider.Test.Services
                 disposableCheckerMock.Object,
                 CreateConfiguration(withConfirmBaseUrl),
                 _logger,
-                new PlaintextSecretProtector(),
-                new PasskeyRegistrationTokenService(context, Mock.Of<ILogger<PasskeyRegistrationTokenService>>()));
+                new PasskeyRegistrationTokenService(context, Mock.Of<ILogger<PasskeyRegistrationTokenService>>()),
+                new OrganizationProvisioningService(context, new PlaintextSecretProtector()));
         }
 
         /// <summary>
@@ -231,8 +231,8 @@ namespace IdentityProvider.Test.Services
 
             var service = new SignupService(
                 context, tenantService, emailMock.Object, disposableMock.Object, config, _logger,
-                new PlaintextSecretProtector(),
-                new PasskeyRegistrationTokenService(context, Mock.Of<ILogger<PasskeyRegistrationTokenService>>()));
+                new PasskeyRegistrationTokenService(context, Mock.Of<ILogger<PasskeyRegistrationTokenService>>()),
+                new OrganizationProvisioningService(context, new PlaintextSecretProtector()));
 
             await service.RequestAsync(ValidInput());
 

--- a/IdentityProvider/Controllers/AccountController.cs
+++ b/IdentityProvider/Controllers/AccountController.cs
@@ -473,21 +473,6 @@ namespace IdentityProvider.Controllers
 
                 parentOrganizationId = parent.Id;
             }
-            else
-            {
-                // 本番サイトのみを上限の対象にする。テストサイトは本番 1 件につき 1 件までという
-                // 別の制約で縛られるため、二重に数えない。
-                var productionCount = ownedOrganizations.Count(o => !o.IsSandbox);
-                if (productionCount >= account.MaxSites)
-                {
-                    return InvalidInput(
-                        "site_limit_exceeded",
-                        $"登録できる本番サイトは {account.MaxSites} 件までです。"
-                            + "不要なサイトを削除するか、サポートにお問い合わせください。",
-                        "site_url");
-                }
-            }
-
             SiteEntry site;
             try
             {
@@ -504,6 +489,52 @@ namespace IdentityProvider.Controllers
             ProvisionedSite provisioned;
             try
             {
+                if (!body.IsSandbox)
+                {
+                    // 本番サイト数の上限判定はトランザクション内で、アカウント行を排他ロックしてから行う。
+                    //
+                    // 「アカウントあたりの本番サイト数」は集計値であり DB 制約として表現できない。
+                    // ロック無しでカウントすると、同一アカウントの並行リクエストが同じスナップショットを
+                    // 読んで両方とも上限未満と判定し、上限を超えて作成できてしまう。既存の DB 制約は
+                    // どちらもこれを止められない:
+                    //   - IX_organization_parent_organization_id_active は parent_organization_id が
+                    //     非 null の行だけが対象で、本番 Org（null）は含まれない
+                    //   - organization.Code のユニーク制約は、別ドメイン同士なら衝突しない
+                    // アカウント行のロックが唯一の直列化ポイントになる。
+                    var maxSites = await LoadMaxSitesForUpdateAsync(subject, HttpContext.RequestAborted);
+                    if (maxSites == null)
+                    {
+                        await transaction.RollbackAsync(HttpContext.RequestAborted);
+                        return Unauthorized(new
+                        {
+                            error = "invalid_token",
+                            error_description = "有効な Account アクセストークンが必要です。"
+                        });
+                    }
+
+                    // ロック取得後に管理下 Org を引き直して数える。ロック待ちの間に別リクエストが
+                    // コミットした Org を取り込む必要があるため、トランザクション開始前に読んだ
+                    // ownedOrganizations は使えない。
+                    var lockedManaged = await _accountService.GetManagedOrganizationsAsync(subject);
+                    var lockedOrgIds = lockedManaged.Select(m => m.OrganizationId).ToHashSet();
+                    var productionCount = lockedOrgIds.Count == 0
+                        ? 0
+                        : await _context.Organizations
+                            .IgnoreQueryFilters()
+                            .CountAsync(o => lockedOrgIds.Contains(o.Id) && !o.IsSandbox,
+                                HttpContext.RequestAborted);
+
+                    if (productionCount >= maxSites.Value)
+                    {
+                        await transaction.RollbackAsync(HttpContext.RequestAborted);
+                        return InvalidInput(
+                            "site_limit_exceeded",
+                            $"登録できる本番サイトは {maxSites.Value} 件までです。"
+                                + "不要なサイトを削除するか、サポートにお問い合わせください。",
+                            "site_url");
+                    }
+                }
+
                 provisioned = await _provisioning.ProvisionAsync(
                     site,
                     account.DisplayName ?? site.Host,
@@ -638,8 +669,48 @@ namespace IdentityProvider.Controllers
         }
 
         /// <summary>
-        /// 呼び出し Account の本番サイト上限を返す。Account が引けない場合は既定値を返す
-        /// （一覧表示のための補助情報であり、実際の上限判定は追加時に Account を引いて行う）。
+        /// 上限判定のために Account 行を読む。**呼び出し側でトランザクションを開始しておくこと。**
+        ///
+        /// <para>
+        /// SQL Server では <c>WITH (UPDLOCK, HOLDLOCK)</c> を付けて行ロックを取り、同一アカウントの
+        /// 並行リクエストをトランザクション終了まで直列化する。UPDLOCK は更新ロックを即座に取って
+        /// ロック昇格時のデッドロックを避け、HOLDLOCK はコミットまでロックを保持して
+        /// 「読んだ後に別トランザクションが Org を追加する」窓を塞ぐ。
+        /// </para>
+        /// <para>
+        /// InMemory プロバイダ（ユニットテスト）は生 SQL を実行できないため、通常の読み取りに
+        /// フォールバックする。この分岐によりロックの実挙動はユニットテストでは検証できないので、
+        /// 並行時の振る舞いは実 SQL Server に対する E2E
+        /// （<c>E2ETests/tests/specs/account_site_limit_concurrency.spec.ts</c>）で担保する。
+        /// </para>
+        /// </summary>
+        /// <returns>Account が見つからない場合は null。</returns>
+        private async Task<int?> LoadMaxSitesForUpdateAsync(string subject, CancellationToken ct)
+        {
+            if (!_context.Database.IsSqlServer())
+            {
+                return await _context.Accounts
+                    .IgnoreQueryFilters()
+                    .Where(a => a.Subject == subject)
+                    .Select(a => (int?)a.MaxSites)
+                    .FirstOrDefaultAsync(ct);
+            }
+
+            // FromSqlInterpolated はパラメータ化されるため、subject の値が SQL に直接埋まることはない。
+            var locked = await _context.Accounts
+                .FromSqlInterpolated(
+                    $"SELECT * FROM dbo.account WITH (UPDLOCK, HOLDLOCK) WHERE subject = {subject}")
+                .IgnoreQueryFilters()
+                .AsNoTracking()
+                .ToListAsync(ct);
+
+            return locked.Count == 0 ? null : locked[0].MaxSites;
+        }
+
+        /// <summary>
+        /// 呼び出し Account の本番サイト上限を返す（一覧表示のための補助情報）。
+        /// 実際の上限判定は <see cref="CreateOrganization"/> がトランザクション内で
+        /// <see cref="LoadMaxSitesForUpdateAsync"/> を使って行う。
         /// </summary>
         private async Task<int> GetMaxSitesAsync(string subject)
         {

--- a/IdentityProvider/Controllers/AccountController.cs
+++ b/IdentityProvider/Controllers/AccountController.cs
@@ -489,10 +489,68 @@ namespace IdentityProvider.Controllers
             ProvisionedSite provisioned;
             try
             {
-                if (!body.IsSandbox)
+                // サイト構成を変える操作は本番・サンドボックスを問わずアカウント行を排他ロックする。
+                // DeleteOrganization も同じ行を取るため、このアカウントの追加・削除は直列化される。
+                var lockedAccount = await LockAccountForUpdateAsync(subject, HttpContext.RequestAborted);
+                if (lockedAccount == null)
                 {
-                    // 本番サイト数の上限判定はトランザクション内で、アカウント行を排他ロックしてから行う。
-                    //
+                    await transaction.RollbackAsync(HttpContext.RequestAborted);
+                    return Unauthorized(new
+                    {
+                        error = "invalid_token",
+                        error_description = "有効な Account アクセストークンが必要です。"
+                    });
+                }
+
+                // ロック取得後に管理下 Org を引き直す。ロック待ちの間に別リクエストがコミットした
+                // 追加・削除を取り込む必要があるため、トランザクション開始前に読んだ
+                // ownedOrganizations は使えない。
+                var lockedManaged = await _accountService.GetManagedOrganizationsAsync(subject);
+                var lockedOrgIds = lockedManaged.Select(m => m.OrganizationId).ToHashSet();
+
+                if (body.IsSandbox)
+                {
+                    // 親をロック下で再検証する。事前チェックはトランザクション外のスナップショットに
+                    // 基づくため、その後に親が削除されていることがある。ここで見ないと、
+                    // 論理削除済みの親を指す有効なサンドボックスが残る（削除側は「まだ存在しない子」を
+                    // カスケードできないため、あとから直る見込みも無い）。
+                    var parentIsUsable = lockedOrgIds.Contains(parentOrganizationId!.Value)
+                        && await _context.Organizations
+                            .IgnoreQueryFilters()
+                            .AnyAsync(o => o.Id == parentOrganizationId.Value
+                                && !o.IsSandbox
+                                && o.DeletedAt == null,
+                                HttpContext.RequestAborted);
+
+                    if (!parentIsUsable)
+                    {
+                        await transaction.RollbackAsync(HttpContext.RequestAborted);
+                        return InvalidInput(
+                            "invalid_parent",
+                            "紐づける本番サイトが見つかりません。",
+                            "parent_organization_id");
+                    }
+
+                    // 同じ親への並行追加もここで弾く（DB のフィルター付きユニークインデックスが
+                    // 最終防衛線だが、409 ではなく理由の分かる 422 を返せるようにする）。
+                    var sandboxTaken = await _context.Organizations
+                        .IgnoreQueryFilters()
+                        .AnyAsync(o => o.ParentOrganizationId == parentOrganizationId.Value
+                            && o.DeletedAt == null,
+                            HttpContext.RequestAborted);
+
+                    if (sandboxTaken)
+                    {
+                        await transaction.RollbackAsync(HttpContext.RequestAborted);
+                        return InvalidInput(
+                            "sandbox_already_exists",
+                            "この本番サイトには既にテストサイトが登録されています。"
+                                + "作り直す場合は既存のテストサイトを削除してから追加してください。",
+                            "parent_organization_id");
+                    }
+                }
+                else
+                {
                     // 「アカウントあたりの本番サイト数」は集計値であり DB 制約として表現できない。
                     // ロック無しでカウントすると、同一アカウントの並行リクエストが同じスナップショットを
                     // 読んで両方とも上限未満と判定し、上限を超えて作成できてしまう。既存の DB 制約は
@@ -500,23 +558,6 @@ namespace IdentityProvider.Controllers
                     //   - IX_organization_parent_organization_id_active は parent_organization_id が
                     //     非 null の行だけが対象で、本番 Org（null）は含まれない
                     //   - organization.Code のユニーク制約は、別ドメイン同士なら衝突しない
-                    // アカウント行のロックが唯一の直列化ポイントになる。
-                    var maxSites = await LoadMaxSitesForUpdateAsync(subject, HttpContext.RequestAborted);
-                    if (maxSites == null)
-                    {
-                        await transaction.RollbackAsync(HttpContext.RequestAborted);
-                        return Unauthorized(new
-                        {
-                            error = "invalid_token",
-                            error_description = "有効な Account アクセストークンが必要です。"
-                        });
-                    }
-
-                    // ロック取得後に管理下 Org を引き直して数える。ロック待ちの間に別リクエストが
-                    // コミットした Org を取り込む必要があるため、トランザクション開始前に読んだ
-                    // ownedOrganizations は使えない。
-                    var lockedManaged = await _accountService.GetManagedOrganizationsAsync(subject);
-                    var lockedOrgIds = lockedManaged.Select(m => m.OrganizationId).ToHashSet();
                     var productionCount = lockedOrgIds.Count == 0
                         ? 0
                         : await _context.Organizations
@@ -524,12 +565,12 @@ namespace IdentityProvider.Controllers
                             .CountAsync(o => lockedOrgIds.Contains(o.Id) && !o.IsSandbox,
                                 HttpContext.RequestAborted);
 
-                    if (productionCount >= maxSites.Value)
+                    if (productionCount >= lockedAccount.MaxSites)
                     {
                         await transaction.RollbackAsync(HttpContext.RequestAborted);
                         return InvalidInput(
                             "site_limit_exceeded",
-                            $"登録できる本番サイトは {maxSites.Value} 件までです。"
+                            $"登録できる本番サイトは {lockedAccount.MaxSites} 件までです。"
                                 + "不要なサイトを削除するか、サポートにお問い合わせください。",
                             "site_url");
                     }
@@ -617,12 +658,7 @@ namespace IdentityProvider.Controllers
                 });
             }
 
-            var managed = await _accountService.GetManagedOrganizationsAsync(subject);
-            var orgIds = managed.Select(m => m.OrganizationId).ToHashSet();
-
-            // 削除済みの Org は管理対象から外れるため、二重削除もここで 404 になる。
-            // 存在しない Org と管理外の Org も同じ 404 に揃える（存在を漏らさない）。
-            if (!orgIds.Contains(id))
+            IActionResult NotFoundResult()
             {
                 _logger.LogWarning(
                     "Account {Subject} attempted to delete organization {OrganizationId} without ownership",
@@ -634,10 +670,48 @@ namespace IdentityProvider.Controllers
                 });
             }
 
+            // 削除済みの Org は管理対象から外れるため、二重削除もここで 404 になる。
+            // 存在しない Org と管理外の Org も同じ 404 に揃える（存在を漏らさない）。
+            // ロック取得前の早期リターン（ロックを取らずに済む分、無駄な待ちを避ける）。
+            var managed = await _accountService.GetManagedOrganizationsAsync(subject);
+            if (!managed.Any(m => m.OrganizationId == id))
+            {
+                return NotFoundResult();
+            }
+
+            await using var transaction = await _context.Database.BeginTransactionAsync(HttpContext.RequestAborted);
+
+            // CreateOrganization と同じアカウント行を排他ロックする。これが無いと
+            // 「サンドボックス追加」と「その親の削除」がすれ違い、削除側は自分のスナップショットに
+            // 無い（＝まだコミットされていない）子をカスケードできないため、論理削除済みの親を指す
+            // 有効なサンドボックスが残る。
+            var lockedAccount = await LockAccountForUpdateAsync(subject, HttpContext.RequestAborted);
+            if (lockedAccount == null)
+            {
+                await transaction.RollbackAsync(HttpContext.RequestAborted);
+                return Unauthorized(new
+                {
+                    error = "invalid_token",
+                    error_description = "有効な Account アクセストークンが必要です。"
+                });
+            }
+
+            // ロック取得後に管理下 Org を引き直す。ロック待ちの間にコミットされたサンドボックスを
+            // カスケード対象に含めるため、ロック前の一覧は使えない。
+            var lockedManaged = await _accountService.GetManagedOrganizationsAsync(subject);
+            var lockedOrgIds = lockedManaged.Select(m => m.OrganizationId).ToHashSet();
+
+            // ロック待ちの間に別リクエストが先に削除していれば、ここで管理対象から外れている。
+            if (!lockedOrgIds.Contains(id))
+            {
+                await transaction.RollbackAsync(HttpContext.RequestAborted);
+                return NotFoundResult();
+            }
+
             var owned = await _context.Organizations
                 .IgnoreQueryFilters()
-                .Where(o => orgIds.Contains(o.Id))
-                .ToListAsync();
+                .Where(o => lockedOrgIds.Contains(o.Id))
+                .ToListAsync(HttpContext.RequestAborted);
 
             var target = owned.First(o => o.Id == id);
 
@@ -656,6 +730,7 @@ namespace IdentityProvider.Controllers
             }
 
             await _context.SaveChangesAsync(HttpContext.RequestAborted);
+            await transaction.CommitAsync(HttpContext.RequestAborted);
 
             _logger.LogInformation(
                 "サイトを削除しました（論理削除）: Subject={Subject}, OrganizationIds={OrganizationIds}",
@@ -669,31 +744,37 @@ namespace IdentityProvider.Controllers
         }
 
         /// <summary>
-        /// 上限判定のために Account 行を読む。**呼び出し側でトランザクションを開始しておくこと。**
+        /// Account 行を排他ロックして読む。**呼び出し側でトランザクションを開始しておくこと。**
         ///
         /// <para>
+        /// このアカウントのサイト構成を変更する操作（追加・削除）が共通で取る唯一の直列化ポイント。
         /// SQL Server では <c>WITH (UPDLOCK, HOLDLOCK)</c> を付けて行ロックを取り、同一アカウントの
-        /// 並行リクエストをトランザクション終了まで直列化する。UPDLOCK は更新ロックを即座に取って
+        /// 並行リクエストをトランザクション終了まで待たせる。UPDLOCK は更新ロックを即座に取って
         /// ロック昇格時のデッドロックを避け、HOLDLOCK はコミットまでロックを保持して
-        /// 「読んだ後に別トランザクションが Org を追加する」窓を塞ぐ。
+        /// 「読んだ後に別トランザクションが Organization を変更する」窓を塞ぐ。
+        /// </para>
+        /// <para>
+        /// 追加と削除で同じ行を取ることが重要。別々のロックにすると、サンドボックス追加と
+        /// その親の削除がすれ違い、削除済みの親を指す有効なサンドボックスが残る
+        /// （削除側は「まだ存在しない子」をカスケードできない）。
         /// </para>
         /// <para>
         /// InMemory プロバイダ（ユニットテスト）は生 SQL を実行できないため、通常の読み取りに
         /// フォールバックする。この分岐によりロックの実挙動はユニットテストでは検証できないので、
         /// 並行時の振る舞いは実 SQL Server に対する E2E
-        /// （<c>E2ETests/tests/specs/account_site_limit_concurrency.spec.ts</c>）で担保する。
+        /// （<c>account_site_limit_concurrency.spec.ts</c> /
+        /// <c>account_site_delete_concurrency.spec.ts</c>）で担保する。
         /// </para>
         /// </summary>
-        /// <returns>Account が見つからない場合は null。</returns>
-        private async Task<int?> LoadMaxSitesForUpdateAsync(string subject, CancellationToken ct)
+        /// <returns>Account が見つからない場合は null。読み取り専用（AsNoTracking）。</returns>
+        private async Task<Account?> LockAccountForUpdateAsync(string subject, CancellationToken ct)
         {
             if (!_context.Database.IsSqlServer())
             {
                 return await _context.Accounts
                     .IgnoreQueryFilters()
-                    .Where(a => a.Subject == subject)
-                    .Select(a => (int?)a.MaxSites)
-                    .FirstOrDefaultAsync(ct);
+                    .AsNoTracking()
+                    .FirstOrDefaultAsync(a => a.Subject == subject, ct);
             }
 
             // FromSqlInterpolated はパラメータ化されるため、subject の値が SQL に直接埋まることはない。
@@ -704,7 +785,7 @@ namespace IdentityProvider.Controllers
                 .AsNoTracking()
                 .ToListAsync(ct);
 
-            return locked.Count == 0 ? null : locked[0].MaxSites;
+            return locked.Count == 0 ? null : locked[0];
         }
 
         /// <summary>

--- a/IdentityProvider/Controllers/AccountController.cs
+++ b/IdentityProvider/Controllers/AccountController.cs
@@ -4,6 +4,7 @@ using System.Security.Cryptography;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Asp.Versioning;
+using IdentityProvider.Exceptions;
 using IdentityProvider.Filters;
 using IdentityProvider.Models;
 using IdentityProvider.Services;
@@ -53,6 +54,7 @@ namespace IdentityProvider.Controllers
         private readonly ITokenService _tokenService;
         private readonly IAccountService _accountService;
         private readonly ISecretProtector _secretProtector;
+        private readonly IOrganizationProvisioningService _provisioning;
         private readonly ILogger<AccountController> _logger;
 
         public AccountController(
@@ -60,12 +62,14 @@ namespace IdentityProvider.Controllers
             ITokenService tokenService,
             IAccountService accountService,
             ISecretProtector secretProtector,
+            IOrganizationProvisioningService provisioning,
             ILogger<AccountController> logger)
         {
             _context = context;
             _tokenService = tokenService;
             _accountService = accountService;
             _secretProtector = secretProtector;
+            _provisioning = provisioning;
             _logger = logger;
         }
 
@@ -284,6 +288,396 @@ namespace IdentityProvider.Controllers
                 id = client.Id,
                 client_id = client.ClientId,
                 allowed_rp_ids = rpIds.ToArray()
+            });
+        }
+
+        // ---- サイト（Organization）の一覧・追加・削除 ----
+
+        /// <summary>
+        /// GET /v1/account/organizations
+        /// 呼び出し Account が管理するサイト（Organization）の一覧を返す。
+        ///
+        /// 論理削除済みのサイトは含まない（<see cref="IAccountService.GetManagedOrganizationsAsync"/>
+        /// が除外する）。本番とテストの対応は <c>parent_organization_id</c> で表現し、
+        /// UI 側はこれを使って本番の下にテストをぶら下げて表示する。
+        /// </summary>
+        [HttpGet("organizations")]
+        public async Task<IActionResult> GetOrganizations()
+        {
+            var subject = await ValidateAccountTokenAsync();
+            if (subject == null)
+            {
+                return Unauthorized(new
+                {
+                    error = "invalid_token",
+                    error_description = "有効な Account アクセストークンが必要です。"
+                });
+            }
+
+            var managed = await _accountService.GetManagedOrganizationsAsync(subject);
+            var orgIds = managed.Select(m => m.OrganizationId).ToHashSet();
+            var maxSites = await GetMaxSitesAsync(subject);
+
+            if (orgIds.Count == 0)
+            {
+                return Ok(new
+                {
+                    organizations = Array.Empty<object>(),
+                    max_sites = maxSites,
+                    production_site_count = 0
+                });
+            }
+
+            // 管理対象 Organization は顧客テナント（別テナント）のため IgnoreQueryFilters で横断取得する。
+            // 削除済みは orgIds の時点で除外済み。
+            var organizations = await _context.Organizations
+                .IgnoreQueryFilters()
+                .Where(o => orgIds.Contains(o.Id))
+                .OrderBy(o => o.Id)
+                .ToListAsync();
+
+            var clients = await _context.Clients
+                .IgnoreQueryFilters()
+                .Include(c => c.RedirectUris)
+                .Where(c => c.OrganizationId != null && orgIds.Contains(c.OrganizationId.Value))
+                .ToListAsync();
+
+            var roleBySubject = managed.ToDictionary(m => m.OrganizationId, m => m.Role);
+
+            var result = organizations.Select(o => new
+            {
+                id = o.Id,
+                code = o.Code,
+                name = o.Name,
+                is_sandbox = o.IsSandbox,
+                parent_organization_id = o.ParentOrganizationId,
+                role = roleBySubject.TryGetValue(o.Id, out var role) ? role : null,
+                created_at = o.CreatedAt,
+                clients = clients
+                    .Where(c => c.OrganizationId == o.Id)
+                    .Select(c => new
+                    {
+                        id = c.Id,
+                        client_id = c.ClientId,
+                        // 値そのものは返さない（一覧に secret を載せない方針。RevealSecret を使う）。
+                        has_secret = !string.IsNullOrEmpty(c.ClientSecret),
+                        app_name = c.AppName,
+                        redirect_uris = c.RedirectUris.Select(r => r.Uri).ToArray(),
+                        allowed_rp_ids = c.AllowedRpIds.ToArray()
+                    })
+                    .ToArray()
+            }).ToArray();
+
+            return Ok(new
+            {
+                organizations = result,
+                max_sites = maxSites,
+                production_site_count = organizations.Count(o => !o.IsSandbox)
+            });
+        }
+
+        /// <summary>
+        /// POST /v1/account/organizations
+        /// サイト（Organization + Client + RsaKeyPair + AccountOrganization）を 1 件追加する。
+        ///
+        /// <para>
+        /// 申込で本番・テストの片方しか登録しなかった場合の復旧手段であり、サイトを増やす唯一の
+        /// 動線でもある（EcAuth#482）。生成ロジックは申込フローと同じ
+        /// <see cref="IOrganizationProvisioningService"/> を通す。
+        /// </para>
+        /// <para>
+        /// 制約は 2 つ。(1) 本番サイトは 1 アカウントあたり <c>account.max_sites</c> 件まで。
+        /// (2) テストサイトは本番 1 件につき 1 件まで（<c>parent_organization_id</c> で紐づけ、
+        /// DB のフィルター付きユニークインデックスでも担保）。
+        /// </para>
+        /// </summary>
+        [HttpPost("organizations")]
+        public async Task<IActionResult> CreateOrganization([FromBody] CreateOrganizationDto? body)
+        {
+            var subject = await ValidateAccountTokenAsync();
+            if (subject == null)
+            {
+                return Unauthorized(new
+                {
+                    error = "invalid_token",
+                    error_description = "有効な Account アクセストークンが必要です。"
+                });
+            }
+
+            if (body == null || string.IsNullOrWhiteSpace(body.SiteUrl))
+            {
+                return InvalidInput("invalid_request", "site_url を指定してください。", "site_url");
+            }
+
+            var ecCubeVersion = NormalizeEcCubeVersion(body.EcCubeVersion);
+            if (ecCubeVersion == null)
+            {
+                return InvalidInput(
+                    "unsupported_version", "対応していない EC-CUBE バージョンです。", "ec_cube_version");
+            }
+
+            var account = await _context.Accounts
+                .IgnoreQueryFilters()
+                .FirstOrDefaultAsync(a => a.Subject == subject);
+            if (account == null)
+            {
+                return Unauthorized(new
+                {
+                    error = "invalid_token",
+                    error_description = "有効な Account アクセストークンが必要です。"
+                });
+            }
+
+            var managed = await _accountService.GetManagedOrganizationsAsync(subject);
+            var orgIds = managed.Select(m => m.OrganizationId).ToHashSet();
+
+            // 削除済みは orgIds に含まれないため、以降のカウント・親検索はすべて有効な Org のみが対象。
+            var ownedOrganizations = orgIds.Count == 0
+                ? new List<Organization>()
+                : await _context.Organizations
+                    .IgnoreQueryFilters()
+                    .Where(o => orgIds.Contains(o.Id))
+                    .ToListAsync();
+
+            int? parentOrganizationId = null;
+            if (body.IsSandbox)
+            {
+                if (body.ParentOrganizationId == null)
+                {
+                    return InvalidInput(
+                        "invalid_request",
+                        "テストサイトを追加するには、紐づける本番サイト（parent_organization_id）を指定してください。",
+                        "parent_organization_id");
+                }
+
+                var parent = ownedOrganizations.FirstOrDefault(o => o.Id == body.ParentOrganizationId.Value);
+                if (parent == null || parent.IsSandbox)
+                {
+                    // 管理外の Org を指定された場合も、テスト Org を親に指定された場合も同じ扱い。
+                    // 他アカウントの Organization の存在を漏らさないため理由は区別しない。
+                    return InvalidInput(
+                        "invalid_parent",
+                        "紐づける本番サイトが見つかりません。",
+                        "parent_organization_id");
+                }
+
+                var sandboxExists = ownedOrganizations.Any(o => o.ParentOrganizationId == parent.Id);
+                if (sandboxExists)
+                {
+                    return InvalidInput(
+                        "sandbox_already_exists",
+                        "この本番サイトには既にテストサイトが登録されています。"
+                            + "作り直す場合は既存のテストサイトを削除してから追加してください。",
+                        "parent_organization_id");
+                }
+
+                parentOrganizationId = parent.Id;
+            }
+            else
+            {
+                // 本番サイトのみを上限の対象にする。テストサイトは本番 1 件につき 1 件までという
+                // 別の制約で縛られるため、二重に数えない。
+                var productionCount = ownedOrganizations.Count(o => !o.IsSandbox);
+                if (productionCount >= account.MaxSites)
+                {
+                    return InvalidInput(
+                        "site_limit_exceeded",
+                        $"登録できる本番サイトは {account.MaxSites} 件までです。"
+                            + "不要なサイトを削除するか、サポートにお問い合わせください。",
+                        "site_url");
+                }
+            }
+
+            SiteEntry site;
+            try
+            {
+                site = _provisioning.BuildSite(body.SiteUrl, body.IsSandbox, "site_url");
+                await _provisioning.EnsureOrganizationCodesAvailableAsync(
+                    new[] { site }, HttpContext.RequestAborted, ownedOrganizationIds: orgIds);
+            }
+            catch (SignupValidationException ex)
+            {
+                return FromValidationException(ex);
+            }
+
+            await using var transaction = await _context.Database.BeginTransactionAsync(HttpContext.RequestAborted);
+            ProvisionedSite provisioned;
+            try
+            {
+                provisioned = await _provisioning.ProvisionAsync(
+                    site,
+                    account.DisplayName ?? site.Host,
+                    ecCubeVersion,
+                    subject,
+                    parentOrganizationId,
+                    HttpContext.RequestAborted);
+
+                await transaction.CommitAsync(HttpContext.RequestAborted);
+            }
+            catch (DbUpdateException ex)
+            {
+                await transaction.RollbackAsync(HttpContext.RequestAborted);
+
+                // 事前チェックをすり抜けた並行追加（同じ組織コード / 同じ親へのテストサイト 2 件）。
+                _logger.LogWarning(ex,
+                    "サイト追加が競合しました: Subject={Subject}, Code={Code}", subject, site.Code);
+                return Conflict(new
+                {
+                    error = "organization_already_exists",
+                    error_description = "サイトの登録が競合しました。時間をおいて再度お試しください。",
+                    field = "site_url"
+                });
+            }
+
+            _logger.LogInformation(
+                "サイトを追加しました: Subject={Subject}, OrganizationId={OrganizationId}, Code={Code}, IsSandbox={IsSandbox}, ParentOrganizationId={ParentOrganizationId}",
+                subject, provisioned.Organization.Id, provisioned.Organization.Code,
+                provisioned.Organization.IsSandbox, parentOrganizationId);
+
+            // client_secret は返さない（一覧に載せないのと同じ理由）。UI は reveal で 1 件ずつ取得する。
+            return Created($"/v1/account/organizations/{provisioned.Organization.Id}", new
+            {
+                id = provisioned.Organization.Id,
+                code = provisioned.Organization.Code,
+                name = provisioned.Organization.Name,
+                is_sandbox = provisioned.Organization.IsSandbox,
+                parent_organization_id = provisioned.Organization.ParentOrganizationId,
+                created_at = provisioned.Organization.CreatedAt,
+                client = new
+                {
+                    id = provisioned.Client.Id,
+                    client_id = provisioned.Client.ClientId,
+                    has_secret = !string.IsNullOrEmpty(provisioned.Client.ClientSecret),
+                    redirect_uris = provisioned.Client.RedirectUris!.Select(r => r.Uri).ToArray(),
+                    allowed_rp_ids = provisioned.Client.AllowedRpIds.ToArray()
+                }
+            });
+        }
+
+        /// <summary>
+        /// POST /v1/account/organizations/{id}/delete
+        /// サイトを論理削除する。
+        ///
+        /// <para>
+        /// <c>DELETE</c> ではなく POST なのは CORS ポリシー <c>SignupApiCors</c> が
+        /// GET / POST / OPTIONS 限定のため（<see cref="UpdateRedirectUris"/> と同じ理由）。
+        /// またレコードを消さない以上、DELETE のセマンティクスとも合わない。
+        /// </para>
+        /// <para>
+        /// **物理削除はしない**。将来の課金は Organization 単位の集計になるため、解約済みサイトも
+        /// 残す必要がある。組織コードも解放しない（同じコードで作り直せると集計で別サイトの
+        /// 利用期間が混ざる）ため、削除したドメインは再登録できない。
+        /// </para>
+        /// <para>
+        /// 本番サイトを削除すると、紐づくテストサイトも同時に論理削除する。親だけ消えて
+        /// 孤立したテストサイトが残ると、UI 上どの本番に属するか分からなくなるため。
+        /// </para>
+        /// </summary>
+        [HttpPost("organizations/{id:int}/delete")]
+        public async Task<IActionResult> DeleteOrganization(int id)
+        {
+            var subject = await ValidateAccountTokenAsync();
+            if (subject == null)
+            {
+                return Unauthorized(new
+                {
+                    error = "invalid_token",
+                    error_description = "有効な Account アクセストークンが必要です。"
+                });
+            }
+
+            var managed = await _accountService.GetManagedOrganizationsAsync(subject);
+            var orgIds = managed.Select(m => m.OrganizationId).ToHashSet();
+
+            // 削除済みの Org は管理対象から外れるため、二重削除もここで 404 になる。
+            // 存在しない Org と管理外の Org も同じ 404 に揃える（存在を漏らさない）。
+            if (!orgIds.Contains(id))
+            {
+                _logger.LogWarning(
+                    "Account {Subject} attempted to delete organization {OrganizationId} without ownership",
+                    subject, id);
+                return NotFound(new
+                {
+                    error = "not_found",
+                    error_description = "対象のサイトが見つかりません。"
+                });
+            }
+
+            var owned = await _context.Organizations
+                .IgnoreQueryFilters()
+                .Where(o => orgIds.Contains(o.Id))
+                .ToListAsync();
+
+            var target = owned.First(o => o.Id == id);
+
+            // 本番サイトの配下にあるテストサイトも巻き込んで削除する。
+            var targets = new List<Organization> { target };
+            if (!target.IsSandbox)
+            {
+                targets.AddRange(owned.Where(o => o.ParentOrganizationId == target.Id));
+            }
+
+            var now = DateTimeOffset.UtcNow;
+            foreach (var organization in targets)
+            {
+                organization.DeletedAt = now;
+                organization.UpdatedAt = now;
+            }
+
+            await _context.SaveChangesAsync(HttpContext.RequestAborted);
+
+            _logger.LogInformation(
+                "サイトを削除しました（論理削除）: Subject={Subject}, OrganizationIds={OrganizationIds}",
+                subject, string.Join(",", targets.Select(o => o.Id)));
+
+            return Ok(new
+            {
+                deleted_organization_ids = targets.Select(o => o.Id).ToArray(),
+                deleted_at = now
+            });
+        }
+
+        /// <summary>
+        /// 呼び出し Account の本番サイト上限を返す。Account が引けない場合は既定値を返す
+        /// （一覧表示のための補助情報であり、実際の上限判定は追加時に Account を引いて行う）。
+        /// </summary>
+        private async Task<int> GetMaxSitesAsync(string subject)
+        {
+            var maxSites = await _context.Accounts
+                .IgnoreQueryFilters()
+                .Where(a => a.Subject == subject)
+                .Select(a => (int?)a.MaxSites)
+                .FirstOrDefaultAsync();
+
+            return maxSites ?? Account.DefaultMaxSites;
+        }
+
+        /// <summary>
+        /// ec_cube_version を検証する。未指定は 4 系として扱う（現行の主流であり、
+        /// 2 系のコールバックパスとの違いは追加後に redirect_uri 編集で直せる）。
+        /// 対応していない値は null を返す。
+        /// </summary>
+        private static string? NormalizeEcCubeVersion(string? version)
+        {
+            var v = version?.Trim();
+            if (string.IsNullOrEmpty(v))
+            {
+                return "4";
+            }
+
+            return v is "2" or "4" or "other" ? v : null;
+        }
+
+        /// <summary>
+        /// プロビジョニング側のバリデーション例外を、この API のエラー形式に変換する。
+        /// </summary>
+        private IActionResult FromValidationException(SignupValidationException ex)
+        {
+            return StatusCode(ex.StatusCode, new
+            {
+                error = ex.Error,
+                error_description = ex.ErrorDescription,
+                field = ex.Field
             });
         }
 
@@ -524,6 +918,34 @@ namespace IdentityProvider.Controllers
         {
             [JsonPropertyName("allowed_rp_ids")]
             public List<string>? AllowedRpIds { get; set; }
+        }
+
+        /// <summary>
+        /// <c>POST /v1/account/organizations</c> のリクエストボディ（snake_case）。
+        /// </summary>
+        public sealed class CreateOrganizationDto
+        {
+            /// <summary>追加するサイトの URL（https 必須）。</summary>
+            [JsonPropertyName("site_url")]
+            public string? SiteUrl { get; set; }
+
+            /// <summary>テストサイトとして追加する場合 true。</summary>
+            [JsonPropertyName("is_sandbox")]
+            public bool IsSandbox { get; set; }
+
+            /// <summary>
+            /// テストサイトを紐づける本番サイトの Organization Id。
+            /// <c>is_sandbox = true</c> のときのみ必須。
+            /// </summary>
+            [JsonPropertyName("parent_organization_id")]
+            public int? ParentOrganizationId { get; set; }
+
+            /// <summary>
+            /// 初期 redirect_uri のコールバックパスを決める（"2" / "4" / "other"）。
+            /// 未指定は "4"。
+            /// </summary>
+            [JsonPropertyName("ec_cube_version")]
+            public string? EcCubeVersion { get; set; }
         }
 
         /// <summary>

--- a/IdentityProvider/Controllers/AuthorizationCallbackController.cs
+++ b/IdentityProvider/Controllers/AuthorizationCallbackController.cs
@@ -129,6 +129,7 @@ namespace IdentityProvider.Controllers
 
                 // 6. EcAuth独自の認可コードを生成
                 var client = await _context.Clients
+                    .ExcludeDeletedOrganizations()
                     .FirstOrDefaultAsync(c => c.Id == stateData.ClientId);
 
                 if (client == null)

--- a/IdentityProvider/Controllers/AuthorizationController.cs
+++ b/IdentityProvider/Controllers/AuthorizationController.cs
@@ -110,6 +110,7 @@ namespace IdentityProvider.Controllers
             }
 
             var Client = await _context.Clients
+                .ExcludeDeletedOrganizations()
                 .Where(c => c.ClientId == client_id)
                 .FirstOrDefaultAsync();
             if (Client == null)

--- a/IdentityProvider/Controllers/B2BPasskeyController.cs
+++ b/IdentityProvider/Controllers/B2BPasskeyController.cs
@@ -463,6 +463,7 @@ namespace IdentityProvider.Controllers
                 // クライアント存在確認（認証なし、client_idのみ）
                 var client = await _context.Clients
                     .IgnoreQueryFilters()
+                    .ExcludeDeletedOrganizations()
                     .FirstOrDefaultAsync(c => c.ClientId == request.ClientId);
 
                 if (client == null)
@@ -560,6 +561,7 @@ namespace IdentityProvider.Controllers
                 {
                     client = await _context.Clients
                         .IgnoreQueryFilters()
+                        .ExcludeDeletedOrganizations()
                         .Include(c => c.RedirectUris)
                         .FirstOrDefaultAsync(c => c.ClientId == request.ClientId);
                 }
@@ -844,6 +846,7 @@ namespace IdentityProvider.Controllers
             // public な Account コンソール client を client_id で解決（secret 不要）。
             var client = await _context.Clients
                 .IgnoreQueryFilters()
+                .ExcludeDeletedOrganizations()
                 .Include(c => c.RedirectUris)
                 .FirstOrDefaultAsync(c => c.ClientId == clientId);
             if (client == null || client.SubjectType != SubjectType.Account)
@@ -883,6 +886,7 @@ namespace IdentityProvider.Controllers
             // client_id のみでクエリし、client_secret はアプリケーション側で比較
             var client = await _context.Clients
                 .IgnoreQueryFilters()
+                .ExcludeDeletedOrganizations()
                 .FirstOrDefaultAsync(c => c.ClientId == clientId);
 
             if (client?.ClientSecret == null)

--- a/IdentityProvider/Controllers/Platform/ClientResolveController.cs
+++ b/IdentityProvider/Controllers/Platform/ClientResolveController.cs
@@ -37,19 +37,26 @@ namespace IdentityProvider.Controllers.Platform
                 });
             }
 
+            // 論理削除済み Organization の Client は解決しない。プラグインは接続先 IdP の
+            // base_url をこのエンドポイントから得るため、ここで 404 にすることが
+            // 「サイトを削除したらプラグインからの認証が止まる」の実効的な担保になる。
+            // Client 自体にはクエリフィルターが無く、ここも IgnoreQueryFilters で引いているため、
+            // Organization 側の DeletedAt 条件は明示的に書く必要がある。
             var result = await _context.Clients
                 .IgnoreQueryFilters()
                 .Where(c => c.ClientId == client_id)
                 .Select(c => new
                 {
-                    TenantName = c.Organization != null ? c.Organization.TenantName : null,
+                    TenantName = c.Organization != null && c.Organization.DeletedAt == null
+                        ? c.Organization.TenantName
+                        : null,
                     OrganizationName = c.Organization != null ? c.Organization.Name : null,
                 })
                 .FirstOrDefaultAsync();
 
             if (result == null || result.TenantName == null)
             {
-                _logger.LogWarning("Client not found or has no organization: client_id={ClientId}", client_id);
+                _logger.LogWarning("Client not found, has no organization, or organization is deleted: client_id={ClientId}", client_id);
                 return NotFound(new
                 {
                     error = "not_found",

--- a/IdentityProvider/Controllers/TokenController.cs
+++ b/IdentityProvider/Controllers/TokenController.cs
@@ -145,6 +145,7 @@ namespace IdentityProvider.Controllers
                 using (TimingScope.Begin("client_lookup"))
                 {
                     client = await _context.Clients
+                        .ExcludeDeletedOrganizations()
                         .FirstOrDefaultAsync(c => c.ClientId == client_id);
                 }
 

--- a/IdentityProvider/Migrations/20260805123823_AddOrganizationSoftDeleteAndSandboxPairing.Designer.cs
+++ b/IdentityProvider/Migrations/20260805123823_AddOrganizationSoftDeleteAndSandboxPairing.Designer.cs
@@ -4,6 +4,7 @@ using IdentityProvider.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace IdentityProvider.Migrations
 {
     [DbContext(typeof(EcAuthDbContext))]
-    partial class EcAuthDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260805123823_AddOrganizationSoftDeleteAndSandboxPairing")]
+    partial class AddOrganizationSoftDeleteAndSandboxPairing
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/IdentityProvider/Migrations/20260805123823_AddOrganizationSoftDeleteAndSandboxPairing.cs
+++ b/IdentityProvider/Migrations/20260805123823_AddOrganizationSoftDeleteAndSandboxPairing.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace IdentityProvider.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOrganizationSoftDeleteAndSandboxPairing : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "deleted_at",
+                table: "organization",
+                type: "datetimeoffset",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "parent_organization_id",
+                table: "organization",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "max_sites",
+                table: "account",
+                type: "int",
+                nullable: false,
+                defaultValue: 10);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_organization_parent_organization_id_active",
+                table: "organization",
+                column: "parent_organization_id",
+                unique: true,
+                filter: "[parent_organization_id] IS NOT NULL AND [deleted_at] IS NULL");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_organization_organization_parent_organization_id",
+                table: "organization",
+                column: "parent_organization_id",
+                principalTable: "organization",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+
+            // 既存の本番 / サンドボックスのペアを parent_organization_id にバックフィルする。
+            //
+            // EXEC() でラップしているのは、--idempotent スクリプトが全マイグレーションを 1 バッチに
+            // まとめるため。同一バッチ内で「このマイグレーションが追加したカラム」を参照する DML は
+            // コンパイル時に解決できずエラーになるので、名前解決を実行時まで遅延させる
+            // （docs/CLAUDE.md「マイグレーション設計ルール」）。
+            //
+            // 段階 1: 組織コードの導出規則（本番コード + "-sandbox"）で確実に一致するペア。
+            // organization.code は一意なので、1 サンドボックスに対して本番は高々 1 件に決まる。
+            migrationBuilder.Sql(@"
+EXEC(N'
+UPDATE sandbox
+SET parent_organization_id = prod.id
+FROM dbo.organization AS sandbox
+INNER JOIN dbo.account_organization AS ao_sandbox ON ao_sandbox.organization_id = sandbox.id
+INNER JOIN dbo.account_organization AS ao_prod ON ao_prod.account_subject = ao_sandbox.account_subject
+INNER JOIN dbo.organization AS prod ON prod.id = ao_prod.organization_id
+WHERE sandbox.is_sandbox = 1
+  AND sandbox.parent_organization_id IS NULL
+  AND prod.is_sandbox = 0
+  AND sandbox.code = prod.code + ''-sandbox''
+');
+");
+
+            // 段階 2: 段階 1 で埋まらなかった分のうち、アカウント配下が「本番 1 件 + サンドボックス 1 件」
+            // だけのケースに限って紐づける。テストサイトに本番と別ドメインを使った申込がこれに当たる。
+            // 3 件以上ある、あるいは本番が複数あるアカウントは対応関係を機械的に決められないため
+            // NULL のまま残す（既存の認証動作には影響しない。サンドボックス追加時に UI 側で手当てする）。
+            //
+            // NOT EXISTS は段階 1 で既に相方が付いた本番 Org を除外するためのもの。これが無いと
+            // IX_organization_parent_organization_id_active のユニーク制約に触れてマイグレーションが失敗する。
+            migrationBuilder.Sql(@"
+EXEC(N'
+UPDATE sandbox
+SET parent_organization_id = pair.prod_id
+FROM dbo.organization AS sandbox
+INNER JOIN (
+    SELECT ao.account_subject,
+           MIN(CASE WHEN o.is_sandbox = 0 THEN o.id END) AS prod_id,
+           MIN(CASE WHEN o.is_sandbox = 1 THEN o.id END) AS sandbox_id,
+           SUM(CASE WHEN o.is_sandbox = 0 THEN 1 ELSE 0 END) AS prod_count,
+           SUM(CASE WHEN o.is_sandbox = 1 THEN 1 ELSE 0 END) AS sandbox_count
+    FROM dbo.account_organization AS ao
+    INNER JOIN dbo.organization AS o ON o.id = ao.organization_id
+    GROUP BY ao.account_subject
+) AS pair ON pair.sandbox_id = sandbox.id
+WHERE sandbox.parent_organization_id IS NULL
+  AND pair.prod_count = 1
+  AND pair.sandbox_count = 1
+  AND NOT EXISTS (
+      SELECT 1 FROM dbo.organization AS existing
+      WHERE existing.parent_organization_id = pair.prod_id
+        AND existing.deleted_at IS NULL
+  )
+');
+");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_organization_organization_parent_organization_id",
+                table: "organization");
+
+            migrationBuilder.DropIndex(
+                name: "IX_organization_parent_organization_id_active",
+                table: "organization");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_at",
+                table: "organization");
+
+            migrationBuilder.DropColumn(
+                name: "parent_organization_id",
+                table: "organization");
+
+            migrationBuilder.DropColumn(
+                name: "max_sites",
+                table: "account");
+        }
+    }
+}

--- a/IdentityProvider/Models/Account.cs
+++ b/IdentityProvider/Models/Account.cs
@@ -11,6 +11,12 @@ namespace IdentityProvider.Models
     [Table("account")]
     public class Account : ISubjectProvider
     {
+        /// <summary>
+        /// 1 アカウントが持てる本番 Organization 数の既定上限。
+        /// サンドボックス Org は各本番に 1 つまでという別制約で縛るため、この数には含めない。
+        /// </summary>
+        public const int DefaultMaxSites = 10;
+
         [Key]
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
         [Column("id")]
@@ -36,6 +42,14 @@ namespace IdentityProvider.Models
 
         [Column("email_verified_at")]
         public DateTimeOffset? EmailVerifiedAt { get; set; }
+
+        /// <summary>
+        /// このアカウントが持てる本番 Organization 数の上限。
+        /// プラン変更や個別対応は DB のこのカラムを直接更新して運用する（変更 API は設けない）。
+        /// 論理削除済みの Organization は上限のカウント対象外。
+        /// </summary>
+        [Column("max_sites")]
+        public int MaxSites { get; set; } = DefaultMaxSites;
 
         [Column("created_at")]
         public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;

--- a/IdentityProvider/Models/ClientQueryExtensions.cs
+++ b/IdentityProvider/Models/ClientQueryExtensions.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace IdentityProvider.Models
+{
+    /// <summary>
+    /// Client クエリの共通条件。
+    /// </summary>
+    public static class ClientQueryExtensions
+    {
+        /// <summary>
+        /// 論理削除された Organization に属する Client を除外する。
+        ///
+        /// <para>
+        /// Client エンティティにはグローバルクエリフィルターが設定されておらず、認証系の経路は
+        /// テナントをまたいで引くために <c>IgnoreQueryFilters()</c> を使う。そのため
+        /// Organization 側の <c>DeletedAt</c> 条件はどちらの経路でも自動適用されない。
+        /// client_id から Client を引いて認証・トークン発行の可否を決める箇所は、
+        /// すべてこの拡張を通すこと。これを忘れると「マイページで削除したサイトから
+        /// 引き続きログインできる」状態になる。
+        /// </para>
+        /// <para>
+        /// <c>Organization == null</c> を許容しているのは、Organization に紐づかない Client
+        /// （旧データ・プラットフォーム用）を除外しないため。削除判定の対象は
+        /// あくまで Organization を持つ顧客サイトの Client。
+        /// </para>
+        /// </summary>
+        public static IQueryable<Client> ExcludeDeletedOrganizations(this IQueryable<Client> clients)
+        {
+            return clients.Where(c => c.Organization == null || c.Organization.DeletedAt == null);
+        }
+    }
+}

--- a/IdentityProvider/Models/EcAuthDbContext.cs
+++ b/IdentityProvider/Models/EcAuthDbContext.cs
@@ -35,36 +35,63 @@ namespace IdentityProvider.Models
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            // 組織エンティティにテナントフィルターを適用
+            // 組織エンティティにテナントフィルターを適用。
+            //
+            // 論理削除（DeletedAt）はテナント条件と同じ扱いで全フィルターに乗せる。EF Core の
+            // グローバルクエリフィルターは「クエリのルート」と「Include したナビゲーション先」には
+            // 効くが、下記のように述語の中でナビゲーションを辿った参照（c.Organization.XXX）には
+            // 自動適用されない。したがって Organization 側に DeletedAt 条件を足すだけでは、
+            // Client 経由・EcAuthUser 経由のエンティティが削除済み Org の行を拾い続ける。
+            // 削除済みサイトで認証が通ってしまうため、派生フィルターにも同じ条件を明記する。
             modelBuilder.Entity<Organization>()
-                .HasQueryFilter(o => o.TenantName == _tenantService.TenantName);
+                .HasQueryFilter(o => o.TenantName == _tenantService.TenantName && o.DeletedAt == null);
 
-            // Organization.Code のグローバルユニーク制約
+            // Organization.Code のグローバルユニーク制約。
+            // 論理削除しても code は解放されない（削除済み Org と同じコードで作り直せてしまうと、
+            // 課金集計で別サイトの利用期間が同一コードに混ざるため）。削除済みドメインの
+            // 再登録は AccountController が organization_deleted で明示的に拒否する。
             modelBuilder.Entity<Organization>()
                 .HasIndex(o => o.Code)
                 .IsUnique();
 
+            // サンドボックス Org → 本番 Org の自己参照。
+            // 自己参照のため Cascade は張れない（SQL Server が循環参照を拒否する）。
+            modelBuilder.Entity<Organization>()
+                .HasOne(o => o.ParentOrganization)
+                .WithMany(o => o.SandboxOrganizations)
+                .HasForeignKey(o => o.ParentOrganizationId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            // 「1 本番 Org あたりサンドボックスは 1 つまで」を DB 制約として担保する。
+            // 論理削除済みを除外しているのは、削除したサンドボックスの枠が空かないと
+            // 「追加 → 動作確認 → 旧削除」での作り直しができなくなるため。
+            modelBuilder.Entity<Organization>()
+                .HasIndex(o => o.ParentOrganizationId)
+                .IsUnique()
+                .HasFilter("[parent_organization_id] IS NOT NULL AND [deleted_at] IS NULL")
+                .HasDatabaseName("IX_organization_parent_organization_id_active");
+
             // EcAuthUserにも同じグローバルクエリフィルターを適用
             modelBuilder.Entity<EcAuthUser>()
-                .HasQueryFilter(u => u.Organization != null && u.Organization.TenantName == _tenantService.TenantName);
+                .HasQueryFilter(u => u.Organization != null && u.Organization.TenantName == _tenantService.TenantName && u.Organization.DeletedAt == null);
 
             // ExternalIdpMappingにもグローバルクエリフィルターを適用
             modelBuilder.Entity<ExternalIdpMapping>()
-                .HasQueryFilter(m => m.EcAuthUser != null && m.EcAuthUser.Organization != null && m.EcAuthUser.Organization.TenantName == _tenantService.TenantName);
+                .HasQueryFilter(m => m.EcAuthUser != null && m.EcAuthUser.Organization != null && m.EcAuthUser.Organization.TenantName == _tenantService.TenantName && m.EcAuthUser.Organization.DeletedAt == null);
 
             // AuthorizationCodeにもグローバルクエリフィルターを適用
             // 注: 旧外部キー削除後はClient経由でテナントフィルターを適用
             modelBuilder.Entity<AuthorizationCode>()
-                .HasQueryFilter(ac => ac.Client != null && ac.Client.Organization != null && ac.Client.Organization.TenantName == _tenantService.TenantName);
+                .HasQueryFilter(ac => ac.Client != null && ac.Client.Organization != null && ac.Client.Organization.TenantName == _tenantService.TenantName && ac.Client.Organization.DeletedAt == null);
 
             // AccessTokenにもグローバルクエリフィルターを適用
             // 注: 旧外部キー削除後はClient経由でテナントフィルターを適用
             modelBuilder.Entity<AccessToken>()
-                .HasQueryFilter(at => at.Client != null && at.Client.Organization != null && at.Client.Organization.TenantName == _tenantService.TenantName);
+                .HasQueryFilter(at => at.Client != null && at.Client.Organization != null && at.Client.Organization.TenantName == _tenantService.TenantName && at.Client.Organization.DeletedAt == null);
 
             // ExternalIdpTokenにもグローバルクエリフィルターを適用
             modelBuilder.Entity<ExternalIdpToken>()
-                .HasQueryFilter(eit => eit.EcAuthUser != null && eit.EcAuthUser.Organization != null && eit.EcAuthUser.Organization.TenantName == _tenantService.TenantName);
+                .HasQueryFilter(eit => eit.EcAuthUser != null && eit.EcAuthUser.Organization != null && eit.EcAuthUser.Organization.TenantName == _tenantService.TenantName && eit.EcAuthUser.Organization.DeletedAt == null);
 
             // EcAuthUser関連の設定
             modelBuilder.Entity<EcAuthUser>()
@@ -142,15 +169,15 @@ namespace IdentityProvider.Models
 
             // B2BUser テナントフィルター
             modelBuilder.Entity<B2BUser>()
-                .HasQueryFilter(u => u.Organization != null && u.Organization.TenantName == _tenantService.TenantName);
+                .HasQueryFilter(u => u.Organization != null && u.Organization.TenantName == _tenantService.TenantName && u.Organization.DeletedAt == null);
 
             // B2BPasskeyCredential テナントフィルター（B2BUser経由）
             modelBuilder.Entity<B2BPasskeyCredential>()
-                .HasQueryFilter(c => c.B2BUser != null && c.B2BUser.Organization != null && c.B2BUser.Organization.TenantName == _tenantService.TenantName);
+                .HasQueryFilter(c => c.B2BUser != null && c.B2BUser.Organization != null && c.B2BUser.Organization.TenantName == _tenantService.TenantName && c.B2BUser.Organization.DeletedAt == null);
 
             // WebAuthnChallenge テナントフィルター（Client経由）
             modelBuilder.Entity<WebAuthnChallenge>()
-                .HasQueryFilter(wc => wc.Client != null && wc.Client.Organization != null && wc.Client.Organization.TenantName == _tenantService.TenantName);
+                .HasQueryFilter(wc => wc.Client != null && wc.Client.Organization != null && wc.Client.Organization.TenantName == _tenantService.TenantName && wc.Client.Organization.DeletedAt == null);
 
             // B2BUser 関連の設定
             // Subject（UUID）はグローバルに一意（RFC 9562）。EC-CUBEプラグインが生成するUUIDを
@@ -200,10 +227,15 @@ namespace IdentityProvider.Models
                 .HasIndex(k => new { k.OrganizationId, k.Kid })
                 .IsUnique();
 
-            // Account: 所属 Org のテナント (accounts / stg-accounts) のみ参照可能
+            // Account: 所属 Org のテナント (accounts / stg-accounts) のみ参照可能。
+            // 所属先は申込受付テナントの Org であり顧客サイトの Org ではないため、通常は
+            // 論理削除されない。それでも条件を揃えているのは、受付 Org が誤って削除された
+            // 状態で Account だけ生き残る（＝どのテナントからも見えない Account が残る）
+            // ズレを防ぐため。
             modelBuilder.Entity<Account>()
                 .HasQueryFilter(a => a.Organization != null
-                    && a.Organization.TenantName == _tenantService.TenantName);
+                    && a.Organization.TenantName == _tenantService.TenantName
+                    && a.Organization.DeletedAt == null);
 
             modelBuilder.Entity<Account>()
                 .HasAlternateKey(a => a.Subject);
@@ -217,6 +249,13 @@ namespace IdentityProvider.Models
             modelBuilder.Entity<Account>()
                 .HasIndex(a => new { a.OrganizationId, a.Email })
                 .IsUnique();
+
+            // 本番 Organization 数の上限。DB 側にも既定値を置くことで、この列を追加する
+            // マイグレーションが既存の全アカウントに 10 を入れる（既定値なしだと 0 が入り、
+            // 全既存アカウントがサイトを 1 件も追加できなくなる）。
+            modelBuilder.Entity<Account>()
+                .Property(a => a.MaxSites)
+                .HasDefaultValue(Account.DefaultMaxSites);
 
             // AccountOrganization: テナント横断 (クエリフィルター対象外)
             modelBuilder.Entity<AccountOrganization>()

--- a/IdentityProvider/Models/Organization.cs
+++ b/IdentityProvider/Models/Organization.cs
@@ -18,10 +18,36 @@ namespace IdentityProvider.Models
         public string? TenantName { get; set; }
         [Column("is_sandbox")]
         public bool IsSandbox { get; set; } = false;
+
+        /// <summary>
+        /// サンドボックス Org が紐づく本番 Org の Id。本番 Org では null。
+        ///
+        /// 「1 本番 Org あたりサンドボックスは 1 つまで」の判定根拠になる。組織コードの導出
+        /// （本番コード + <c>-sandbox</c>）では、テストサイトに本番と別ドメインを使った場合
+        /// （<c>shop.example.jp</c> と <c>stg.example.jp</c>）にペアを特定できないため、
+        /// 関連そのものをカラムとして持つ。制約は EcAuthDbContext のフィルター付き
+        /// ユニークインデックスで担保する。
+        /// </summary>
+        [Column("parent_organization_id")]
+        public int? ParentOrganizationId { get; set; }
+
+        /// <summary>
+        /// 論理削除された日時。null なら有効。
+        ///
+        /// **物理削除はしない**。将来の課金は Organization 単位の集計になるため、
+        /// 解約済みサイトも期間つきで残す必要がある。削除済み Org は認証系の全経路から
+        /// 除外される（EcAuthDbContext のクエリフィルター、ClientResolveController、
+        /// AccountService.GetManagedOrganizationsAsync）。
+        /// </summary>
+        [Column("deleted_at")]
+        public DateTimeOffset? DeletedAt { get; set; }
+
         [Column("created_at")]
         public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
         [Column("updated_at")]
         public DateTimeOffset UpdatedAt { get; set; } = DateTimeOffset.UtcNow;
+        public Organization? ParentOrganization { get; set; }
+        public ICollection<Organization> SandboxOrganizations { get; } = new List<Organization>();
         public ICollection<Client> Clients { get; } = new List<Client>();
         public ICollection<RsaKeyPair> RsaKeyPairs { get; } = new List<RsaKeyPair>();
     }

--- a/IdentityProvider/Program.cs
+++ b/IdentityProvider/Program.cs
@@ -67,6 +67,8 @@ builder.Services.AddScoped<IB2BPasskeyService, B2BPasskeyService>();
 
 // Account 申込フロー（Phase D-1）関連サービス
 builder.Services.AddScoped<ISignupService, SignupService>();
+// サイト（Organization）払い出し。申込フローとマイページのサイト追加が共用する。
+builder.Services.AddScoped<IOrganizationProvisioningService, OrganizationProvisioningService>();
 // メール送信プロバイダは Email:Provider で切替。既定は本番 / staging 用の SendGrid（HTTP API）。
 // ローカル開発 / CI E2E では Email:Provider=Smtp で MailKit ベースの SmtpEmailService に切替え、
 // mailpit（Smtp:Host / Smtp:Port）へ送信して実メール経路を検証する。

--- a/IdentityProvider/Services/AccountService.cs
+++ b/IdentityProvider/Services/AccountService.cs
@@ -45,11 +45,15 @@ namespace IdentityProvider.Services
 
             // account_organization はテナント横断（クエリフィルター対象外）。
             // 管理対象 Organization も別テナントのため、Organization 側も IgnoreQueryFilters で引く。
+            //
+            // IgnoreQueryFilters は Organization のグローバルクエリフィルターごと外すため、
+            // 論理削除の条件も一緒に外れる。削除済みサイトが managed_orgs クレームに残ると
+            // 削除後もそのテナントのトークンが発行できてしまうため、ここで明示的に除外する。
             var managed = await _context.AccountOrganizations
                 .IgnoreQueryFilters()
                 .Where(ao => ao.AccountSubject == subject)
                 .Join(
-                    _context.Organizations.IgnoreQueryFilters(),
+                    _context.Organizations.IgnoreQueryFilters().Where(o => o.DeletedAt == null),
                     ao => ao.OrganizationId,
                     o => o.Id,
                     (ao, o) => new IAccountService.ManagedOrganization(o.Id, o.Code, ao.Role))

--- a/IdentityProvider/Services/B2BPasskeyService.cs
+++ b/IdentityProvider/Services/B2BPasskeyService.cs
@@ -84,6 +84,7 @@ namespace IdentityProvider.Services
             // クライアント取得
             var client = await _context.Clients
                 .IgnoreQueryFilters()
+                .ExcludeDeletedOrganizations()
                 .Include(c => c.Organization)
                 .FirstOrDefaultAsync(c => c.ClientId == request.ClientId);
 
@@ -533,6 +534,7 @@ namespace IdentityProvider.Services
             // クライアント取得
             var client = await _context.Clients
                 .IgnoreQueryFilters()
+                .ExcludeDeletedOrganizations()
                 .FirstOrDefaultAsync(c => c.ClientId == request.ClientId);
 
             if (client == null)

--- a/IdentityProvider/Services/IOrganizationProvisioningService.cs
+++ b/IdentityProvider/Services/IOrganizationProvisioningService.cs
@@ -1,0 +1,87 @@
+using IdentityProvider.Models;
+
+namespace IdentityProvider.Services
+{
+    /// <summary>
+    /// 顧客サイト 1 件分の Organization 一式（Organization / Client / RsaKeyPair /
+    /// AccountOrganization）を払い出すサービス。
+    ///
+    /// <para>
+    /// 申込フロー（<see cref="ISignupService"/>）とマイページのサイト追加
+    /// （<c>POST /v1/account/organizations</c>）の両方から使う。申込で 1〜2 件まとめて作るのも、
+    /// 後からサイトを 1 件足すのも「サイト = Organization を 1 つ作る」という同じ操作であり、
+    /// 組織コードの導出規則・client_id の形・初期 redirect_uri / allowed_rp_ids がずれると
+    /// 「申込で作ったサイトは動くが後から足したサイトは動かない」類の差異を生むため、
+    /// 生成ロジックを 1 箇所に集約する。
+    /// </para>
+    /// </summary>
+    public interface IOrganizationProvisioningService
+    {
+        /// <summary>
+        /// サイト URL を検証し、組織コードを導出した <see cref="SiteEntry"/> を返す。
+        /// </summary>
+        /// <param name="url">申込・追加で入力されたサイト URL（https 必須）。</param>
+        /// <param name="isSandbox">テストサイトとして作る場合 true（組織コードに <c>-sandbox</c> が付く）。</param>
+        /// <param name="field">エラー時にクライアントへ返す入力フィールド名。</param>
+        /// <exception cref="Exceptions.SignupValidationException">URL が https でない、ホスト名が無い等。</exception>
+        SiteEntry BuildSite(string url, bool isSandbox, string field);
+
+        /// <summary>
+        /// 組織コードが使用可能か（長さ上限・他アカウントによる占有・削除済みドメイン）を検証する。
+        /// </summary>
+        /// <param name="sites">これから作るサイト。</param>
+        /// <param name="ct">キャンセルトークン。</param>
+        /// <param name="statusCode">違反時に返す HTTP ステータス（申込リクエスト時は 422、confirm 時の競合は 409）。</param>
+        /// <param name="ownedOrganizationIds">
+        /// 呼び出し元アカウントが現に管理している Organization の Id。ここに含まれる Org は
+        /// ドメイン占有の衝突とみなさない。本番サイトと同じドメインでサンドボックスを追加する
+        /// ケース（自分の本番 Org が既にそのドメインを占有している）を通すために必要。
+        /// 申込フローでは Org がまだ 1 つも無いため null でよい。
+        /// </param>
+        /// <exception cref="Exceptions.SignupValidationException">
+        /// <c>invalid_site_url</c>（コードが DNS ラベル上限超過）/
+        /// <c>organization_already_exists</c>（他アカウントが使用中）/
+        /// <c>organization_deleted</c>（削除済みドメインの再登録）。
+        /// </exception>
+        Task EnsureOrganizationCodesAvailableAsync(
+            IReadOnlyCollection<SiteEntry> sites,
+            CancellationToken ct,
+            int statusCode = 422,
+            IReadOnlyCollection<int>? ownedOrganizationIds = null);
+
+        /// <summary>
+        /// Organization / Client / RsaKeyPair / AccountOrganization を作成する。
+        ///
+        /// <para>
+        /// トランザクション管理は呼び出し側の責務。本メソッドは Organization の Id 採番のために
+        /// 途中で <c>SaveChanges</c> を 2 回呼ぶため、失敗時にロールバックしたい場合は
+        /// 呼び出し側でトランザクションを張ること。
+        /// </para>
+        /// </summary>
+        /// <param name="site"><see cref="BuildSite"/> の結果。</param>
+        /// <param name="organizationName">組織名（Organization.Name / Client.AppName）。</param>
+        /// <param name="ecCubeVersion">初期 redirect_uri のコールバックパスを決める（"2" / "4" / "other"）。</param>
+        /// <param name="accountSubject">この Organization のオーナーになる Account の subject。</param>
+        /// <param name="parentOrganizationId">
+        /// サンドボックス Org の場合に紐づける本番 Org の Id。本番 Org を作る場合は null。
+        /// </param>
+        /// <param name="ct">キャンセルトークン。</param>
+        Task<ProvisionedSite> ProvisionAsync(
+            SiteEntry site,
+            string organizationName,
+            string ecCubeVersion,
+            string accountSubject,
+            int? parentOrganizationId,
+            CancellationToken ct = default);
+    }
+
+    /// <summary>
+    /// 検証済みのサイト 1 件。<c>Host</c> は RP ID / 組織コード導出用（ポートを含まない）、
+    /// <c>BaseUrl</c> は redirect_uri 組み立て用（非既定ポートとベースパスを含み、末尾はスラッシュ）。
+    /// </summary>
+    public sealed record SiteEntry(
+        string Code, string Host, string BaseUrl, bool IsSandbox, string Field);
+
+    /// <summary>払い出し結果。client_secret は暗号化済みの値が入っている。</summary>
+    public sealed record ProvisionedSite(Organization Organization, Client Client);
+}

--- a/IdentityProvider/Services/MagicLinkService.cs
+++ b/IdentityProvider/Services/MagicLinkService.cs
@@ -290,6 +290,7 @@ namespace IdentityProvider.Services
             // account は GetBySubjectAsync でテナント分離済み。その OrganizationId で Client を絞るため、
             // テナントクエリフィルター（将来 Client に追加された場合も含む）はそのまま尊重する。
             var client = await _context.Clients
+                .ExcludeDeletedOrganizations()
                 .FirstOrDefaultAsync(
                     c => c.OrganizationId == organizationId && c.SubjectType == SubjectType.Account, ct);
 

--- a/IdentityProvider/Services/OrganizationProvisioningService.cs
+++ b/IdentityProvider/Services/OrganizationProvisioningService.cs
@@ -1,0 +1,381 @@
+using System.Security.Cryptography;
+using System.Text.RegularExpressions;
+using IdentityProvider.Exceptions;
+using IdentityProvider.Models;
+using IdentityProvider.Telemetry;
+using IdpUtilities.Security;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.EntityFrameworkCore;
+
+namespace IdentityProvider.Services
+{
+    /// <inheritdoc cref="IOrganizationProvisioningService" />
+    public class OrganizationProvisioningService : IOrganizationProvisioningService
+    {
+        // 組織コード導出: 英数字以外の連続を 1 つの "-" に畳み込むための正規表現。
+        private static readonly Regex NonAlphanumericRun = new("[^a-z0-9]+", RegexOptions.Compiled);
+
+        // サンドボックス（テストサイト）Org の組織コードに付ける接尾辞。
+        public const string SandboxCodeSuffix = "-sandbox";
+
+        // 組織コードはそのままテナント名になり {tenant}.ec-auth.io の 1 ラベルを構成する。
+        // DNS のラベル上限は 63 オクテット（RFC 1035）。超えると Org は作れてもその
+        // サブドメインに到達できず、プラグインの接続先が解決不能になる。
+        private const int MaxOrganizationCodeLength = 63;
+
+        // サイト URL のベースパス正規化: 末尾セグメントをファイル名とみなして落とす拡張子。
+        private static readonly string[] WebDocumentExtensions = [".php", ".html", ".htm"];
+
+        private readonly EcAuthDbContext _context;
+        private readonly ISecretProtector _secretProtector;
+
+        public OrganizationProvisioningService(
+            EcAuthDbContext context,
+            ISecretProtector secretProtector)
+        {
+            _context = context;
+            _secretProtector = secretProtector;
+        }
+
+        /// <inheritdoc />
+        public SiteEntry BuildSite(string url, bool isSandbox, string field)
+        {
+            var siteUrl = ValidateHttpsAndParseSiteUrl(url, field);
+            return new SiteEntry(
+                DeriveOrganizationCode(siteUrl.Host, isSandbox),
+                siteUrl.Host,
+                siteUrl.BaseUrl,
+                isSandbox,
+                field);
+        }
+
+        /// <inheritdoc />
+        public async Task EnsureOrganizationCodesAvailableAsync(
+            IReadOnlyCollection<SiteEntry> sites,
+            CancellationToken ct,
+            int statusCode = 422,
+            IReadOnlyCollection<int>? ownedOrganizationIds = null)
+        {
+            // 組織コードはテナント名（= {tenant}.ec-auth.io の 1 ラベル）になるため、
+            // DNS のラベル上限を超えるものは作らせない。作れても到達できないため。
+            foreach (var site in sites)
+            {
+                if (site.Code.Length > MaxOrganizationCodeLength)
+                {
+                    throw new SignupValidationException(
+                        "invalid_site_url",
+                        "サイト URL のドメインが長すぎます。より短いドメインでお申し込みください。",
+                        field: site.Field,
+                        statusCode: 422);
+                }
+            }
+
+            // 同一リクエスト内で導出後の組織コードが衝突していないか検知する。
+            // 本番とテストは接尾辞（-sandbox）で必ず分かれるため通常は発火しないが、
+            // 導出規則を将来変えたときに黙って 1 件に潰れるのを防ぐガードとして残す。
+            var seenCodes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var site in sites)
+            {
+                if (!seenCodes.Add(site.Code))
+                {
+                    throw new SignupValidationException(
+                        "duplicate_site",
+                        "本番サイトとテストサイトが同じ組織として扱われます。"
+                            + "テストサイトには別のドメインをご指定ください。",
+                        field: site.Field,
+                        statusCode: 422);
+                }
+            }
+
+            var owned = ownedOrganizationIds ?? Array.Empty<int>();
+
+            // ドメインの占有は「接尾辞を除いた導出コード」で判定する。site.Code をそのまま
+            // 比較すると、サンドボックス側だけコードが変わったせいで
+            //   - 旧規則（接尾辞なし）で登録済みのサンドボックス Org
+            //   - 本番として登録済みのドメイン
+            // を、別アカウントがテストサイトとして再登録できてしまう。
+            //
+            // 同一申込内での本番＋サンドボックス併存はこれでも壊れない。Organization の作成は
+            // このチェックより後（トランザクション内）で行うため、ペアの相方はまだ DB に無いため。
+            // 申込内の衝突判定は上の seenCodes が接尾辞込みのコードで行っており、そちらは併存を許す。
+            //
+            // マイページからのサイト追加では相方が既に DB にあるので、呼び出し元アカウントが
+            // 管理している Org（ownedOrganizationIds）は占有の衝突から除外する。これが無いと
+            // 「本番と同じドメインでテスト環境を追加する」が自分の本番 Org に阻まれて必ず失敗する。
+            foreach (var site in sites)
+            {
+                var baseCode = DeriveOrganizationCode(site.Host, isSandbox: false);
+                var sandboxCode = baseCode + SandboxCodeSuffix;
+
+                var conflicts = await _context.Organizations
+                    .IgnoreQueryFilters()
+                    .Where(o => o.Code == baseCode || o.Code == sandboxCode)
+                    .Select(o => new { o.Id, o.Code, o.DeletedAt })
+                    .ToListAsync(ct);
+
+                // これから作るコードそのものの重複は、自分の Org でも許さない（unique 制約に触れる）。
+                var blocking = conflicts
+                    .Where(c => string.Equals(c.Code, site.Code, StringComparison.OrdinalIgnoreCase)
+                        || !owned.Contains(c.Id))
+                    .ToList();
+
+                if (blocking.Count == 0)
+                {
+                    continue;
+                }
+
+                // 論理削除済みの Org は code を解放しない（課金集計で別サイトの利用期間が
+                // 同一コードに混ざるため）。再登録できない理由が「他人が使っている」のか
+                // 「自分が削除した」のかで案内が変わるので、エラーコードを分ける。
+                if (blocking.All(c => c.DeletedAt != null))
+                {
+                    throw new SignupValidationException(
+                        "organization_deleted",
+                        "このドメインは削除済みのサイトで使用されています。同じドメインでの再登録はできません。",
+                        field: site.Field,
+                        statusCode: statusCode);
+                }
+
+                throw new SignupValidationException(
+                    "organization_already_exists",
+                    "このドメインは既に EcAuth に登録されています。別のサイト URL でお申し込みください。",
+                    field: site.Field,
+                    statusCode: statusCode);
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task<ProvisionedSite> ProvisionAsync(
+            SiteEntry site,
+            string organizationName,
+            string ecCubeVersion,
+            string accountSubject,
+            int? parentOrganizationId,
+            CancellationToken ct = default)
+        {
+            var organization = new Organization
+            {
+                Code = site.Code,
+                Name = organizationName,
+                TenantName = site.Code,
+                IsSandbox = site.IsSandbox,
+                ParentOrganizationId = parentOrganizationId
+            };
+            _context.Organizations.Add(organization);
+            // RsaKeyPair / AccountOrganization が OrganizationId を必要とするため、
+            // ここで一度 SaveChanges して採番された Id を確定させる。
+            await _context.SaveChangesAsync(ct);
+
+            var client = CreateClient(organization, site, organizationName, ecCubeVersion);
+            // 保存前に client_secret を暗号化する（レガシー/dev は平文パススルー）。
+            // Key Vault 暗号化の所要時間を独立ステップとして計測する。
+            using (TimingScope.Begin("client_secret_protect"))
+            {
+                client.ClientSecret = await _secretProtector.ProtectAsync(client.ClientSecret, ct);
+            }
+            _context.Clients.Add(client);
+
+            _context.RsaKeyPairs.Add(CreateRsaKeyPair(organization.Id));
+
+            _context.AccountOrganizations.Add(new AccountOrganization
+            {
+                AccountSubject = accountSubject,
+                OrganizationId = organization.Id,
+                Role = "owner"
+            });
+
+            await _context.SaveChangesAsync(ct);
+
+            return new ProvisionedSite(organization, client);
+        }
+
+        // ---- 組織コード導出・URL 処理 ----
+
+        /// <summary>
+        /// ホスト名から組織コードを導出する。
+        /// lowercase → 先頭 www. 除去 → サブドメイン保持 → 英数以外の連続を "-" に置換 → 前後の "-" を trim。
+        /// 例: <c>shop.example.jp → shop-example-jp</c>。
+        ///
+        /// サンドボックス（テストサイト）の Org には必ず <c>-sandbox</c> を付ける。理由は 2 つある:
+        /// <list type="number">
+        ///   <item>
+        ///     本番と同じドメイン（あるいは <c>www.</c> の有無だけが違うドメイン）でもテスト Org を
+        ///     作れるようにするため。付けないと導出後コードが本番と衝突し、テスト環境を持たない
+        ///     顧客は検証にも本番 Org を使うしかなくなる（EcAuth#482 の問題 2）。
+        ///   </item>
+        ///   <item>
+        ///     組織コードはそのままテナント名になり、プラグインが接続する
+        ///     <c>https://{tenant}.ec-auth.io</c>（<c>ClientResolveController</c>）に現れる。
+        ///     接続先を見ただけで本番かサンドボックスかが分かる。
+        ///   </item>
+        /// </list>
+        /// </summary>
+        public static string DeriveOrganizationCode(string host, bool isSandbox)
+        {
+            var normalized = StripWwwPrefix(host.Trim().ToLowerInvariant());
+            var code = NonAlphanumericRun.Replace(normalized, "-").Trim('-');
+            return isSandbox ? code + SandboxCodeSuffix : code;
+        }
+
+        /// <summary>
+        /// 先頭の <c>www.</c> を除去する（無ければそのまま返す）。呼び出し側で小文字化済みであることを前提とする。
+        /// </summary>
+        private static string StripWwwPrefix(string host)
+        {
+            return host.StartsWith("www.", StringComparison.Ordinal)
+                ? host["www.".Length..]
+                : host;
+        }
+
+        /// <summary>
+        /// URL が HTTPS であることを検証し、RP ID 用のホスト名と、コールバック URL の基点になる
+        /// ベース URL（scheme + authority + 末尾スラッシュ付きベースパス）を返す。
+        /// </summary>
+        private static SiteUrl ValidateHttpsAndParseSiteUrl(string url, string field)
+        {
+            if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)
+                || !string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
+                || string.IsNullOrEmpty(uri.Host))
+            {
+                throw new SignupValidationException(
+                    "invalid_site_url", "サイト URL は https:// で始まる正しい URL を入力してください。", field: field);
+            }
+
+            // IDN（国際化ドメイン）は Uri.Host だと Unicode のまま返り、組織コード導出の
+            // [^a-z0-9] 除去で空文字や衝突を招く。IdnHost（Punycode, ASCII）を使う。
+            // ブラウザが送る Host ヘッダも Punycode なので、プラグインが組み立てる
+            // redirect_uri / rp_id と一致する。
+            var host = uri.IdnHost;
+
+            // 非既定ポートは redirect_uri の完全一致検証に必要なので保持する
+            // （RP ID はポートを含まないドメイン名なので host 側では使わない）。
+            var authority = uri.IsDefaultPort ? host : $"{host}:{uri.Port}";
+
+            return new SiteUrl(host, $"https://{authority}{NormalizeBasePath(uri.AbsolutePath)}");
+        }
+
+        /// <summary>
+        /// サイト URL のパスを、コールバック URL の基点になるベースパスへ正規化する（先頭・末尾がスラッシュ）。
+        /// EC-CUBE 2 系・4 系ともサブディレクトリインストールがあり得るため、パスを捨てずに引き継ぐ。
+        /// 末尾セグメントがウェブ文書の場合のみ落とす（<c>.../index.php</c> を貼られるケース）。
+        /// </summary>
+        private static string NormalizeBasePath(string absolutePath)
+        {
+            var path = string.IsNullOrEmpty(absolutePath) ? "/" : absolutePath;
+
+            // ドットの有無で判定すると "ec-cube-4.2" のようなディレクトリ名をファイル名と
+            // 誤判定してサブディレクトリごと落としてしまうため、拡張子で判定する。
+            var lastSlash = path.LastIndexOf('/');
+            var lastSegment = lastSlash >= 0 ? path[(lastSlash + 1)..] : string.Empty;
+            if (WebDocumentExtensions.Any(ext => lastSegment.EndsWith(ext, StringComparison.OrdinalIgnoreCase)))
+            {
+                path = path[..(lastSlash + 1)];
+            }
+
+            if (!path.StartsWith('/'))
+            {
+                path = "/" + path;
+            }
+
+            return path.EndsWith('/') ? path : path + "/";
+        }
+
+        // ---- レコード生成（AccountsOrganizationSeeder の流儀を流用）----
+
+        /// <summary>
+        /// 顧客 Org 用 Client を生成する。ClientSecret 生成・AllowedRpIds 設定・RedirectUri 付与の流儀は
+        /// <c>AccountsOrganizationSeeder.SeedClientAsync</c> / <c>SeedRedirectUriAsync</c> を流用する。
+        /// </summary>
+        private static Client CreateClient(
+            Organization organization, SiteEntry site, string appName, string ecCubeVersion)
+        {
+            var client = new Client
+            {
+                ClientId = BuildClientId(site.Code),
+                ClientSecret = GenerateClientSecret(),
+                AppName = appName,
+                OrganizationId = organization.Id,
+                SubjectType = SubjectType.B2B,
+                AllowedRpIds = BuildAllowedRpIds(site.Host)
+            };
+
+            // プラグインが authenticate/verify に送る redirect_uri は完全一致で検証される
+            // （B2BPasskeyController）。サイトのトップ URL では一致しないため、選択された
+            // EC プラットフォームのコールバック URL を登録する。
+            client.RedirectUris!.Add(new RedirectUri
+            {
+                Uri = site.BaseUrl + CallbackPathFor(ecCubeVersion)
+            });
+
+            return client;
+        }
+
+        /// <summary>
+        /// 選択された EC プラットフォームのコールバックパスを返す（ベースパスからの相対）。
+        /// EC-CUBE 4 系はルート <c>ecauth_callback</c>（<c>/ecauth/callback</c>）、
+        /// 2 系は <c>HTTPS_URL . 'ecauth/callback.php'</c> を使う。
+        /// </summary>
+        private static string CallbackPathFor(string ecCubeVersion) => ecCubeVersion switch
+        {
+            "2" => "ecauth/callback.php",
+            // "4" と "other"（EC-CUBE 以外）は 4 系と同じパスを初期値にする。
+            _ => "ecauth/callback"
+        };
+
+        /// <summary>
+        /// 初期の allowed_rp_ids を組み立てる。サイト URL が <c>www.</c> 付きでも管理画面は apex
+        /// ドメインというケースがあるため、<c>www.</c> 除去版も許可しておく。
+        /// RP ID はポートを含まないドメイン名（WebAuthn の valid domain string）。
+        /// </summary>
+        private static List<string> BuildAllowedRpIds(string host)
+        {
+            var rpIds = new List<string> { host };
+
+            var stripped = StripWwwPrefix(host);
+            if (!string.Equals(stripped, host, StringComparison.Ordinal))
+            {
+                rpIds.Add(stripped);
+            }
+
+            return rpIds;
+        }
+
+        /// <summary>
+        /// RSA 鍵ペアを生成する。RSA.Create(2048) → Base64 エクスポートの流儀は
+        /// <c>AccountsOrganizationSeeder.SeedRsaKeyPairAsync</c> を流用する。
+        /// </summary>
+        private static RsaKeyPair CreateRsaKeyPair(int organizationId)
+        {
+            using var rsa = RSA.Create(2048);
+            return new RsaKeyPair
+            {
+                Kid = Guid.NewGuid().ToString(),
+                OrganizationId = organizationId,
+                PublicKey = Convert.ToBase64String(rsa.ExportRSAPublicKey()),
+                PrivateKey = Convert.ToBase64String(rsa.ExportRSAPrivateKey()),
+                IsActive = true
+            };
+        }
+
+        private static string GenerateClientSecret()
+        {
+            var bytes = RandomNumberGenerator.GetBytes(32);
+            return Base64UrlTextEncoder.Encode(bytes);
+        }
+
+        /// <summary>
+        /// 顧客 Org 用の client_id を組織コードから導出する。
+        /// グローバルユニーク制約があるため、組織コードに短いランダムサフィックスを付与して衝突を避ける。
+        /// </summary>
+        private static string BuildClientId(string code)
+        {
+            return $"ec-{code}-{Guid.NewGuid():N}";
+        }
+
+        /// <summary>
+        /// サイト URL の解析結果。<c>Host</c> は RP ID / 組織コード導出用（ポートを含まない）、
+        /// <c>BaseUrl</c> は redirect_uri 組み立て用（非既定ポートとベースパスを含み、末尾はスラッシュ）。
+        /// </summary>
+        private sealed record SiteUrl(string Host, string BaseUrl);
+    }
+}

--- a/IdentityProvider/Services/SignupService.cs
+++ b/IdentityProvider/Services/SignupService.cs
@@ -20,24 +20,10 @@ namespace IdentityProvider.Services
         // 同意バージョンの既定値（input で未指定の場合に使用）。
         private const string DefaultPolicyVersion = "1.0";
 
-        // 組織コード導出: 英数字以外の連続を 1 つの "-" に畳み込むための正規表現。
-        private static readonly Regex NonAlphanumericRun = new("[^a-z0-9]+", RegexOptions.Compiled);
-
-        // サンドボックス（テストサイト）Org の組織コードに付ける接尾辞。
-        private const string SandboxCodeSuffix = "-sandbox";
-
-        // 組織コードはそのままテナント名になり {tenant}.ec-auth.io の 1 ラベルを構成する。
-        // DNS のラベル上限は 63 オクテット（RFC 1035）。超えると Org は作れてもその
-        // サブドメインに到達できず、プラグインの接続先が解決不能になる。
-        private const int MaxOrganizationCodeLength = 63;
-
         // 確認 URL 設定キーのテナント部を環境変数名に使える形へ正規化する正規表現。
         // 環境変数名はハイフンを含められない（Azure Linux App Service が 400 で拒否）ため、
         // [A-Za-z0-9_] 以外を "_" に置換する（例: "stg-accounts" -> "stg_accounts"）。
         private static readonly Regex NonConfigKeyChar = new("[^A-Za-z0-9_]", RegexOptions.Compiled);
-
-        // 申込 URL のベースパス正規化: 末尾セグメントをファイル名とみなして落とす拡張子。
-        private static readonly string[] WebDocumentExtensions = [".php", ".html", ".htm"];
 
         private readonly EcAuthDbContext _context;
         private readonly ITenantService _tenantService;
@@ -45,8 +31,8 @@ namespace IdentityProvider.Services
         private readonly IDisposableEmailChecker _disposableEmailChecker;
         private readonly IConfiguration _configuration;
         private readonly ILogger<SignupService> _logger;
-        private readonly ISecretProtector _secretProtector;
         private readonly IPasskeyRegistrationTokenService _registrationTokenService;
+        private readonly IOrganizationProvisioningService _provisioning;
 
         public SignupService(
             EcAuthDbContext context,
@@ -55,8 +41,8 @@ namespace IdentityProvider.Services
             IDisposableEmailChecker disposableEmailChecker,
             IConfiguration configuration,
             ILogger<SignupService> logger,
-            ISecretProtector secretProtector,
-            IPasskeyRegistrationTokenService registrationTokenService)
+            IPasskeyRegistrationTokenService registrationTokenService,
+            IOrganizationProvisioningService provisioning)
         {
             _context = context;
             _tenantService = tenantService;
@@ -64,8 +50,8 @@ namespace IdentityProvider.Services
             _disposableEmailChecker = disposableEmailChecker;
             _configuration = configuration;
             _logger = logger;
-            _secretProtector = secretProtector;
             _registrationTokenService = registrationTokenService;
+            _provisioning = provisioning;
         }
 
         /// <inheritdoc />
@@ -85,7 +71,7 @@ namespace IdentityProvider.Services
                 ValidateEcCubeVersion(input.EcCubeVersion);
 
                 // 組織コードの重複チェック（全テナント横断）。
-                await EnsureOrganizationCodesAvailableAsync(sites, ct);
+                await _provisioning.EnsureOrganizationCodesAvailableAsync(sites.Sites, ct);
             }
 
             // 生トークン（メール URL に使う）と、その SHA-256 ハッシュ（DB に保存する）を生成する。
@@ -173,7 +159,7 @@ namespace IdentityProvider.Services
                 // 申込時から confirm までの間にデータが変わっている可能性があるため、再バリデーションする。
                 sites = ValidateSiteUrls(signupRequest.ProductionSiteUrl, signupRequest.TestSiteUrl);
                 // confirm 時の code 衝突は Race Condition のため 409 を返す。
-                await EnsureOrganizationCodesAvailableAsync(sites, ct, statusCode: 409);
+                await _provisioning.EnsureOrganizationCodesAvailableAsync(sites.Sites, ct, statusCode: 409);
 
                 // 受付テナント（accounts / stg-accounts）の Organization を取得する。
                 // 受付 Org の code は tenant_name と一致する（AccountsOrganizationSeeder の定義）。
@@ -241,38 +227,26 @@ namespace IdentityProvider.Services
 
                 // 顧客 Organization を入力 URL に応じて 1〜2 件作成し、
                 // 各 Org に Client / RsaKeyPair / AccountOrganization を作成する。
-                foreach (var site in sites.Sites)
+                //
+                // 本番を先に作り、テスト Org には本番の Id を親として持たせる
+                //（「1 本番 Org あたりサンドボックスは 1 つ」の紐付け）。テストサイトだけで
+                // 申し込んだ場合は親が存在しないため null のままにする。後から本番サイトを
+                // 追加したときに、マイページ側でこの孤立サンドボックスを親に紐づけ直せる。
+                int? productionOrganizationId = null;
+                foreach (var site in sites.Sites.OrderBy(s => s.IsSandbox))
                 {
-                    var organization = new Organization
-                    {
-                        Code = site.Code,
-                        Name = signupRequest.OrganizationName,
-                        TenantName = site.Code,
-                        IsSandbox = site.IsSandbox
-                    };
-                    _context.Organizations.Add(organization);
-                    // RsaKeyPair / AccountOrganization が OrganizationId を必要とするため、
-                    // ここで一度 SaveChanges して採番された Id を確定させる。
-                    await _context.SaveChangesAsync(ct);
+                    var provisioned = await _provisioning.ProvisionAsync(
+                        site,
+                        signupRequest.OrganizationName,
+                        signupRequest.EcCubeVersion,
+                        subject,
+                        parentOrganizationId: site.IsSandbox ? productionOrganizationId : null,
+                        ct);
 
-                    var client = CreateClient(
-                        organization, site, signupRequest.OrganizationName, signupRequest.EcCubeVersion);
-                    // 保存前に client_secret を暗号化する（レガシー/dev は平文パススルー）。
-                    // Key Vault 暗号化の所要時間を confirm 内の独立ステップとして計測する。
-                    using (TimingScope.Begin("client_secret_protect"))
+                    if (!site.IsSandbox)
                     {
-                        client.ClientSecret = await _secretProtector.ProtectAsync(client.ClientSecret, ct);
+                        productionOrganizationId = provisioned.Organization.Id;
                     }
-                    _context.Clients.Add(client);
-
-                    _context.RsaKeyPairs.Add(CreateRsaKeyPair(organization.Id));
-
-                    _context.AccountOrganizations.Add(new AccountOrganization
-                    {
-                        AccountSubject = subject,
-                        OrganizationId = organization.Id,
-                        Role = "owner"
-                    });
                 }
 
                 signupRequest.ConfirmedAt = DateTimeOffset.UtcNow;
@@ -434,7 +408,7 @@ namespace IdentityProvider.Services
             return name;
         }
 
-        private static SiteSet ValidateSiteUrls(string? productionSiteUrl, string? testSiteUrl)
+        private SiteSet ValidateSiteUrls(string? productionSiteUrl, string? testSiteUrl)
         {
             var production = NormalizeOptionalUrl(productionSiteUrl);
             var test = NormalizeOptionalUrl(testSiteUrl);
@@ -447,34 +421,16 @@ namespace IdentityProvider.Services
                     field: "production_site_url");
             }
 
-            SiteUrl? productionSite = null;
-            SiteUrl? testSite = null;
+            var sites = new List<SiteEntry>();
 
             if (production != null)
             {
-                productionSite = ValidateHttpsAndParseSiteUrl(production, "production_site_url");
+                sites.Add(_provisioning.BuildSite(production, isSandbox: false, "production_site_url"));
             }
+
             if (test != null)
             {
-                testSite = ValidateHttpsAndParseSiteUrl(test, "test_site_url");
-            }
-
-            var sites = new List<SiteEntry>();
-
-            if (productionSite != null)
-            {
-                sites.Add(new SiteEntry(
-                    DeriveOrganizationCode(productionSite.Host, isSandbox: false),
-                    productionSite.Host, productionSite.BaseUrl,
-                    IsSandbox: false, "production_site_url"));
-            }
-
-            if (testSite != null)
-            {
-                sites.Add(new SiteEntry(
-                    DeriveOrganizationCode(testSite.Host, isSandbox: true),
-                    testSite.Host, testSite.BaseUrl,
-                    IsSandbox: true, "test_site_url"));
+                sites.Add(_provisioning.BuildSite(test, isSandbox: true, "test_site_url"));
             }
 
             return new SiteSet(
@@ -493,163 +449,10 @@ namespace IdentityProvider.Services
             }
         }
 
-        private async Task EnsureOrganizationCodesAvailableAsync(SiteSet sites, CancellationToken ct, int statusCode = 422)
-        {
-            // 組織コードはテナント名（= {tenant}.ec-auth.io の 1 ラベル）になるため、
-            // DNS のラベル上限を超えるものは作らせない。作れても到達できないため。
-            foreach (var site in sites.Sites)
-            {
-                if (site.Code.Length > MaxOrganizationCodeLength)
-                {
-                    throw new SignupValidationException(
-                        "invalid_site_url",
-                        "サイト URL のドメインが長すぎます。より短いドメインでお申し込みください。",
-                        field: site.Field,
-                        statusCode: 422);
-                }
-            }
-
-            // 同一リクエスト内で導出後の組織コードが衝突していないか検知する。
-            // 本番とテストは接尾辞（-sandbox）で必ず分かれるため通常は発火しないが、
-            // 導出規則を将来変えたときに黙って 1 件に潰れるのを防ぐガードとして残す。
-            var seenCodes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var site in sites.Sites)
-            {
-                if (!seenCodes.Add(site.Code))
-                {
-                    throw new SignupValidationException(
-                        "duplicate_site",
-                        "本番サイトとテストサイトが同じ組織として扱われます。"
-                            + "テストサイトには別のドメインをご指定ください。",
-                        field: site.Field,
-                        statusCode: 422);
-                }
-            }
-
-            // ドメインの占有は「接尾辞を除いた導出コード」で判定する。site.Code をそのまま
-            // 比較すると、サンドボックス側だけコードが変わったせいで
-            //   - 旧規則（接尾辞なし）で登録済みのサンドボックス Org
-            //   - 本番として登録済みのドメイン
-            // を、別アカウントがテストサイトとして再登録できてしまう。
-            //
-            // 同一申込内での本番＋サンドボックス併存はこれでも壊れない。Organization の作成は
-            // このチェックより後（トランザクション内）で行うため、ペアの相方はまだ DB に無いため。
-            // 申込内の衝突判定は上の seenCodes が接尾辞込みのコードで行っており、そちらは併存を許す。
-            foreach (var site in sites.Sites)
-            {
-                var baseCode = DeriveOrganizationCode(site.Host, isSandbox: false);
-                var sandboxCode = baseCode + SandboxCodeSuffix;
-
-                var exists = await _context.Organizations
-                    .IgnoreQueryFilters()
-                    .AnyAsync(o => o.Code == baseCode || o.Code == sandboxCode, ct);
-
-                if (exists)
-                {
-                    throw new SignupValidationException(
-                        "organization_already_exists",
-                        "このドメインは既に EcAuth に登録されています。別のサイト URL でお申し込みください。",
-                        field: site.Field,
-                        statusCode: statusCode);
-                }
-            }
-        }
-
-        // ---- 組織コード導出・URL 処理 ----
-
-        /// <summary>
-        /// ホスト名から組織コードを導出する。
-        /// lowercase → 先頭 www. 除去 → サブドメイン保持 → 英数以外の連続を "-" に置換 → 前後の "-" を trim。
-        /// 例: <c>shop.example.jp → shop-example-jp</c>。
-        ///
-        /// サンドボックス（テストサイト）の Org には必ず <c>-sandbox</c> を付ける。理由は 2 つある:
-        /// <list type="number">
-        ///   <item>
-        ///     本番と同じドメイン（あるいは <c>www.</c> の有無だけが違うドメイン）でもテスト Org を
-        ///     作れるようにするため。付けないと導出後コードが本番と衝突し、テスト環境を持たない
-        ///     顧客は検証にも本番 Org を使うしかなくなる（EcAuth#482 の問題 2）。
-        ///   </item>
-        ///   <item>
-        ///     組織コードはそのままテナント名になり、プラグインが接続する
-        ///     <c>https://{tenant}.ec-auth.io</c>（<c>ClientResolveController</c>）に現れる。
-        ///     接続先を見ただけで本番かサンドボックスかが分かる。
-        ///   </item>
-        /// </list>
-        /// </summary>
-        private static string DeriveOrganizationCode(string host, bool isSandbox)
-        {
-            var normalized = StripWwwPrefix(host.Trim().ToLowerInvariant());
-            var code = NonAlphanumericRun.Replace(normalized, "-").Trim('-');
-            return isSandbox ? code + SandboxCodeSuffix : code;
-        }
-
-        /// <summary>
-        /// 先頭の <c>www.</c> を除去する（無ければそのまま返す）。呼び出し側で小文字化済みであることを前提とする。
-        /// </summary>
-        private static string StripWwwPrefix(string host)
-        {
-            return host.StartsWith("www.", StringComparison.Ordinal)
-                ? host["www.".Length..]
-                : host;
-        }
-
         private static string? NormalizeOptionalUrl(string? url)
         {
             var trimmed = url?.Trim();
             return string.IsNullOrEmpty(trimmed) ? null : trimmed;
-        }
-
-        /// <summary>
-        /// URL が HTTPS であることを検証し、RP ID 用のホスト名と、コールバック URL の基点になる
-        /// ベース URL（scheme + authority + 末尾スラッシュ付きベースパス）を返す。
-        /// </summary>
-        private static SiteUrl ValidateHttpsAndParseSiteUrl(string url, string field)
-        {
-            if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)
-                || !string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
-                || string.IsNullOrEmpty(uri.Host))
-            {
-                throw new SignupValidationException(
-                    "invalid_site_url", "サイト URL は https:// で始まる正しい URL を入力してください。", field: field);
-            }
-
-            // IDN（国際化ドメイン）は Uri.Host だと Unicode のまま返り、組織コード導出の
-            // [^a-z0-9] 除去で空文字や衝突を招く。IdnHost（Punycode, ASCII）を使う。
-            // ブラウザが送る Host ヘッダも Punycode なので、プラグインが組み立てる
-            // redirect_uri / rp_id と一致する。
-            var host = uri.IdnHost;
-
-            // 非既定ポートは redirect_uri の完全一致検証に必要なので保持する
-            // （RP ID はポートを含まないドメイン名なので host 側では使わない）。
-            var authority = uri.IsDefaultPort ? host : $"{host}:{uri.Port}";
-
-            return new SiteUrl(host, $"https://{authority}{NormalizeBasePath(uri.AbsolutePath)}");
-        }
-
-        /// <summary>
-        /// 申込 URL のパスを、コールバック URL の基点になるベースパスへ正規化する（先頭・末尾がスラッシュ）。
-        /// EC-CUBE 2 系・4 系ともサブディレクトリインストールがあり得るため、パスを捨てずに引き継ぐ。
-        /// 末尾セグメントがウェブ文書の場合のみ落とす（<c>.../index.php</c> を貼られるケース）。
-        /// </summary>
-        private static string NormalizeBasePath(string absolutePath)
-        {
-            var path = string.IsNullOrEmpty(absolutePath) ? "/" : absolutePath;
-
-            // ドットの有無で判定すると "ec-cube-4.2" のようなディレクトリ名をファイル名と
-            // 誤判定してサブディレクトリごと落としてしまうため、拡張子で判定する。
-            var lastSlash = path.LastIndexOf('/');
-            var lastSegment = lastSlash >= 0 ? path[(lastSlash + 1)..] : string.Empty;
-            if (WebDocumentExtensions.Any(ext => lastSegment.EndsWith(ext, StringComparison.OrdinalIgnoreCase)))
-            {
-                path = path[..(lastSlash + 1)];
-            }
-
-            if (!path.StartsWith('/'))
-            {
-                path = "/" + path;
-            }
-
-            return path.EndsWith('/') ? path : path + "/";
         }
 
         private static bool IsValidEmail(string email)
@@ -666,83 +469,6 @@ namespace IdentityProvider.Services
             }
         }
 
-        // ---- レコード生成（AccountsOrganizationSeeder の流儀を流用）----
-
-        /// <summary>
-        /// 顧客 Org 用 Client を生成する。ClientSecret 生成・AllowedRpIds 設定・RedirectUri 付与の流儀は
-        /// <c>AccountsOrganizationSeeder.SeedClientAsync</c> / <c>SeedRedirectUriAsync</c> を流用する。
-        /// </summary>
-        private static Client CreateClient(
-            Organization organization, SiteEntry site, string appName, string ecCubeVersion)
-        {
-            var client = new Client
-            {
-                ClientId = BuildClientId(site.Code),
-                ClientSecret = GenerateClientSecret(),
-                AppName = appName,
-                OrganizationId = organization.Id,
-                SubjectType = SubjectType.B2B,
-                AllowedRpIds = BuildAllowedRpIds(site.Host)
-            };
-
-            // プラグインが authenticate/verify に送る redirect_uri は完全一致で検証される
-            // （B2BPasskeyController）。サイトのトップ URL では一致しないため、申込時に
-            // 選ばれた EC プラットフォームのコールバック URL を登録する。
-            client.RedirectUris!.Add(new RedirectUri
-            {
-                Uri = site.BaseUrl + CallbackPathFor(ecCubeVersion)
-            });
-
-            return client;
-        }
-
-        /// <summary>
-        /// 申込時に選ばれた EC プラットフォームのコールバックパスを返す（ベースパスからの相対）。
-        /// EC-CUBE 4 系はルート <c>ecauth_callback</c>（<c>/ecauth/callback</c>）、
-        /// 2 系は <c>HTTPS_URL . 'ecauth/callback.php'</c> を使う。
-        /// </summary>
-        private static string CallbackPathFor(string ecCubeVersion) => ecCubeVersion switch
-        {
-            "2" => "ecauth/callback.php",
-            // "4" と "other"（EC-CUBE 以外）は 4 系と同じパスを初期値にする。
-            _ => "ecauth/callback"
-        };
-
-        /// <summary>
-        /// 初期の allowed_rp_ids を組み立てる。申込 URL が <c>www.</c> 付きでも管理画面は apex
-        /// ドメインというケースがあるため、<c>www.</c> 除去版も許可しておく。
-        /// RP ID はポートを含まないドメイン名（WebAuthn の valid domain string）。
-        /// </summary>
-        private static List<string> BuildAllowedRpIds(string host)
-        {
-            var rpIds = new List<string> { host };
-
-            var stripped = StripWwwPrefix(host);
-            if (!string.Equals(stripped, host, StringComparison.Ordinal))
-            {
-                rpIds.Add(stripped);
-            }
-
-            return rpIds;
-        }
-
-        /// <summary>
-        /// RSA 鍵ペアを生成する。RSA.Create(2048) → Base64 エクスポートの流儀は
-        /// <c>AccountsOrganizationSeeder.SeedRsaKeyPairAsync</c> を流用する。
-        /// </summary>
-        private static RsaKeyPair CreateRsaKeyPair(int organizationId)
-        {
-            using var rsa = RSA.Create(2048);
-            return new RsaKeyPair
-            {
-                Kid = Guid.NewGuid().ToString(),
-                OrganizationId = organizationId,
-                PublicKey = Convert.ToBase64String(rsa.ExportRSAPublicKey()),
-                PrivateKey = Convert.ToBase64String(rsa.ExportRSAPrivateKey()),
-                IsActive = true
-            };
-        }
-
         // ---- トークン・URL・補助 ----
 
         private static string GenerateConfirmToken()
@@ -750,21 +476,6 @@ namespace IdentityProvider.Services
             // 32 byte の URL-safe ランダム。Base64URL（パディング除去）でエンコードする。
             var bytes = RandomNumberGenerator.GetBytes(ConfirmTokenBytes);
             return Base64UrlEncode(bytes);
-        }
-
-        private static string GenerateClientSecret()
-        {
-            var bytes = RandomNumberGenerator.GetBytes(32);
-            return Base64UrlEncode(bytes);
-        }
-
-        /// <summary>
-        /// 顧客 Org 用の client_id を組織コードから導出する。
-        /// グローバルユニーク制約があるため、組織コードに短いランダムサフィックスを付与して衝突を避ける。
-        /// </summary>
-        private static string BuildClientId(string code)
-        {
-            return $"ec-{code}-{Guid.NewGuid():N}";
         }
 
         private static string Base64UrlEncode(byte[] bytes)
@@ -848,15 +559,10 @@ namespace IdentityProvider.Services
 
         // ---- 内部表現 ----
 
-        private sealed record SiteSet(string? ProductionUrl, string? TestUrl, List<SiteEntry> Sites);
-
-        private sealed record SiteEntry(
-            string Code, string Host, string BaseUrl, bool IsSandbox, string Field);
-
         /// <summary>
-        /// 申込 URL の解析結果。<c>Host</c> は RP ID / 組織コード導出用（ポートを含まない）、
-        /// <c>BaseUrl</c> は redirect_uri 組み立て用（非既定ポートとベースパスを含み、末尾はスラッシュ）。
+        /// 申込 1 件が作るサイトの集合。<c>Sites</c> の各要素は
+        /// <see cref="IOrganizationProvisioningService.BuildSite"/> が検証・導出した結果。
         /// </summary>
-        private sealed record SiteUrl(string Host, string BaseUrl);
+        private sealed record SiteSet(string? ProductionUrl, string? TestUrl, List<SiteEntry> Sites);
     }
 }

--- a/IdentityProvider/Services/SignupService.cs
+++ b/IdentityProvider/Services/SignupService.cs
@@ -156,6 +156,26 @@ namespace IdentityProvider.Services
                         "token_expired", "確認トークンの有効期限が切れています。お手数ですが再度お申し込みください。", field: "token");
                 }
 
+                // 本番サイト URL 必須化（EcAuth#482）より前に保存された申込は、本番 URL を
+                // 持たないまま確認待ちになっている可能性がある。下の再バリデーションに任せると
+                // 「本番サイト URL を入力してください」が返るが、確認画面には入力欄が無く
+                // 利用者は何もできない。再申込しかないことが伝わるエラーに振り替える。
+                //
+                // 該当するのはこの変更のデプロイ前 24 時間（ConfirmTokenLifetime）以内に
+                // テストサイトのみで申し込み、まだ確認していないケースに限られる。
+                if (string.IsNullOrWhiteSpace(signupRequest.ProductionSiteUrl))
+                {
+                    _logger.LogWarning(
+                        "本番サイト URL を持たない申込の確認を拒否しました: Tenant={Tenant}, TokenHash={TokenHash}",
+                        signupRequest.TenantName, TokenHashPrefix(token));
+                    throw new SignupValidationException(
+                        "signup_needs_resubmission",
+                        "お申し込み内容が現在の登録要件を満たしていません。"
+                            + "お手数ですが、本番サイト URL を入力して再度お申し込みください。",
+                        field: "token",
+                        statusCode: 422);
+                }
+
                 // 申込時から confirm までの間にデータが変わっている可能性があるため、再バリデーションする。
                 sites = ValidateSiteUrls(signupRequest.ProductionSiteUrl, signupRequest.TestSiteUrl);
                 // confirm 時の code 衝突は Race Condition のため 409 を返す。

--- a/IdentityProvider/Services/SignupService.cs
+++ b/IdentityProvider/Services/SignupService.cs
@@ -413,11 +413,18 @@ namespace IdentityProvider.Services
             var production = NormalizeOptionalUrl(productionSiteUrl);
             var test = NormalizeOptionalUrl(testSiteUrl);
 
-            if (production == null && test == null)
+            // 本番サイトは必須。テストサイトだけの申込を許すと、紐づく本番が無い
+            // サンドボックス Org（parent_organization_id が null）ができてしまう。
+            // このサンドボックスは「1 本番あたりテストは 1 件」の判定
+            // （AccountController が ParentOrganizationId で数える）に引っかからないため、
+            // 後から本番を追加するとサンドボックスが 2 件並ぶ状態を作れてしまう。
+            // テスト環境から始めたい利用者には、本番ドメインを申込時に決めてもらったうえで
+            // テストサイトを併記する運用に寄せる。
+            if (production == null)
             {
                 throw new SignupValidationException(
                     "invalid_site_url",
-                    "本番サイト URL またはテストサイト URL のいずれかを入力してください。",
+                    "本番サイト URL を入力してください。",
                     field: "production_site_url");
             }
 

--- a/IdentityProvider/Services/TokenService.cs
+++ b/IdentityProvider/Services/TokenService.cs
@@ -387,6 +387,7 @@ namespace IdentityProvider.Services
                 // 2. Client を検索
                 var client = await _context.Clients
                     .IgnoreQueryFilters()
+                    .ExcludeDeletedOrganizations()
                     .FirstOrDefaultAsync(c => c.ClientId == clientIdClaim);
 
                 if (client == null)


### PR DESCRIPTION
## Summary

申込で本番・テストの片方しか登録しなかった場合に、後からもう一方を追加する手段が無かった問題（EcAuth/EcAuth#482）を解消します。サイト = Organization は 1:1 のため、「もう一方を追加する」は Organization の新規作成になります。

あわせて、サイトの付け替えを「サイト追加 → 動作確認 → 旧サイト削除」で行うために必須となるサイト削除も実装しました。

## Changes

### API（`AccountController`）

| エンドポイント | 内容 |
|---|---|
| `GET /v1/account/organizations` | 管理下サイトの一覧（`max_sites` / 本番サイト数付き） |
| `POST /v1/account/organizations` | サイト追加 |
| `POST /v1/account/organizations/{id}/delete` | サイト削除（論理削除） |

エラー: `site_limit_exceeded` / `sandbox_already_exists` / `invalid_parent` / `organization_deleted` / `organization_already_exists`。

`DELETE` を使わないのは、CORS ポリシー `SignupApiCors` が `GET / POST / OPTIONS` 限定であることに加え、レコードを残す論理削除が `DELETE` のセマンティクスと合わないためです。将来 PUT / DELETE に寄せる場合は `Program.cs` の `WithMethods` に足すだけで対応できますが、`/api/signup` と共用のポリシーである点に注意が必要です。

### 制約（方針として確定済み）

- **サイトは物理削除しない**（`organization.deleted_at`）。将来の課金は Organization 単位の集計になるため、解約済みサイトも期間つきで残します。組織コードも解放しません（同じコードで作り直せると集計で別サイトの利用期間が混ざるため）。削除済みドメインの再登録は `organization_deleted` で拒否します
- **本番サイトは 1 アカウント 10 件まで**（`account.max_sites`）。プラン変更や個別対応は DB のこのカラムを直接更新して運用します（変更 API は設けていません）。サンドボックスは「本番 1 件につき 1 件」という別制約で縛るため、この上限には数えません
- **申込は本番サイト URL を必須にする**。テストサイトだけの申込を許すと、紐づく本番の無いサンドボックス Org（`parent_organization_id` が null）ができ、「1 本番 1 テスト」の判定をすり抜けて後から本番を追加するとサンドボックスが 2 件並ぶ状態を作れてしまう。本番 DB を確認したところ該当アカウントは **0 件**（Organization 14 件 / サンドボックス 2 件）で、既存データの救済は不要。申込フォーム側は EcAuth/ecauth-website#28 で揃える
- **1 本番 Org あたりテストは 1 件**。`organization.parent_organization_id` で紐づけ、フィルター付きユニークインデックスで DB 制約としても担保します。組織コードの導出（本番コード + `-sandbox`）では別ドメインのテストサイト（`shop.example.jp` と `stg.example.jp`）を紐づけられないため、関連をカラムとして持たせています

### 論理削除の伝播

`Organization` のクエリフィルターに `DeletedAt` 条件を足すだけでは止まりません。EF Core のグローバルクエリフィルターは、述語の中でナビゲーションを辿った参照（`c.Organization.XXX`）には自動適用されないためです。

- `EcAuthDbContext` の派生クエリフィルター全てに `DeletedAt == null` を明記
- 認証系は `IgnoreQueryFilters()` で Client を引くため、`ClientQueryExtensions.ExcludeDeletedOrganizations()` を全経路（`TokenController` / `AuthorizationController` / `AuthorizationCallbackController` / `B2BPasskeyController` / `B2BPasskeyService` / `TokenService` / `MagicLinkService`）に適用
- `ClientResolveController` は削除済みなら 404。プラグインは接続先 IdP の `base_url` をここから得るため、これが「サイトを削除したら接続が止まる」の実効的な担保になります
- `AccountService.GetManagedOrganizationsAsync` も除外（`managed_orgs` クレームから外れます）

### プロビジョニングの共通化

Organization / Client / RsaKeyPair / AccountOrganization の払い出しを `SignupService` から `OrganizationProvisioningService` へ切り出し、申込フローとサイト追加で共用します。組織コードの導出規則や初期 redirect_uri がずれると「申込で作ったサイトは動くが後から足したサイトは動かない」類の差異を生むためです。申込フローの挙動は変えていません。

### マイグレーション

```
organization  + deleted_at / + parent_organization_id / + フィルター付きユニークインデックス
account       + max_sites (既定 10)
```

既存の本番 / テストペアを `parent_organization_id` にバックフィルします（`EXEC()` ラップ）。

1. 組織コードが本番 + `-sandbox` で一致するペア
2. 残りのうち、アカウント配下が「本番 1 + サンドボックス 1」だけのケース
3. 対応関係を機械的に決められないものは NULL のまま残す（既存の認証動作には影響しません）

## Test plan

実行済み:

- [x] `dotnet build EcAuth.sln` — 0 エラー
- [x] `dotnet test IdentityProvider.Test` — **771 件全パス**（変更前 745 → 26 件追加）
- [x] `dotnet ef migrations has-pending-model-changes` — 差分ゼロ
- [x] 実 SQL Server 2022 に対して前提スキーマ → データ投入 → 本マイグレーション適用（エラーなし）
- [x] バックフィル 3 ケースの分岐が期待どおり（コード一致ペア / 別ドメインのテスト / 曖昧なものは NULL）
- [x] 既存アカウントの `max_sites` に 10 が入る
- [x] 「1 本番 1 テスト」のユニーク制約が 2 件目の INSERT を拒否する（`Msg 2601`）
- [x] 論理削除後は枠が空き、新しいテスト Org を追加できる
- [x] 生成スクリプトの冪等性（再実行してエラーなし）

ローカル Docker（実 SQL Server + 実 IdP）に対して実行済み:

- [x] `op run --env-file=.env.dev.tpl -- docker compose -p ec-auth up -d --build` で起動 → `/healthz` が `{"status":"healthy","database":"connected"}`
- [x] 起動時に本マイグレーションが適用され、全シーダーが完走（`DbInitializer: Initialization completed`）
- [x] 実 DB に `deleted_at` / `parent_organization_id` / `max_sites` とフィルター付きインデックスが存在し、既存アカウント 14 件の `max_sites` が 10 になっている
- [x] **回帰**: `signup_client_b2b_login.spec.ts` + `platform_client_resolve.spec.ts` — **12 件全パス**（論理削除フィルター追加の影響なし。申込 → パスキー登録 → 認証 → トークン交換 → redirect_uri 更新まで通過）
- [x] **新規**: `account_site_management.spec.ts`（10 件）+ `account_test_only_signup.spec.ts`（2 件）を追加
- [x] 上記 4 spec を通しで実行し **24 件全パス**

追加した E2E がカバーするもの（InMemory では確かめられない実 DB 依存の挙動）:

- [x] 申込直後の一覧に `max_sites` / `production_site_count` が出る
- [x] 本番サイトを追加でき、初期 `redirect_uri` が申込と同じ導出になる
- [x] 追加したサイトの `client_id` が `/platform/v1/client-resolve` で解決できる
- [x] 本番と同じドメインでもテストサイトを追加できる（`-sandbox` 接尾辞で分かれるため）
- [x] 1 本番あたりテストは 1 件まで（`sandbox_already_exists`）
- [x] 管理外の Organization は親に指定できない（`invalid_parent`）
- [x] 本番を削除すると配下のテストも消える
- [x] **削除したサイトの `client_id` は `client-resolve` から 404 になる**（プラグインが接続先を解決できなくなる = 削除が実際に効いている担保）
- [x] 削除したドメインは再登録できない（`organization_deleted`）
- [x] 削除で枠が空き、同じ本番に新しいテストサイトを作れる（付け替え手順の前提）
- [x] テストサイト URL だけの申込は 422 `invalid_site_url` / `field=production_site_url` で拒否される
- [x] サイト URL を両方省いた申込も 422 で拒否される

## Notes

- 検証中に `QUOTED_IDENTIFIER` エラーが出ましたが、これは手元の `sqlcmd` に `-I` を付け忘れたためです。CI（`dotnet_tests.yml:123`）は `-I` を付けており、既存マイグレーションにもフィルター付きインデックスが 2 件あって本番稼働実績があります
- **ロールバック方針**: `Down` は 3 カラムとインデックスを落とします。`deleted_at` が消えると削除済みサイトが復活するため、本番投入後の revert は避け、前進修正で対応します
- **関連 PR**: EcAuth/ecauth-website#28（申込フォームを本番必須に揃える）。**本 PR を先にマージ**してください。逆順だとフォームを経由しない直接 POST が素通りする期間が残ります
- 画面側（EcAuth/ecauth-website#20）はこの API のマージ後に着手します
- EcAuth/EcAuth#482 の残タスク 2（`B2BPasskeyService` のローカル開発ポート 4430 / 8000）と残タスク 3（EC-CUBE 4 系プラグインの `error_description` 透過）は本 PR のスコープ外です

Refs: EcAuth/EcAuth#482

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * アカウントごとにサイトを一覧・追加・削除できるようになりました。
  * 本番サイトとサンドボックスサイトの親子関係に対応しました。
  * サイト作成時にクライアントや認証用鍵を自動生成します。
  * アカウントごとのサイト登録上限を設定できるようになりました。

* **バグ修正**
  * 削除済みサイトのクライアントが、ログインや認証処理で利用されないよう改善しました。
  * 削除済みサイトが管理対象一覧に表示されないようにしました。

* **テスト**
  * サイト登録、上限、重複、URL検証、サンドボックス連携などの検証を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

