### PR TITLE
fix: B2B パスキー認証の assertion 検証に WebAuthn §7.2 Step 5 / Step 6 を実装

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ cd E2ETests && pnpm install && pnpm exec playwright test
 | `/userinfo` | `auth_header_parse` / `access_token_validate` / `user_lookup` |
 | `/api/external-userinfo` | `auth_header_parse` / `access_token_validate` / `external_userinfo_fetch` |
 | `register/verify` | `client_authenticate` / `service_call`（内訳: `challenge_lookup` / `fido2_make_credential` / `credential_persist` / `challenge_consume`） |
-| `authenticate/verify` | `client_authenticate` / `service_call`（内訳: `challenge_lookup` / `credential_lookup` / `fido2_make_assertion` / `signcount_persist` / `challenge_consume`） |
+| `authenticate/verify` | `client_authenticate` / `service_call`（内訳: `challenge_lookup` / `session_client_verify` / `credential_lookup` / `credential_organization_verify` / `fido2_make_assertion` / `signcount_persist` / `challenge_consume`） |
 | `/api/signup/request` | `validate` / `persist` / `send_email` |
 | `/api/signup/confirm` | `token_lookup` / `confirm`（内訳: `client_secret_protect`） |
 | `/api/signup/status` | `status_lookup` |
@@ -151,6 +151,43 @@ AppServiceConsoleLogs
 - 切り分けの原則: 起動・マイグレーション・シーダー等 `app.Run()` 前の診断は **`AppServiceConsoleLogs`**、
   リクエスト処理時（host start 後）の診断は **`traces` / `AppTraces`**。「App Insights に出ない」と感じたら、
   まず参照テーブルの取り違えを疑う（起動前ログを App Insights に押し込む `ForceFlush` 等の小細工は不要・無効）。
+
+### B2B パスキー authenticate/verify の検証レイヤ（WebAuthn §7.2）
+
+`B2BPasskeyService.VerifyAuthenticationAsync` は assertion 検証の前に 5 段の検証を行う。
+**どれも冗長ではない**（EcAuth#516 でこの多くが欠けていたことが判明した）。順序と目的:
+
+| # | 検証 | 失敗理由ログ | 何を守るか |
+|---|------|--------------|-----------|
+| 1 | セッションとリクエスト元 Client の突合（`client.Id == challenge.ClientId`） | `session_client_mismatch` | 別 Client が発行したセッションを自分の `client_id` で持ち込み、認可コードを自分宛に発行させる経路 |
+| 2 | §7.2 Step 5: `challenge.AllowedCredentialIds` との照合 | `credential_not_allowed` | このセッションで発行していないクレデンシャルでの認証 |
+| 3 | §7.2 Step 6: `challenge.Subject` との照合 | `credential_subject_mismatch` | b2b_subject 指定経路で、確定済みユーザー以外のクレデンシャルでの認証。登録側の `ExpectedSubject` 突合と対称 |
+| 4 | Organization スコープ（`credential.B2BSubject` が Client の Organization の `B2BUser` に属するか） | `credential_organization_mismatch` | **同一 rp_id を共有する別 Organization 間の越境**。同一ドメインで本番サイトとサンドボックスサイトの両方を申し込むと `allowed_rp_ids` が同値になりうるため、rpIdHash 検証では防げない |
+| 5 | `isUserHandleOwner` コールバック（Fido2.NetLib 経由） | — | Step 6 の後者（ユーザー未確定経路）の要件 |
+
+判断の根拠:
+
+- **Organization 検証（#4）は #2 / #3 では代替できない。** `CreateAuthenticationOptionsAsync` の
+  b2b_subject 指定経路は、リクエスト由来の `b2b_subject` をそのまま使う（この API は無認証で呼べる）。
+  Organization で絞らなければ他 Organization のユーザーの b2b_subject を指定できてしまい、
+  その場合 #2 / #3 は「発行した一覧」「確定した subject」と整合するので通過する。
+  → **options 側でも Organization で絞る**ことと、verify 側の #4 の両方が必要。
+  この不変条件は `AuthorizeByRegistrationTokenAsync` が登録トークンに対して既に課しているものと同じ。
+- **`rpIdHash` 検証では足りない。** Fido2.NetLib の origin / rpIdHash 検証は
+  `ServerDomain = challenge.RpId` に基づくため、rp_id が違うクレデンシャルは落ちる。
+  逆に**同一 rp_id なら Organization / Client をまたいでも通る**。
+- **#2 を自前で実装しているのは Fido2.NetLib と二重防御にするため。** `OriginalOptions.AllowCredentials`
+  も発行時の値へ復元してライブラリ側の照合にも掛けているが、失敗理由を構造化ログに出し、
+  ユニットテスト（`IFido2` はモック）で守れる形にするために自前チェックを残す。
+- **`webauthn_challenge.allowed_credential_ids` の 3 状態**（NULL / `"[]"` / 要素あり）は意図的。
+  NULL は「発行時に記録していない」（登録チャレンジ、カラム追加前の既存行）、`"[]"` は
+  「allowCredentials を空で発行した」（discoverable credential フロー）。どちらも §7.2 Step 5 の
+  「空でない場合」を満たさないため照合しないが、事後に理由を切り分けられるよう区別して保存する。
+- **Client 境界（同一 Organization 内の Client 間）は #2 が担う。** ただし b2b_subject 未指定経路の
+  allowCredentials は現在 Organization 単位で発行しているため、この経路では実質 Organization
+  境界と同じになる。`CreateAuthenticationOptionsAsync` のコメントにある移行
+  （rk フラグ保存 → `ResidentKey.Required` 化 → 既存ユーザー再登録 → 空 allowCredentials へ切替）を
+  終えた時点で、#2 が自動的に Client 境界の強制になる。
 
 ### E2E テストの実装上の要点
 

--- a/IdentityProvider.Test/Services/B2BPasskeyServiceTests.cs
+++ b/IdentityProvider.Test/Services/B2BPasskeyServiceTests.cs
@@ -1604,6 +1604,42 @@ namespace IdentityProvider.Test.Services
             Assert.Empty(capturedChallengeRequest.AllowedCredentialIds!);
         }
 
+        /// <summary>
+        /// Organization 未設定の Client は Organization スコープを判定できないため、
+        /// options 発行前に拒否する（登録側 / verify 側と同じ扱い）。
+        /// </summary>
+        [Fact]
+        public async Task CreateAuthenticationOptionsAsync_ClientWithoutOrganization_ShouldThrowInvalidOperationException()
+        {
+            // Arrange
+            _context.Clients.Add(new Client
+            {
+                Id = 3,
+                ClientId = "orphan-client-id",
+                ClientSecret = "orphan-secret",
+                AppName = "Organization 未設定クライアント",
+                OrganizationId = null,
+                AllowedRpIds = new List<string> { "shop.example.com" }
+            });
+            await _context.SaveChangesAsync();
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                _service.CreateAuthenticationOptionsAsync(
+                    new IB2BPasskeyService.AuthenticationOptionsRequest
+                    {
+                        ClientId = "orphan-client-id",
+                        RpId = "shop.example.com",
+                        B2BSubject = null
+                    }));
+            Assert.Contains("no associated Organization", exception.Message);
+
+            // チャレンジは発行されないこと
+            _mockChallengeService.Verify(
+                x => x.GenerateChallengeAsync(It.IsAny<IWebAuthnChallengeService.ChallengeRequest>()),
+                Times.Never);
+        }
+
         #endregion
 
         #region VerifyAuthenticationAsync Tests

