### PR TITLE
chore: Dependabot の依存更新を group 化

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,68 +25,76 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
-    # 公式 actions/* と azure/* を種類ごとに 1 PR に集約
-    # major は breaking change の可能性があるため個別 PR を維持
+    # minor/patch と major の 2 PR に集約する。
+    # patterns を "*" にしているのは、公式 actions/* 以外のサードパーティ
+    # （anthropics/* 1password/* pnpm/* peaceiris/* nanasess/* 等）を
+    # 取りこぼさないため。ベンダー別に patterns を切ると、列挙から漏れた
+    # action がそのまま個別 PR として滞留する。
     groups:
-      actions-minor-patch:
+      github-actions-minor:
         patterns:
-          - "actions/*"
+          - "*"
         update-types:
           - "minor"
           - "patch"
-      azure-minor-patch:
+      github-actions-major:
         patterns:
-          - "azure/*"
+          - "*"
         update-types:
-          - "minor"
-          - "patch"
+          - "major"
 
   # .NET NuGet パッケージの自動更新
   - package-ecosystem: "nuget"
     directories:
       - "/"
       - "/IdentityProvider"
-      - "/MockOpenIdProvider"
-      - "/IdpUtilities"
       - "/IdentityProvider.Test"
-      - "/MockOpenIdProvider.Test"
-      - "/IdpUtilities.Test"
+      - "/E2ETests.Selenium"
     schedule:
       interval: "weekly"
       day: "tuesday"
       time: "09:00"
       timezone: "Asia/Tokyo"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     labels:
       - "dependencies"
       - "dotnet"
     commit-message:
       prefix: "chore"
       include: "scope"
-    # セキュリティアップデートは即座に作成
     allow:
       - dependency-type: "all"
     # GitHub Packages の認証設定を参照
     registries:
       - github-packages
-    # .NET 10 へのメジャーバージョンアップグレードを無視
-    # プロジェクトが net9.0 をターゲットにしているため、ランタイムに含まれる
-    # パッケージは同じメジャーバージョンを維持する
+    # group を指定すると複数 directories の同一パッケージ更新が 1 PR に集約される
+    groups:
+      nuget-minor:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      nuget-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    # .NET ランタイム同梱パッケージの major 更新は、.NET 本体のメジャー移行と
+    # 同時に IdpUtilities → MockIdP → EcAuth の順で進める必要があるため止める。
+    # 手順は EcAuthDocs の claude-repository-guide.md
+    # 「.NET メジャーバージョン移行の順序（標準手順）」を参照。
+    # patch/minor（10.0.9 → 10.0.10 等）は通す。
     ignore:
       - dependency-name: "System.Text.Json"
-        versions: [">= 10.0.0"]
+        update-types: ["version-update:semver-major"]
       - dependency-name: "Microsoft.EntityFrameworkCore*"
-        versions: [">= 10.0.0"]
+        update-types: ["version-update:semver-major"]
       - dependency-name: "Microsoft.AspNetCore*"
-        versions: [">= 10.0.0"]
+        update-types: ["version-update:semver-major"]
       - dependency-name: "Microsoft.Extensions*"
-        versions: [">= 10.0.0"]
+        update-types: ["version-update:semver-major"]
       - dependency-name: "dotnet-ef"
-        versions: [">= 10.0.0"]
-      # Swashbuckle 10.x は Microsoft.OpenApi 2.x を要求するが、
-      # Microsoft.AspNetCore.OpenApi 9.x（.NET 9）は Microsoft.OpenApi 1.x に依存するため競合する。
-      # .NET 10 移行時にまとめて対応する（ref: PR #298）
-      - dependency-name: "Swashbuckle.AspNetCore"
         update-types: ["version-update:semver-major"]
 
   # E2ETests の npm パッケージの自動更新
@@ -108,3 +116,15 @@ updates:
     # 開発依存関係も含める
     allow:
       - dependency-type: "all"
+    groups:
+      npm-minor:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      npm-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"


### PR DESCRIPTION
## 背景

EcAuth 系リポジトリ全体で Dependabot PR が **52 件**滞留しており、うちこのリポジトリが **12 件**。原因は group 設定の不足。

既存 group はベンダー別（`actions/*` / `azure/*`）かつ minor/patch 限定だったため、以下が取りこぼされていた。

- **サードパーティ actions** — `anthropics/*` `1password/*` `pnpm/*` `peaceiris/*` `nanasess/*` はどの group にも属さず個別 PR
- **major 更新** — #465 (setup-dotnet 5→6) / #466 (setup-node 6→7) は group 対象外で個別 PR
- **nuget / npm** — group が無く全て個別 PR（#454 #455 #475 #483 #508 等）

## 変更内容

### 1. group を minor/patch と major の 2 本に集約

全エコシステム（github-actions / nuget / npm）で `patterns: ["*"]` を使い、必ずどちらかの group に入るようにした。ベンダー別に patterns を切ると、列挙から漏れた依存がそのまま滞留するため。

group 指定により、複数 `directories` の同一パッケージ更新も 1 PR にまとまる。

### 2. nuget の `directories` を実態に合わせて修正

MockIdP / IdpUtilities が別リポジトリに分離された後も、存在しないディレクトリ指定が残っていた。

| | ディレクトリ |
|---|---|
| 削除（実在しない） | `/MockOpenIdProvider` `/IdpUtilities` `/MockOpenIdProvider.Test` `/IdpUtilities.Test` |
| 追加（実在するが指定漏れ） | `/E2ETests.Selenium` |

### 3. `ignore` を major-only に修正（重要）

`versions: [">= 10.0.0"]` は**バージョン範囲**を止める指定で、net10.0 移行済みの現在は **EF Core 等の 10.x 内 patch/minor 更新まで全てブロックしていた**。

> 証拠: IdpUtilities では `Microsoft.Extensions.Logging.Abstractions 10.0.9 → 10.0.10`（EcAuth/EcAuth.IdpUtilities#38）の PR が来ているが、同じパッケージ群を持つ EcAuth 側には来ていない。

`update-types: ["version-update:semver-major"]` に変更し、.NET 11 への major だけを止める形にした（移行は CLAUDE.md「.NET メジャーバージョン移行の順序（標準手順）」に従う）。

### 4. `Swashbuckle.AspNetCore` の major ignore を削除

.NET 9 の `Microsoft.OpenApi` 1.x 競合（#298）が理由だったが、.NET 10 移行で解消済み。現在 10.2.3 が入っている。

## 検証

- [x] YAML パース（`yaml.safe_load`）
- [x] 指定した全 `directories` に対応する manifest が実在することを確認
- [x] 行末空白なし / LF 改行
- [ ] **Dependabot 設定の妥当性はサーバー側でしか検証できない**（未検証）。マージ後に Insights → Dependency graph → Dependabot でエラーが出ていないことを確認する

## マージ後の作業

既存のオープン PR は group 再編で置き換わるが、Dependabot が自動クローズしない場合がある。残存分を手動クローズし、`@dependabot recreate` または次回スケジュール実行（月=actions / 火=nuget / 水=npm、09:00 JST）で group PR を作らせる。

## 関連

EcAuth 系 10 リポジトリ横断で同じテンプレートを適用する PR の 1 本。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 依存関係の自動更新設定を整理しました。
  * NuGet、npm、GitHub Actions の更新を、メジャー更新とマイナー／パッチ更新に分けて管理します。
  * NuGet の更新対象と自動更新数を見直し、不要な主要 .NET パッケージのメジャー更新を除外しました。
  * これにより、依存関係の更新をより安定して管理できるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->