### PR TITLE
test(e2e): マイページの参照先が organizations に変わったことをコメントに反映する

### DIFF
--- a/E2ETests/tests/specs/website_signup_flow.spec.ts
+++ b/E2ETests/tests/specs/website_signup_flow.spec.ts
@@ -14,7 +14,7 @@ import { createMailbox, extractToken, Mailbox } from '../helpers/mailbox';
  *     → Frontend:BaseUrl 経由でマイページへ復帰
  *     → /mypage/ から PKCE で認可開始 → accounts で実パスキー認証 → 認可コード
  *     → /auth/callback が /v1/token でトークン交換（public client・PKCE）
- *     → /v1/account/clients で Client 一覧、secret の reveal / 再生成
+ *     → /v1/account/organizations でサイト一覧、secret の reveal / 再生成
  *     → マイページの編集 UI から redirect_uri / allowed_rp_ids を実 API で全置換
  *     → リカバリ（マジックリンク）でも同じマイページに着地する
  *
@@ -200,10 +200,13 @@ test.describe.serial('ecauth-website フロント × EcAuth 実バックエン�
     await expect(page.locator('#login-view')).toBeHidden();
   });
 
-  test('マイページが実 API から Client 一覧を取得して表示する', async () => {
+  test('マイページが実 API からサイト一覧を取得して表示する', async () => {
     test.setTimeout(30000);
 
-    // 申込で作られた顧客 Org の Client が出ること（組織コードはサイト host から導出される）。
+    // 申込で作られた顧客 Org が出ること（組織コードはサイト host から導出される）。
+    // マイページは 1 カード = 1 サイト（Organization）で描画し、その配下に Client を出す。
+    // カードのクラス名は Client 単位だった頃から .client-item のまま
+    // （単位が変わっていないため据え置き。ecauth-website#29）。
     const item = page.locator('.client-item').filter({ hasText: expectedOrgCode });
     await expect(item).toHaveCount(1, { timeout: 15000 });
 
@@ -275,7 +278,7 @@ test.describe.serial('ecauth-website フロント × EcAuth 実バックエン�
    * 参照実装 signup_client_b2b_login.spec.ts も同じ使い分けをしている:
    *   :180 / :187  期待値は siteHost から組み立てて登録値と突き合わせる（回帰検出）
    *   :207 / :225  セレモニーに渡すのは API から取った registeredRpId / registeredRedirectUri
-   * 画面に出ている値は mypage.js が GET /v1/account/clients を描画したものなので、
+   * 画面に出ている値は mypage.js が GET /v1/account/organizations を描画したものなので、
    * 「登録値を使う」側の要請はブラウザ経由で既に満たされている。
    */
 


### PR DESCRIPTION
Refs EcAuth/ecauth-website#20, EcAuth/ecauth-website#29

## 概要

[ecauth-website#29](https://github.com/EcAuth/ecauth-website/pull/29) でマイページのデータ源が `GET /v1/account/clients` から `GET /v1/account/organizations` に変わり、画面の単位も Client からサイト（Organization）になりました。

`website_signup_flow.spec.ts` はブラウザ経由でマイページを操作するため**テスト自体は無変更で通ります**が、「何を叩いている画面なのか」の説明が実装と食い違うため合わせます。

## 変更内容

`E2ETests/tests/specs/website_signup_flow.spec.ts` のコメント 3 箇所のみ。ロジックの変更はありません。

| 箇所 | 変更 |
|---|---|
| ファイル冒頭のフロー説明 | `/v1/account/clients で Client 一覧` → `/v1/account/organizations でサイト一覧` |
| テスト名 | `マイページが実 API から Client 一覧を取得して表示する` → `…サイト一覧を…` |
| 期待値の組み立て方針に関するコメント | `mypage.js が GET /v1/account/clients を描画` → `…organizations を描画` |

あわせて、カードのクラス名が `.client-item` のままである理由（1 カード = 1 サイトという単位は変わっていないので据え置いた）を書き添えました。次にセレクタを触る人が「Client 単位のはずなのにサイトが 1 枚ずつ出ている」と混乱しないようにするためです。

## 変更しなかったもの

`GET /v1/account/clients` **自体は現役のエンドポイント**です。`E2ETests/tests/helpers/accounts.ts:198` が登録済みの `redirect_uri` / `rp_id` を引くのに使っており、`CLAUDE.md:184` の「`redirect_uri` / `rp_id` をテスト側で組み立てない」の記述もそのまま有効なので、どちらも触っていません。

## Test plan

- [x] `pnpm exec playwright test --list tests/specs/website_signup_flow.spec.ts` — 11 tests を認識
- [x] ecauth-website#29 マージ前に、同 spec が新しいマイページに対して通ることを確認済み（[run 31062364464](https://github.com/EcAuth/EcAuth/actions/runs/31062364464) — 11 テストが skip されずに通過）
- [x] この PR の CI（`main.yml` → `playwright.yml`）が全ジョブ pass。ecauth-website の main は #29 マージ済みで、`website_ref` 未指定のまま結合が回った（74 tests = 61 passed + 12 skipped + 1 flaky。12 skipped は `eccube_plugin_signup_login.spec.ts`、1 flaky は既知の #502）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **テスト**
  - サイト一覧のテスト内容を更新し、組織配下のサイト一覧が正しく表示されることを検証するようにしました。
  - サイト一覧の表示元に関するテスト説明を最新の仕様に合わせて更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->