--- a/IdentityProvider.Test/Services/B2BPasskeyServiceTests.cs
+++ b/IdentityProvider.Test/Services/B2BPasskeyServiceTests.cs
@@ -1497,6 +1497,113 @@ namespace IdentityProvider.Test.Services
             Assert.Equal(expectedLowercaseRpId, capturedChallengeRequest.RpId);
         }
 
+        /// <summary>
+        /// 発行した allowCredentials がチャレンジへ束縛されること（WebAuthn §7.2 Step 5 を
+        /// verify 側で実施するための前提）。
+        /// </summary>
+        [Fact]
+        public async Task CreateAuthenticationOptionsAsync_ShouldBindIssuedAllowCredentialsToChallenge()
+        {
+            // Arrange
+            var credentialId1 = Encoding.UTF8.GetBytes("bind-credential-1");
+            var credentialId2 = Encoding.UTF8.GetBytes("bind-credential-2");
+            _context.B2BPasskeyCredentials.AddRange(
+                NewCredential(TestB2BSubject, credentialId1),
+                NewCredential(TestB2BSubject, credentialId2));
+            await _context.SaveChangesAsync();
+
+            IWebAuthnChallengeService.ChallengeRequest? capturedChallengeRequest = null;
+            _mockChallengeService.Setup(x => x.GenerateChallengeAsync(It.IsAny<IWebAuthnChallengeService.ChallengeRequest>()))
+                .Callback<IWebAuthnChallengeService.ChallengeRequest>(req => capturedChallengeRequest = req)
+                .ReturnsAsync(new IWebAuthnChallengeService.ChallengeResult
+                {
+                    SessionId = "bind-session",
+                    Challenge = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes("auth-challenge")),
+                    ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5)
+                });
+
+            // Act
+            var result = await _service.CreateAuthenticationOptionsAsync(
+                new IB2BPasskeyService.AuthenticationOptionsRequest
+                {
+                    ClientId = "test-client-id",
+                    RpId = "shop.example.com",
+                    B2BSubject = TestB2BSubject
+                });
+
+            // Assert: 束縛された一覧が、実際に発行した allowCredentials と一致すること
+            Assert.NotNull(capturedChallengeRequest);
+            Assert.NotNull(capturedChallengeRequest.AllowedCredentialIds);
+
+            var issued = result.Options.AllowCredentials!
+                .Select(c => WebEncoders.Base64UrlEncode(c.Id))
+                .ToList();
+            Assert.Equal(issued, capturedChallengeRequest.AllowedCredentialIds);
+            Assert.Equal(
+                new[]
+                {
+                    WebEncoders.Base64UrlEncode(credentialId1),
+                    WebEncoders.Base64UrlEncode(credentialId2)
+                }.Order(),
+                capturedChallengeRequest.AllowedCredentialIds.Order());
+        }
+
+        /// <summary>
+        /// b2b_subject 指定経路は Client の Organization に属するユーザーのクレデンシャルに
+        /// 限定する。この API は無認証で呼べるため、絞らないと他 Organization のユーザーの
+        /// クレデンシャル ID 一覧が本人確認前に漏れる。
+        /// </summary>
+        [Fact]
+        public async Task CreateAuthenticationOptionsAsync_SubjectFromAnotherOrganization_ShouldReturnEmptyAllowCredentials()
+        {
+            // Arrange: 別 Organization のユーザーとそのクレデンシャル
+            var otherOrganization = new Organization
+            {
+                Id = 2,
+                Code = "other-org",
+                Name = "別組織",
+                TenantName = "test-tenant"
+            };
+            _context.Organizations.Add(otherOrganization);
+
+            _context.B2BUsers.Add(new B2BUser
+            {
+                Id = 2,
+                Subject = TestB2BSubject2,
+                ExternalId = ExternalIdHasher.Hash("admin@other.example.com"),
+                UserType = "admin",
+                OrganizationId = 2,
+                Organization = otherOrganization
+            });
+            _context.B2BPasskeyCredentials.Add(
+                NewCredential(TestB2BSubject2, Encoding.UTF8.GetBytes("other-org-credential")));
+            await _context.SaveChangesAsync();
+
+            IWebAuthnChallengeService.ChallengeRequest? capturedChallengeRequest = null;
+            _mockChallengeService.Setup(x => x.GenerateChallengeAsync(It.IsAny<IWebAuthnChallengeService.ChallengeRequest>()))
+                .Callback<IWebAuthnChallengeService.ChallengeRequest>(req => capturedChallengeRequest = req)
+                .ReturnsAsync(new IWebAuthnChallengeService.ChallengeResult
+                {
+                    SessionId = "cross-org-options-session",
+                    Challenge = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes("auth-challenge")),
+                    ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5)
+                });
+
+            // Act: Organization 1 の Client で、Organization 2 のユーザーの b2b_subject を指定
+            var result = await _service.CreateAuthenticationOptionsAsync(
+                new IB2BPasskeyService.AuthenticationOptionsRequest
+                {
+                    ClientId = "test-client-id",
+                    RpId = "shop.example.com",
+                    B2BSubject = TestB2BSubject2
+                });
+
+            // Assert: 他 Organization のクレデンシャルは一切返さない
+            Assert.Empty(result.Options.AllowCredentials!);
+            Assert.NotNull(capturedChallengeRequest);
+            Assert.Empty(capturedChallengeRequest.AllowedCredentialIds!);
+        }
+
         #endregion
 
         #region VerifyAuthenticationAsync Tests
@@ -1807,6 +1914,334 @@ namespace IdentityProvider.Test.Services
             // SignCount異常（クローン攻撃の可能性）としてエラーが返されること
             Assert.Contains("Signature counter", result.ErrorMessage);
         }
+
+        #endregion
+
+        #region WebAuthn §7.2 Step 5 / Step 6 検証 Tests
+
+        /// <summary>
+        /// WebAuthn Level 3 §7.2 Step 5: allowCredentials が空でない場合、assertion の
+        /// credential.id がその一覧に含まれることを検証する。
+        /// challenge.Subject を null にして Step 6 と Organization 検証では捕まらない状況を作り、
+        /// Step 5 単独の効果を確認する。
+        /// </summary>
+        [Fact]
+        public async Task VerifyAuthenticationAsync_CredentialNotInIssuedAllowCredentials_ShouldReturnFailure()
+        {
+            // Arrange: 同一ユーザーの 2 本のクレデンシャル。発行した allowCredentials には
+            // 1 本目しか入っていないが、assertion は 2 本目で返ってくる。
+            var issuedCredentialId = Encoding.UTF8.GetBytes("issued-credential");
+            var notIssuedCredentialId = Encoding.UTF8.GetBytes("not-issued-credential");
+
+            _context.B2BPasskeyCredentials.AddRange(
+                NewCredential(TestB2BSubject, issuedCredentialId),
+                NewCredential(TestB2BSubject, notIssuedCredentialId));
+            await _context.SaveChangesAsync();
+
+            var challenge = NewAuthenticationChallenge("step5-session", subject: null);
+            challenge.AllowedCredentialIds = new List<string>
+            {
+                WebEncoders.Base64UrlEncode(issuedCredentialId)
+            };
+            SetupChallenge(challenge);
+            SetupSuccessfulAssertion(challenge.SessionId, signCount: 1);
+
+            // Act
+            var result = await _service.VerifyAuthenticationAsync(
+                NewVerifyRequest(challenge.SessionId, "test-client-id", notIssuedCredentialId));
+
+            // Assert
+            Assert.False(result.Success);
+            Assert.Contains("not allowed", result.ErrorMessage);
+        }
+
+        /// <summary>
+        /// 発行した allowCredentials に含まれるクレデンシャルは Step 5 を通過する。
+        /// </summary>
+        [Fact]
+        public async Task VerifyAuthenticationAsync_CredentialInIssuedAllowCredentials_ShouldSucceed()
+        {
+            // Arrange
+            var credentialId = Encoding.UTF8.GetBytes("allowed-credential");
+            _context.B2BPasskeyCredentials.Add(NewCredential(TestB2BSubject, credentialId));
+            await _context.SaveChangesAsync();
+
+            var challenge = NewAuthenticationChallenge("step5-ok-session", subject: null);
+            challenge.AllowedCredentialIds = new List<string> { WebEncoders.Base64UrlEncode(credentialId) };
+            SetupChallenge(challenge);
+            SetupSuccessfulAssertion(challenge.SessionId, signCount: 1);
+
+            // Act
+            var result = await _service.VerifyAuthenticationAsync(
+                NewVerifyRequest(challenge.SessionId, "test-client-id", credentialId));
+
+            // Assert
+            Assert.True(result.Success);
+            Assert.Equal(TestB2BSubject, result.B2BSubject);
+        }
+
+        /// <summary>
+        /// allowCredentials を空で発行したセッション（discoverable credential フロー）では
+        /// Step 5 の「空でない場合」という前提を満たさないため照合しない。
+        /// </summary>
+        [Fact]
+        public async Task VerifyAuthenticationAsync_EmptyIssuedAllowCredentials_ShouldSkipStep5()
+        {
+            // Arrange
+            var credentialId = Encoding.UTF8.GetBytes("discoverable-only-credential");
+            _context.B2BPasskeyCredentials.Add(NewCredential(TestB2BSubject, credentialId));
+            await _context.SaveChangesAsync();
+
+            var challenge = NewAuthenticationChallenge("step5-empty-session", subject: null);
+            challenge.AllowedCredentialIds = new List<string>();
+            SetupChallenge(challenge);
+            SetupSuccessfulAssertion(challenge.SessionId, signCount: 1);
+
+            // Act
+            var result = await _service.VerifyAuthenticationAsync(
+                NewVerifyRequest(challenge.SessionId, "test-client-id", credentialId));
+
+            // Assert
+            Assert.True(result.Success);
+            Assert.Equal(TestB2BSubject, result.B2BSubject);
+        }
+
+        /// <summary>
+        /// allowed_credential_ids カラム追加前に発行された既存セッション（NULL）では
+        /// Step 5 を適用できないため照合しない（マイグレーション直後の 5 分間の互換性）。
+        /// </summary>
+        [Fact]
+        public async Task VerifyAuthenticationAsync_AllowedCredentialIdsNotRecorded_ShouldSkipStep5()
+        {
+            // Arrange
+            var credentialId = Encoding.UTF8.GetBytes("legacy-session-credential");
+            _context.B2BPasskeyCredentials.Add(NewCredential(TestB2BSubject, credentialId));
+            await _context.SaveChangesAsync();
+
+            var challenge = NewAuthenticationChallenge("legacy-session", subject: null);
+            Assert.Null(challenge.AllowedCredentialIdsJson); // 未記録であることを明示
+            SetupChallenge(challenge);
+            SetupSuccessfulAssertion(challenge.SessionId, signCount: 1);
+
+            // Act
+            var result = await _service.VerifyAuthenticationAsync(
+                NewVerifyRequest(challenge.SessionId, "test-client-id", credentialId));
+
+            // Assert
+            Assert.True(result.Success);
+        }
+
+        /// <summary>
+        /// WebAuthn Level 3 §7.2 Step 6: options 発行時にユーザーが確定していた場合
+        /// （b2b_subject 指定経路 = challenge.Subject が非 null）、そのユーザーの
+        /// クレデンシャルであることを検証する。登録側の ExpectedSubject 突合と対称。
+        /// </summary>
+        [Fact]
+        public async Task VerifyAuthenticationAsync_CredentialOfAnotherSubject_ShouldReturnFailure()
+        {
+            // Arrange: 同一 Organization の別ユーザーのクレデンシャル
+            var otherUser = new B2BUser
+            {
+                Id = 2,
+                Subject = TestB2BSubject2,
+                ExternalId = ExternalIdHasher.Hash("staff@example.com"),
+                UserType = "staff",
+                OrganizationId = 1,
+                Organization = _organization
+            };
+            _context.B2BUsers.Add(otherUser);
+
+            var credentialId = Encoding.UTF8.GetBytes("other-subject-credential");
+            _context.B2BPasskeyCredentials.Add(NewCredential(TestB2BSubject2, credentialId));
+            await _context.SaveChangesAsync();
+
+            // challenge.Subject は TestB2BSubject（別人）。Step 5 は未記録にして Step 6 単独の効果を見る。
+            var challenge = NewAuthenticationChallenge("step6-session", subject: TestB2BSubject);
+            SetupChallenge(challenge);
+            SetupSuccessfulAssertion(challenge.SessionId, signCount: 1);
+
+            // Act
+            var result = await _service.VerifyAuthenticationAsync(
+                NewVerifyRequest(challenge.SessionId, "test-client-id", credentialId));
+
+            // Assert
+            Assert.False(result.Success);
+            Assert.Contains("session subject", result.ErrorMessage);
+        }
+
+        /// <summary>
+        /// 同一 rp_id を共有する別 Organization のクレデンシャルでは認証を通さない。
+        ///
+        /// 同一ドメインで本番サイトとサンドボックスサイトの両方を申し込んだ場合、両者は
+        /// 別 Organization だが allowed_rp_ids が同じ値になりうる。rpIdHash の検証は
+        /// challenge.RpId に基づくため assertion 自体は成立してしまい、Organization
+        /// 検証がなければ本番 / サンドボックスの分離が破れる。
+        /// </summary>
+        [Fact]
+        public async Task VerifyAuthenticationAsync_CredentialFromAnotherOrganization_ShouldReturnFailure()
+        {
+            // Arrange: 同一テナント内の別 Organization（サンドボックス相当）
+            var sandboxOrganization = new Organization
+            {
+                Id = 2,
+                Code = "test-org-sandbox",
+                Name = "テスト組織（サンドボックス）",
+                TenantName = "test-tenant"
+            };
+            _context.Organizations.Add(sandboxOrganization);
+
+            var sandboxUser = new B2BUser
+            {
+                Id = 2,
+                Subject = TestB2BSubject2,
+                ExternalId = ExternalIdHasher.Hash("admin@example.com"),
+                UserType = "admin",
+                OrganizationId = 2,
+                Organization = sandboxOrganization
+            };
+            _context.B2BUsers.Add(sandboxUser);
+
+            var credentialId = Encoding.UTF8.GetBytes("sandbox-credential");
+            _context.B2BPasskeyCredentials.Add(NewCredential(TestB2BSubject2, credentialId));
+            await _context.SaveChangesAsync();
+
+            // Step 5 / Step 6 では捕まらない状況（未記録 + ユーザー未確定）で Organization 検証を見る
+            var challenge = NewAuthenticationChallenge("cross-org-session", subject: null);
+            SetupChallenge(challenge);
+            SetupSuccessfulAssertion(challenge.SessionId, signCount: 1);
+
+            // Act: 本番 Client（Organization 1）のセッションでサンドボックスのクレデンシャルを提示
+            var result = await _service.VerifyAuthenticationAsync(
+                NewVerifyRequest(challenge.SessionId, "test-client-id", credentialId));
+
+            // Assert
+            Assert.False(result.Success);
+            Assert.Contains("organization", result.ErrorMessage);
+        }
+
+        /// <summary>
+        /// 別 Client が発行したセッションを自分の client_id で verify に持ち込めない。
+        /// コントローラーは request.ClientId で Client を認証するが、セッションが
+        /// その Client のものであることは検証していないため、サービス側で突合する。
+        /// </summary>
+        [Fact]
+        public async Task VerifyAuthenticationAsync_SessionIssuedForAnotherClient_ShouldReturnFailure()
+        {
+            // Arrange: 同一 Organization 内の別 Client が発行したセッション
+            var otherClient = new Client
+            {
+                Id = 2,
+                ClientId = "other-client-id",
+                ClientSecret = "other-secret",
+                AppName = "別クライアント",
+                OrganizationId = 1,
+                AllowedRpIds = new List<string> { "shop.example.com" }
+            };
+            _context.Clients.Add(otherClient);
+
+            var credentialId = Encoding.UTF8.GetBytes("cross-client-credential");
+            _context.B2BPasskeyCredentials.Add(NewCredential(TestB2BSubject, credentialId));
+            await _context.SaveChangesAsync();
+
+            var challenge = NewAuthenticationChallenge("cross-client-session", subject: null, clientId: 2);
+            SetupChallenge(challenge);
+            SetupSuccessfulAssertion(challenge.SessionId, signCount: 1);
+
+            // Act: Client 2 のセッションを Client 1 の client_id で verify する
+            var result = await _service.VerifyAuthenticationAsync(
+                NewVerifyRequest(challenge.SessionId, "test-client-id", credentialId));
+
+            // Assert
+            Assert.False(result.Success);
+            Assert.Contains("does not belong to this client", result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task VerifyAuthenticationAsync_UnknownClient_ShouldReturnFailure()
+        {
+            // Arrange
+            var credentialId = Encoding.UTF8.GetBytes("unknown-client-credential");
+            _context.B2BPasskeyCredentials.Add(NewCredential(TestB2BSubject, credentialId));
+            await _context.SaveChangesAsync();
+
+            var challenge = NewAuthenticationChallenge("unknown-client-session", subject: null);
+            SetupChallenge(challenge);
+            SetupSuccessfulAssertion(challenge.SessionId, signCount: 1);
+
+            // Act
+            var result = await _service.VerifyAuthenticationAsync(
+                NewVerifyRequest(challenge.SessionId, "unknown-client-id", credentialId));
+
+            // Assert
+            Assert.False(result.Success);
+            Assert.Contains("Client not found", result.ErrorMessage);
+        }
+
+        #endregion
+
+        #region §7.2 検証テスト用ヘルパー
+
+        private B2BPasskeyCredential NewCredential(string b2bSubject, byte[] credentialId) =>
+            new B2BPasskeyCredential
+            {
+                B2BSubject = b2bSubject,
+                CredentialId = credentialId,
+                PublicKey = Encoding.UTF8.GetBytes("public-key"),
+                SignCount = 0,
+                AaGuid = Guid.NewGuid()
+            };
+
+        private WebAuthnChallenge NewAuthenticationChallenge(string sessionId, string? subject, int clientId = 1) =>
+            new WebAuthnChallenge
+            {
+                SessionId = sessionId,
+                Challenge = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes("auth-challenge")),
+                Type = "authentication",
+                UserType = "b2b",
+                Subject = subject,
+                RpId = "shop.example.com",
+                ClientId = clientId,
+                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5)
+            };
+
+        private void SetupChallenge(WebAuthnChallenge challenge) =>
+            _mockChallengeService.Setup(x => x.GetChallengeBySessionIdAsync(challenge.SessionId))
+                .ReturnsAsync(challenge);
+
+        /// <summary>
+        /// Fido2 の assertion 検証自体は成功する状態にする。これにより、テストが失敗した場合の
+        /// 原因が §7.2 の追加検証であることを切り分けられる。
+        /// </summary>
+        private void SetupSuccessfulAssertion(string sessionId, uint signCount)
+        {
+            _mockFido2.Setup(x => x.MakeAssertionAsync(
+                It.IsAny<MakeAssertionParams>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new VerifyAssertionResult { SignCount = signCount });
+
+            _mockChallengeService.Setup(x => x.ConsumeChallengeAsync(sessionId))
+                .ReturnsAsync(true);
+        }
+
+        private static IB2BPasskeyService.AuthenticationVerifyRequest NewVerifyRequest(
+            string sessionId, string clientId, byte[] credentialId) =>
+            new IB2BPasskeyService.AuthenticationVerifyRequest
+            {
+                SessionId = sessionId,
+                ClientId = clientId,
+                AssertionResponse = new AuthenticatorAssertionRawResponse
+                {
+                    Id = WebEncoders.Base64UrlEncode(credentialId),
+                    RawId = credentialId,
+                    Type = PublicKeyCredentialType.PublicKey,
+                    Response = new AuthenticatorAssertionRawResponse.AssertionResponse
+                    {
+                        AuthenticatorData = Encoding.UTF8.GetBytes("auth-data"),
+                        ClientDataJson = Encoding.UTF8.GetBytes("client-data"),
+                        Signature = Encoding.UTF8.GetBytes("signature")
+                    }
+                }
+            };
 
         #endregion
 

--- a/IdentityProvider.Test/Services/WebAuthnChallengeServiceTests.cs
+++ b/IdentityProvider.Test/Services/WebAuthnChallengeServiceTests.cs
@@ -81,6 +81,67 @@ namespace IdentityProvider.Test.Services
             Assert.Equal(request.Subject, saved.Subject);
             Assert.Equal(request.RpId, saved.RpId);
             Assert.Equal(request.ClientId, saved.ClientId);
+            // 登録チャレンジは WebAuthn §7.2 Step 5 の対象外なので未記録（NULL）
+            Assert.Null(saved.AllowedCredentialIdsJson);
+            Assert.Null(saved.AllowedCredentialIds);
+        }
+
+        /// <summary>
+        /// 発行した allowCredentials をチャレンジへ束縛する（WebAuthn §7.2 Step 5 の照合用）。
+        /// </summary>
+        [Fact]
+        public async Task GenerateChallengeAsync_WithAllowedCredentialIds_ShouldPersistThem()
+        {
+            // Arrange
+            var allowedCredentialIds = new List<string> { "Y3JlZGVudGlhbC0x", "Y3JlZGVudGlhbC0y" };
+            var request = new IWebAuthnChallengeService.ChallengeRequest
+            {
+                Type = "authentication",
+                UserType = "b2b",
+                RpId = "shop.example.com",
+                ClientId = 1,
+                AllowedCredentialIds = allowedCredentialIds
+            };
+
+            // Act
+            var result = await _service.GenerateChallengeAsync(request);
+
+            // Assert
+            var saved = await _context.WebAuthnChallenges
+                .IgnoreQueryFilters()
+                .FirstOrDefaultAsync(c => c.SessionId == result.SessionId);
+            Assert.NotNull(saved);
+            Assert.Equal(allowedCredentialIds, saved.AllowedCredentialIds);
+        }
+
+        /// <summary>
+        /// allowCredentials が空のまま発行した場合も「記録済みだが空」として保存する。
+        /// NULL（未記録）と区別できるようにしておくことで、Step 5 が適用されない理由が
+        /// 「発行時に記録していない」のか「空で発行した」のかを事後に切り分けられる。
+        /// </summary>
+        [Fact]
+        public async Task GenerateChallengeAsync_WithEmptyAllowedCredentialIds_ShouldPersistEmptyList()
+        {
+            // Arrange
+            var request = new IWebAuthnChallengeService.ChallengeRequest
+            {
+                Type = "authentication",
+                UserType = "b2b",
+                RpId = "shop.example.com",
+                ClientId = 1,
+                AllowedCredentialIds = new List<string>()
+            };
+
+            // Act
+            var result = await _service.GenerateChallengeAsync(request);
+
+            // Assert
+            var saved = await _context.WebAuthnChallenges
+                .IgnoreQueryFilters()
+                .FirstOrDefaultAsync(c => c.SessionId == result.SessionId);
+            Assert.NotNull(saved);
+            Assert.NotNull(saved.AllowedCredentialIdsJson);
+            Assert.Empty(saved.AllowedCredentialIds!);
         }
 
         [Fact]

--- a/IdentityProvider/Migrations/20260808122654_AddWebAuthnChallengeAllowedCredentialIds.Designer.cs
+++ b/IdentityProvider/Migrations/20260808122654_AddWebAuthnChallengeAllowedCredentialIds.Designer.cs
@@ -4,6 +4,7 @@ using IdentityProvider.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace IdentityProvider.Migrations
 {
     [DbContext(typeof(EcAuthDbContext))]
-    partial class EcAuthDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260808122654_AddWebAuthnChallengeAllowedCredentialIds")]
+    partial class AddWebAuthnChallengeAllowedCredentialIds
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/IdentityProvider/Migrations/20260808122654_AddWebAuthnChallengeAllowedCredentialIds.cs
+++ b/IdentityProvider/Migrations/20260808122654_AddWebAuthnChallengeAllowedCredentialIds.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace IdentityProvider.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddWebAuthnChallengeAllowedCredentialIds : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "allowed_credential_ids",
+                table: "webauthn_challenge",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "allowed_credential_ids",
+                table: "webauthn_challenge");
+        }
+    }
+}

--- a/IdentityProvider/Models/WebAuthnChallenge.cs
+++ b/IdentityProvider/Models/WebAuthnChallenge.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json;
 
 namespace IdentityProvider.Models
 {
@@ -42,6 +43,34 @@ namespace IdentityProvider.Models
         [Column("client_id")]
         [Required]
         public int ClientId { get; set; }
+
+        /// <summary>
+        /// このセッションで発行した allowCredentials の credential_id（Base64URL 形式）を JSON 配列で保持する。
+        /// WebAuthn Level 3 §7.2 Step 5「pkOptions.allowCredentials が空でない場合、credential.id が
+        /// その一覧のいずれかを指すことを検証する」を verify 時に実施するための束縛先。
+        ///
+        /// 値の意味を 3 状態で使い分ける:
+        /// - NULL: 発行時に記録していない（登録チャレンジ、およびこのカラム追加前の既存行）→ Step 5 は適用不可
+        /// - "[]": allowCredentials が空で発行された（discoverable credential フロー）→ Step 5 は「空でない場合」の
+        ///   条件を満たさないため適用しない
+        /// - 要素あり: verify 時に照合する
+        /// </summary>
+        [Column("allowed_credential_ids")]
+        public string? AllowedCredentialIdsJson { get; set; }
+
+        /// <summary>
+        /// <see cref="AllowedCredentialIdsJson"/> のリスト表現。未記録の場合は null。
+        /// </summary>
+        [NotMapped]
+        public IReadOnlyList<string>? AllowedCredentialIds
+        {
+            get => AllowedCredentialIdsJson == null
+                ? null
+                : JsonSerializer.Deserialize<List<string>>(AllowedCredentialIdsJson) ?? new List<string>();
+            set => AllowedCredentialIdsJson = value == null
+                ? null
+                : JsonSerializer.Serialize(value);
+        }
 
         [Column("expires_at")]
         [Required]

--- a/IdentityProvider/Services/B2BPasskeyService.cs
+++ b/IdentityProvider/Services/B2BPasskeyService.cs
@@ -540,6 +540,13 @@ namespace IdentityProvider.Services
             if (client == null)
                 throw new InvalidOperationException($"Client not found: {request.ClientId}");
 
+            // Organization 未設定の Client は Organization スコープを判定できないため拒否する。
+            // 登録側（CreateRegistrationOptionsAsync）と verify 側（VerifyAuthenticationAsync）は
+            // 既に拒否しており、ここで通しても後段で必ず落ちる。allowCredentials とチャレンジを
+            // 発行してから verify で落とすのではなく、options 発行前に明示的に弾く。
+            if (client.OrganizationId == null)
+                throw new InvalidOperationException($"Client has no associated Organization: {request.ClientId}");
+
             // RP ID検証（ドメイン名は大文字小文字を区別しない: RFC 4343）
             if (!client.AllowedRpIds.Contains(rpId, StringComparer.OrdinalIgnoreCase))
                 throw new InvalidOperationException($"RpId is not allowed for this client: {rpId}");

--- a/IdentityProvider/Services/B2BPasskeyService.cs
+++ b/IdentityProvider/Services/B2BPasskeyService.cs
@@ -559,9 +559,17 @@ namespace IdentityProvider.Services
             if (b2bSubject != null)
             {
                 // 特定ユーザーのクレデンシャルのみ（ユーザー確定済みの経路）
+                //
+                // b2b_subject はリクエスト由来の値で、この API は無認証で呼べる。Organization で
+                // 絞らないと、他 Organization のユーザーの b2b_subject を指定するだけでその
+                // クレデンシャル ID 一覧を取得でき（本人確認前の情報漏えい）、さらにその
+                // allowCredentials で認証を試行できてしまう。Client の Organization に属する
+                // ユーザーのクレデンシャルに限定する。
                 allowCredentials = await _context.B2BPasskeyCredentials
                     .IgnoreQueryFilters()
-                    .Where(c => c.B2BSubject == b2bSubject)
+                    .Where(c => c.B2BSubject == b2bSubject
+                        && c.B2BUser != null
+                        && c.B2BUser.OrganizationId == client.OrganizationId)
                     .Select(c => new PublicKeyCredentialDescriptor(
                         PublicKeyCredentialType.PublicKey,
                         c.CredentialId,
@@ -604,6 +612,9 @@ namespace IdentityProvider.Services
             }
 
             // チャレンジ生成
+            // 発行する allowCredentials をチャレンジへ束縛し、verify 側で WebAuthn §7.2 Step 5 を
+            // 実施できるようにする。descriptor から導出することで「発行した一覧」と
+            // 「照合する一覧」が構造的に一致する。
             var challengeResult = await _challengeService.GenerateChallengeAsync(
                 new IWebAuthnChallengeService.ChallengeRequest
                 {
@@ -611,7 +622,10 @@ namespace IdentityProvider.Services
                     UserType = "b2b",
                     Subject = b2bSubject,
                     RpId = rpId,
-                    ClientId = client.Id
+                    ClientId = client.Id,
+                    AllowedCredentialIds = allowCredentials
+                        .Select(c => WebEncoders.Base64UrlEncode(c.Id))
+                        .ToList()
                 });
 
             // 認証オプション生成
@@ -689,6 +703,61 @@ namespace IdentityProvider.Services
                     };
                 }
 
+                // セッションとリクエスト元 Client の束縛検証
+                //
+                // コントローラーは request.ClientId で Client を認証するが、チャレンジセッションが
+                // その Client のものであることは検証していない。ここで突合しないと、別 Client が
+                // 発行したセッションを自分の client_id で verify に持ち込め、認可コードが
+                // リクエスト元 Client 宛に発行される（Client 境界の越境）。
+                //
+                // 注: GetChallengeBySessionIdAsync は Client / Organization を Include 済みだが、
+                // ここでは navigation に依存せず明示的に引く。テストは challenge をモックで返すため
+                // navigation が null になり、依存すると本番だけ通る経路が生まれてテストで守れない。
+                Client? client;
+                using (TimingScope.Begin("session_client_verify"))
+                {
+                    client = await _context.Clients
+                        .IgnoreQueryFilters()
+                        .ExcludeDeletedOrganizations()
+                        .FirstOrDefaultAsync(c => c.ClientId == request.ClientId);
+                }
+
+                if (client == null)
+                {
+                    _logger.LogWarning(
+                        PasskeyVerifyFailedLogTemplate,
+                        request.ClientId, request.SessionId, "client_not_found", "Client not found");
+                    return new IB2BPasskeyService.AuthenticationVerifyResult
+                    {
+                        Success = false,
+                        ErrorMessage = "Client not found"
+                    };
+                }
+
+                if (client.Id != challenge.ClientId)
+                {
+                    _logger.LogWarning(
+                        PasskeyVerifyFailedLogTemplate,
+                        request.ClientId, request.SessionId, "session_client_mismatch", "Session was not issued for this client");
+                    return new IB2BPasskeyService.AuthenticationVerifyResult
+                    {
+                        Success = false,
+                        ErrorMessage = "Session does not belong to this client"
+                    };
+                }
+
+                if (client.OrganizationId == null)
+                {
+                    _logger.LogWarning(
+                        PasskeyVerifyFailedLogTemplate,
+                        request.ClientId, request.SessionId, "client_organization_missing", "Client has no associated Organization");
+                    return new IB2BPasskeyService.AuthenticationVerifyResult
+                    {
+                        Success = false,
+                        ErrorMessage = "Client has no associated Organization"
+                    };
+                }
+
                 // クレデンシャル取得
                 // Fido2.NetLib 4.0.0では Id は Base64URL文字列なのでデコードが必要
                 var assertionCredentialIdBytes = WebEncoders.Base64UrlDecode(request.AssertionResponse.Id);
@@ -713,11 +782,88 @@ namespace IdentityProvider.Services
                     };
                 }
 
+                // WebAuthn Level 3 §7.2 Step 5
+                // 「pkOptions.allowCredentials が空でない場合、credential.id がその一覧の
+                // いずれかを指すことを検証する」
+                //
+                // 比較はデコード後のバイト列を再エンコードした正規形で行う（クライアントが送る
+                // Base64URL 文字列のパディング差異で不一致にならないようにする）。
+                var assertionCredentialId = WebEncoders.Base64UrlEncode(assertionCredentialIdBytes);
+                var allowedCredentialIds = challenge.AllowedCredentialIds;
+                if (allowedCredentialIds is { Count: > 0 }
+                    && !allowedCredentialIds.Contains(assertionCredentialId, StringComparer.Ordinal))
+                {
+                    _logger.LogWarning(
+                        PasskeyVerifyFailedLogTemplate,
+                        request.ClientId, request.SessionId, "credential_not_allowed", "Credential is not in the allowCredentials issued for this session");
+                    return new IB2BPasskeyService.AuthenticationVerifyResult
+                    {
+                        Success = false,
+                        ErrorMessage = "Credential is not allowed for this session"
+                    };
+                }
+
+                // WebAuthn Level 3 §7.2 Step 6（ユーザー事前確定時）
+                // 「認証セレモニー開始前にユーザーが特定されていた場合、その特定されたユーザー
+                // アカウントが credential.rawId に等しい id を持つ credential record を含むことを
+                // 検証する」
+                //
+                // b2b_subject 指定経路では options 発行時に RP がユーザーを確定しており、それが
+                // challenge.Subject に保存されている。登録側（VerifyRegistrationAsync の
+                // ExpectedSubject 突合）と対称になる。
+                // challenge.Subject が null の経路（ユーザー未確定）は Step 6 の後者の要件を
+                // isUserHandleOwner コールバックが満たす。
+                if (!string.IsNullOrEmpty(challenge.Subject)
+                    && !string.Equals(credential.B2BSubject, challenge.Subject, StringComparison.Ordinal))
+                {
+                    _logger.LogWarning(
+                        PasskeyVerifyFailedLogTemplate,
+                        request.ClientId, request.SessionId, "credential_subject_mismatch", "Credential does not belong to the subject identified for this session");
+                    return new IB2BPasskeyService.AuthenticationVerifyResult
+                    {
+                        Success = false,
+                        ErrorMessage = "Credential does not belong to the session subject"
+                    };
+                }
+
+                // Organization スコープ検証
+                //
+                // rpIdHash の検証は Fido2.NetLib が ServerDomain = challenge.RpId に基づいて行うため、
+                // rp_id が異なるクレデンシャルは assertion 検証で落ちる。しかし同一 rp_id を共有する
+                // 別 Organization（同一ドメインで本番サイトとサンドボックスサイトの両方を申し込んだ
+                // 場合など）のクレデンシャルは通ってしまう。Client の Organization に属するユーザーの
+                // クレデンシャルであることを明示的に検証する。
+                bool credentialBelongsToClientOrganization;
+                using (TimingScope.Begin("credential_organization_verify"))
+                {
+                    credentialBelongsToClientOrganization = await _context.B2BUsers
+                        .IgnoreQueryFilters()
+                        .AnyAsync(u => u.Subject == credential.B2BSubject
+                            && u.OrganizationId == client.OrganizationId);
+                }
+
+                if (!credentialBelongsToClientOrganization)
+                {
+                    _logger.LogWarning(
+                        PasskeyVerifyFailedLogTemplate,
+                        request.ClientId, request.SessionId, "credential_organization_mismatch", "Credential owner does not belong to the client's Organization");
+                    return new IB2BPasskeyService.AuthenticationVerifyResult
+                    {
+                        Success = false,
+                        ErrorMessage = "Credential does not belong to this organization"
+                    };
+                }
+
                 // AssertionOptionsを復元
+                // AllowCredentials も発行時の値へ復元する。Fido2.NetLib 側も §7.2 Step 5 相当の
+                // 照合を行うため、上の自前チェックとの二重防御になる（未記録の既存行では null）。
                 var options = new AssertionOptions
                 {
                     Challenge = WebEncoders.Base64UrlDecode(challenge.Challenge),
-                    RpId = challenge.RpId
+                    RpId = challenge.RpId,
+                    AllowCredentials = allowedCredentialIds?
+                        .Select(id => new PublicKeyCredentialDescriptor(WebEncoders.Base64UrlDecode(id)))
+                        .ToList()
                 };
 
                 // ユーザーハンドル所有権チェック用デリゲート

--- a/IdentityProvider/Services/IWebAuthnChallengeService.cs
+++ b/IdentityProvider/Services/IWebAuthnChallengeService.cs
@@ -36,6 +36,14 @@ namespace IdentityProvider.Services
             /// クライアントID
             /// </summary>
             public int ClientId { get; set; }
+
+            /// <summary>
+            /// このセッションで発行する allowCredentials の credential_id（Base64URL 形式）。
+            /// WebAuthn Level 3 §7.2 Step 5 の照合のためチャレンジへ束縛する。
+            /// null は「記録しない」を意味する（登録チャレンジなど Step 5 が適用されない経路）。
+            /// 空リストは「allowCredentials を空で発行した」ことの記録で、Step 5 は適用されない。
+            /// </summary>
+            public IReadOnlyList<string>? AllowedCredentialIds { get; set; }
         }
 
         /// <summary>

--- a/IdentityProvider/Services/WebAuthnChallengeService.cs
+++ b/IdentityProvider/Services/WebAuthnChallengeService.cs
@@ -67,6 +67,7 @@ namespace IdentityProvider.Services
                 Subject = request.Subject,
                 RpId = request.RpId,
                 ClientId = request.ClientId,
+                AllowedCredentialIds = request.AllowedCredentialIds,
                 ExpiresAt = expiresAt,
                 CreatedAt = DateTimeOffset.UtcNow
             };


### PR DESCRIPTION
Closes #516

## 背景

`B2BPasskeyService.VerifyAuthenticationAsync` が credential_id だけで DB 全体からクレデンシャルを引いており、WebAuthn Level 3 §7.2 *Verifying an Authentication Assertion* が **MUST** とする 2 つの検証ステップを実施していなかった。

実害は **本番サイトとサンドボックスサイトを同一ドメインで申し込んだケース**。両者は別 Organization（サンドボックスは `-sandbox` サフィックス）だが `allowed_rp_ids` は同値になりうる。`rpIdHash` の検証は Fido2.NetLib が `ServerDomain = challenge.RpId` に基づいて行うため、**同一 rp_id なら Organization / Client をまたいでも assertion が成立する**。結果としてサンドボックスで登録したパスキーで本番 Client のセッションを通せる状態だった（逆も同様）。

第三者によるなりすましではない（被害者の認証器での assertion 生成が必要）。破れていたのは **本番 / サンドボックスの分離**。

## 変更内容

### verify 側（`VerifyAuthenticationAsync`）

検証を 4 段追加した。順序は「クエリ不要なものを先」。

| # | 検証 | 失敗理由ログ | 何を守るか |
|---|------|--------------|-----------|
| 1 | セッションとリクエスト元 Client の突合（`client.Id == challenge.ClientId`） | `session_client_mismatch` | コントローラーは `request.ClientId` で Client を認証するが、セッションがその Client のものかは検証していなかった。別 Client のセッションを自分の client_id で持ち込むと、認可コードがリクエスト元 Client 宛に発行される |
| 2 | **§7.2 Step 5**: 発行した allowCredentials との照合 | `credential_not_allowed` | このセッションで発行していないクレデンシャルでの認証 |
| 3 | **§7.2 Step 6**: `challenge.Subject` との照合 | `credential_subject_mismatch` | b2b_subject 指定経路（ユーザー確定済み）で別ユーザーのクレデンシャルでの認証。登録側の `ExpectedSubject` 突合と対称になる |
| 4 | Organization スコープ（所有者が Client の Organization の `B2BUser` か） | `credential_organization_mismatch` | 同一 rp_id を共有する別 Organization 間の越境（上記の本番 / サンドボックス） |

`OriginalOptions.AllowCredentials` も発行時の値へ復元したので、Fido2.NetLib 側の Step 5 相当の照合との二重防御になる。自前チェックを残しているのは、失敗理由を構造化ログに出すためと、`IFido2` をモックするユニットテストで守れる形にするため。

### options 側（`CreateAuthenticationOptionsAsync`）

b2b_subject 指定経路のクレデンシャル取得を **Client の Organization に限定**した。

この API は無認証で呼べるうえ `b2b_subject` はリクエスト由来の値なので、Organization で絞らないと他 Organization のユーザーの b2b_subject を指定するだけでクレデンシャル ID 一覧が本人確認前に漏れる。さらにその allowCredentials で認証を試行でき、**この場合 verify の #2 / #3 は「発行した一覧」「確定した subject」と整合するので通過する**。つまり options 側の絞り込みと verify 側 #4 の両方が必要。

なお、この不変条件は `AuthorizeByRegistrationTokenAsync`（`B2BPasskeyController.cs:868`）が登録トークンに対して既に課しているものと同じ。

### データモデル

`webauthn_challenge.allowed_credential_ids`（`nvarchar(max)`, NULL 許容）を追加。3 状態を意図的に使い分ける。

| 値 | 意味 | Step 5 |
|---|---|---|
| `NULL` | 発行時に記録していない（登録チャレンジ / カラム追加前の既存行） | 適用不可 |
| `"[]"` | allowCredentials を空で発行した（discoverable credential フロー、`SubjectType.Account`） | 「空でない場合」を満たさないので適用しない |
| 要素あり | verify で照合する | 適用 |

前 2 者は挙動としては同じ「照合しない」だが、事後に理由を切り分けられるよう区別して保存する。

**マイグレーション**: `AddColumn` のみ（DML なし）なので `EXEC()` ラップは不要。冪等スクリプトも純 DDL で生成されることを確認済み。既存行は NULL になるが、チャレンジの寿命は 5 分なのでデプロイ直後の窓だけ Step 5 が適用されない（#1 / #3 / #4 は既存行でも効く）。

### ドキュメント

`CLAUDE.md` に「B2B パスキー authenticate/verify の検証レイヤ（WebAuthn §7.2）」を追加した。**各検証がなぜ冗長でないか**を記録している（特に「#4 は #2 / #3 では代替できない」「rpIdHash 検証では足りない」）。レビュー時に「重複チェック」と読めてしまう構造のため。

`TimingScope` の計測対象表にも `session_client_verify` / `credential_organization_verify` を追記した。

## 影響範囲の確認

- **EC-CUBE プラグインの管理画面ログイン**（b2b_subject 未指定 = Organization 単位の allowCredentials）: 発行した一覧をそのまま束縛するので #2 は必ず通る。`challenge.Subject` は null なので #3 はスキップ。#4 は自 Organization のユーザーなので通る。**挙動変化なし**。
- **accounts 管理コンソール**（`SubjectType.Account`）: allowCredentials は空（`"[]"`）で #2 スキップ、`challenge.Subject` は null で #3 スキップ。#4 は Account コンソールのパスキーも accounts Organization の `B2BUser` に紐づく（`AuthorizeByRegistrationTokenAsync` が `client.OrganizationId == b2bUser.OrganizationId` を要求している）ので通る。**挙動変化なし**。

## テスト

ユニットテスト 12 件追加。**785 件すべて pass**（追加前 773 件）。

`B2BPasskeyServiceTests`:
- Step 5: 発行外のクレデンシャル → 失敗 / 発行済み → 成功 / 空で発行（discoverable）→ スキップ / 未記録（既存行）→ スキップ
- Step 6: 同一 Organization の別ユーザーのクレデンシャル → 失敗
- Organization: 別 Organization（サンドボックス相当）のクレデンシャル → 失敗
- Client: 別 Client が発行したセッション → 失敗 / 未知の client_id → 失敗
- options: 発行した allowCredentials がチャレンジへ束縛される / 他 Organization の b2b_subject では空を返す

各テストは **他の検証では捕まらない状況**（`challenge.Subject` を null にする、allowCredentials を未記録にする等）を作って対象の検証を単独で確認している。Fido2 の assertion 検証自体はモックで成功させているので、失敗した場合の原因が追加検証であることが切り分けられる。

`WebAuthnChallengeServiceTests`: 3 状態の永続化（要素あり / 空リスト / 未記録）。

## 検証状況

| 項目 | 結果 |
|---|---|
| `dotnet build EcAuth.sln` | 0 エラー |
| `dotnet test IdentityProvider.Test` | 785 pass / 0 fail |
| `dotnet ef migrations has-pending-model-changes` | 差分ゼロ |
| `dotnet ef migrations script --idempotent` | 生成成功、純 DDL |
| ModelSnapshot の diff | 新カラム 4 行のみ |
| `playwright / test`（CI、実 SQL Server + 実 Fido2） | **62 passed / 0 failed**。ログに `Registered passkey for B2BUser ...` と `UPDATE [b2b_passkey_credential] SET [last_used_at], [sign_count]` が出ており、`authenticate/verify` が実 DB で通っている |
| `eccube-plugin-e2e`（EC-CUBE 4系 / 2系 プラグイン結合） | **pass**。b2b_subject 未指定経路（管理画面ログイン）の回帰確認としてはこれが本命 |
| `selenium` | pass |
| `verify-idempotent-script`（CI） | pass |

ローカル Docker では未実行（1Password が未サインインで `op run` が使えなかった）。ただし CI の `playwright` ジョブが同じ compose 構成・同じ spec を実 SQL Server に対して回しているため、実 DB / 実 Fido2 経路の検証は CI で取れている。手元で再現したい場合:

```bash
cd EcAuth
op run --env-file=.env.dev.tpl -- docker compose -p ec-auth up -d --build
cd E2ETests && pnpm exec playwright test tests/specs/b2b_passkey_authentication.spec.ts --reporter=list
```

**新規環境変数はゼロ**。`.env.*.tpl` / `staging.yml` / `production.yml` / Terraform への配線は不要（`allowed_credential_ids` はコード内で完結する）。

## 残る課題（本 PR のスコープ外）

b2b_subject 未指定経路の allowCredentials は現在も Organization 単位で発行しているため、**同一 Organization 内の Client 間境界は #2 では守れない**（発行した一覧が既に Organization 全体をまたぐため）。`CreateAuthenticationOptionsAsync` のコメントにある移行（rk フラグ保存 → `ResidentKey.Required` 化 → 既存ユーザー再登録 → 空 allowCredentials へ切替）を終えた時点で、#2 が自動的に Client 境界の強制になる。この構造は `CLAUDE.md` に記録した。

なお標準の申込フローでは 1 Organization = 1 Client なので、この構成は ConsoleApp の払い出しや DB 操作でしか作れない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
